### PR TITLE
[testsuite] Fix ERROR in gdb.rocm/step-over-kernel-exit.exp

### DIFF
--- a/gdb/testsuite/gdb.rocm/step-over-kernel-exit.exp
+++ b/gdb/testsuite/gdb.rocm/step-over-kernel-exit.exp
@@ -91,13 +91,13 @@ proc do_test { step_over_mode schedlock } {
 	    [get_integer_valueof "\$_thread" 0 "get selected thread before"]
 
 	gdb_test "stepi" \
-	    "\r\n\[$wave_target_id_re \\(id $::decimal\\) exited\]\r\nCommand aborted, thread exited\\." \
+	    "\r\n\\\[$wave_target_id_re \\(id $::decimal\\) exited\\\]\r\nCommand aborted, thread exited\\." \
 	    "single-step s_endpgm"
 
 	# Check that the selected thread didn't change, and that GDB
 	# manages to print the exited wave's target ID properly.
 	gdb_test "thread" \
-	    "\r\n\[Current thread is $selected_thread_before \\($wave_target_id_re\\) \\(exited\\)\]" \
+	    "\r\n\\\[Current thread is $selected_thread_before \\($wave_target_id_re\\) \\(exited\\)\\\]" \
 	    "exited wave target id"
     }
 }


### PR DESCRIPTION
I ran into the following:

ERROR: couldn't compile regular expression pattern: parentheses () not balanced
    while executing
"expect {
-i exp9 -timeout 10
        -re ".*A problem internal to GDB has been detected" {
            fail "$message (GDB internal error)"
            gdb_internal_error..."
    ("uplevel" body line 1)
    invoked from within
"uplevel $body" REGEXP REG_EPAREN {parentheses () not balanced} couldn't compile regular expression pattern: parentheses () not balanced

Looks like we need extra escaping of the brackets when we have some parenthesis going on.