### PR TITLE
binutils/readelf: Remove unused static variables

### DIFF
--- a/binutils/readelf.c
+++ b/binutils/readelf.c
@@ -241,8 +241,6 @@ static bool do_dump = false;
 static bool do_version = false;
 static bool do_histogram = false;
 static bool do_debugging = false;
-static bool do_ctf = false;
-static bool do_sframe = false;
 static bool do_arch = false;
 static bool do_notes = false;
 static bool do_archive_index = false;
@@ -6988,7 +6986,6 @@ parse_args (struct dump_data *dumpdata, int argc, char ** argv)
 	  dwarf_check = true;
 	  break;
 	case OPTION_CTF_DUMP:
-	  do_ctf = true;
 	  request_dump (dumpdata, CTF_DUMP);
 	  break;
 	case OPTION_CTF_SYMBOLS:
@@ -7004,7 +7001,6 @@ parse_args (struct dump_data *dumpdata, int argc, char ** argv)
 	  dump_ctf_parent_name = strdup (optarg);
 	  break;
 	case OPTION_SFRAME_DUMP:
-	  do_sframe = true;
 	  /* Fix PR/32589 but keep the error messaging same ?  */
 	  if (optarg != NULL && strcmp (optarg, "") == 0)
 	    {


### PR DESCRIPTION
Remove static variables do_ctf and do_sframe that are set but never read, causing build failures with LLVM's extended
-Wunused-but-set-variable warning.

These variables are dead code:
- Declared at lines 244-245 as static booleans
- Set to true when --ctf or --sframe options are parsed
- Never actually used or read anywhere in the code
- The actual dump functionality is triggered by request_dump() calls

Build error with -Werror enabled:
binutils/readelf.c:244:13: error: variable 'do_ctf' set but not used
  [-Werror,-Wunused-but-set-variable]
binutils/readelf.c:245:13: error: variable 'do_sframe' set but not used
  [-Werror,-Wunused-but-set-variable]

Fixes: AIROCGDB-553

There is a commit that supresses the issue:  3e011457055bd3868bd05cf80bc1a4482777809b but we should still fix this.
I will send the same patch upstream, this is just a stand in until it gets merged, so we don't block LLVM bumps.