### PR TITLE
Update the gdb docs contributors page and bug report url

### DIFF
--- a/gdb/configure
+++ b/gdb/configure
@@ -26027,7 +26027,7 @@ if test "${with_bugurl+set}" = set; then :
 	   ;;
      esac
 else
-  BUGURL="https://github.com/ROCm/ROCgdb/issues"
+  BUGURL="https://www.gnu.org/software/gdb/bugs/"
 
 fi
 

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -44127,8 +44127,9 @@ distribution.
 @ifset BUGURL_DEFAULT
 In any event, we also recommend that you submit bug reports for
 @value{GDBN}.  The preferred method is to submit them directly using
-@uref{https://github.com/ROCm/ROCgdb/issues, @value{GDBN}'s issues
-page}.
+@uref{http://www.gnu.org/software/gdb/bugs/, @value{GDBN}'s Bugs web
+page}.  Alternatively, the @email{bug-gdb@@gnu.org, e-mail gateway} can
+be used.
 
 @strong{Do not send bug reports to @samp{info-gdb}, or to
 @samp{help-gdb}, or to any newsgroups.}  Most users of @value{GDBN} do


### PR DESCRIPTION
## Motivation

The generated pdf files highlighted the problems:
* The tool branding is inconsistent. Ideally, we should use ROCgdb everywhere and not ROCGDB.

## Technical Details

Update the gdb docs contributors page and bug report url.

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
