### PR TITLE
gdb/amdgcn: Dynamically select which bits to use to hold CORE_ADDR

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1755,7 +1755,6 @@ amdgpu_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
     error (_("amd_dbgapi_dwarf_address_space_to_address_space failed"));
 
   amd_dbgapi_status_t ret;
-#if AMD_DBGAPI_VERSION_MAJOR > 0 || AMD_DBGAPI_VERSION_MINOR >= 79
   /* Access to GPU globals can be made from host threads.  When we place a
      watchpoint on such global GPU variable, a matching watchpoint is also
      added on the CPU side for the same address, so it is possible to call here
@@ -1770,11 +1769,6 @@ amdgpu_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
   ret = amd_dbgapi_address_dependency (process_id, wave_id,
 				       address_space_id, segment_address,
 				       &segment_address_dependency);
-#else
-  ret = amd_dbgapi_address_dependency (address_space_id,
-				       segment_address,
-				       &segment_address_dependency);
-#endif
   if (ret != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_address_dependency failed"));
 

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -30,16 +30,62 @@
 #include "gdbtypes.h"
 #include "inferior.h"
 #include "language.h"
+#include "observable.h"
 #include "producer.h"
 #include "reggroups.h"
 #include "extract-store-integer.h"
+#include <optional>
 
-/* Bit mask of the address space information in the core address.  */
-constexpr CORE_ADDR AMDGPU_ADDRESS_SPACE_MASK = 0xff00000000000000;
+struct amdgpu_per_inferior
+{
+  amdgpu_per_inferior ()
+    : significant_bits {}
+  {}
 
-/* Bit offset from the start of the core address
-   that represent the address space information.  */
-constexpr unsigned int AMDGPU_ADDRESS_SPACE_BIT_OFFSET = 56;
+  std::optional<amd_dbgapi_segment_address_t> significant_bits = {};
+};
+
+static const registry<inferior>::key<amdgpu_per_inferior> amdgpu_per_inf;
+
+static void
+amdgpu_observer_inferior_appeared (inferior *inf)
+{
+  /* Invalidate the cached data by clearing it.  */
+  amdgpu_per_inf.clear(inf);
+}
+
+static amdgpu_per_inferior &
+get_amdgpu_per_inferior (inferior *inf)
+{
+  return amdgpu_per_inf.try_emplace (inf);
+}
+
+/* Return a bit-mask showing which bits of a segment address are significant
+   for at least one address space in at least one agent.  Any bits outside
+   this mask can be modified by GDB and cleared before sending the address to
+   dbgapi without affecting the address value.  */
+
+static amd_dbgapi_segment_address_t
+amdgpu_get_segment_address_significant_bits (inferior *inf)
+{
+  amdgpu_per_inferior &per_inf = get_amdgpu_per_inferior (inf);
+
+  if (!per_inf.significant_bits.has_value ())
+    {
+      amd_dbgapi_process_id_t process_id = get_amd_dbgapi_process_id (inf);
+
+      amd_dbgapi_segment_address_t sb;
+      if (amd_dbgapi_process_get_info
+	  (process_id, AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS,
+	   sizeof (sb), &sb)
+	  != AMD_DBGAPI_STATUS_SUCCESS)
+	error (_("amd_dbgapi_process_get_info failed"));
+
+      per_inf.significant_bits = sb;
+    }
+
+  return *per_inf.significant_bits;
+}
 
 /* Return true if INFO is of an AMDGPU architecture.  */
 
@@ -1435,8 +1481,37 @@ static CORE_ADDR
 amdgpu_segment_address_to_core_address (arch_addr_space_id address_space_id,
 					CORE_ADDR address)
 {
-  return (address & ~AMDGPU_ADDRESS_SPACE_MASK)
-	 | (((CORE_ADDR) address_space_id) << AMDGPU_ADDRESS_SPACE_BIT_OFFSET);
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
+
+  /* The address must not have bits set outside of the significant bits.  */
+  gdb_assert ((significant_bits & address) == address);
+
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  uint64_t id = address_space_id;
+  uint64_t mask = aspace_id_mask;
+  while (id != 0)
+    {
+      /* Isolate the lowest set bit in the mask.  */
+      uint64_t lowbit = mask & ~(mask - 1);
+
+      if (id & 1)
+	address |= lowbit;
+
+      mask ^= lowbit; /* Clear bit from mask.  */
+      id >>= 1;	      /* Move on to the next bit in ID.  */
+
+      /* As long as there's ID bits, there should be some MASK bits too.  */
+      gdb_assert (!(mask == 0 && id != 0));
+    }
+
+  /* If all the bits are set, then this could collide with the
+     sign extension of the address.  */
+  if ((address & aspace_id_mask) == aspace_id_mask)
+    error (_("Address-space ID overflow"));
+
+  return address;
 }
 
 /* Convert an integer to an address of a given segment address.  */
@@ -1454,7 +1529,36 @@ amdgpu_integer_to_address (struct gdbarch *gdbarch,
 arch_addr_space_id
 amdgpu_address_space_id_from_core_address (CORE_ADDR addr)
 {
-  return (addr & AMDGPU_ADDRESS_SPACE_MASK) >> AMDGPU_ADDRESS_SPACE_BIT_OFFSET;
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  /* Shortcut for aspace 0 (global).  */
+  if ((addr & aspace_id_mask) == 0)
+    return 0;
+
+  /* The all 1s address space is not valid, so 0.  */
+  if ((addr & aspace_id_mask) == aspace_id_mask)
+    return 0;
+
+  arch_addr_space_id aspace_id = 0;
+  uint64_t mask = aspace_id_mask;
+  uint64_t set_bit = 1;    /* A set bit in the lowest position.  */
+  while (mask != 0)
+    {
+      /* Isolate the lowest set bit in the mask.  */
+      uint64_t lowbit = mask & ~(mask - 1);
+
+      if (addr & lowbit)
+	aspace_id |= set_bit;
+
+      /* Move on to the next bit position.  */
+      set_bit <<= 1;
+      /* Clear bit from mask.  */
+      mask ^= lowbit;
+    }
+
+  return aspace_id;
 }
 
 /* See amdgpu-tdep.h.  */
@@ -1462,7 +1566,16 @@ amdgpu_address_space_id_from_core_address (CORE_ADDR addr)
 CORE_ADDR
 amdgpu_segment_address_from_core_address (CORE_ADDR addr)
 {
-  return addr & ~AMDGPU_ADDRESS_SPACE_MASK;
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  /* The all-1s address-space is not valid, this must be the original
+     address.  */
+  if ((addr & aspace_id_mask) == aspace_id_mask)
+    return addr;
+
+  return addr & significant_bits;
 }
 
 /* Address class to address space mapping.
@@ -2300,6 +2413,8 @@ INIT_GDB_FILE (amdgpu_tdep)
 {
   gdbarch_register (bfd_arch_amdgcn, amdgpu_gdbarch_init, NULL,
 		    amdgpu_supports_arch_info);
+  gdb::observers::inferior_appeared.attach (amdgpu_observer_inferior_appeared,
+					    "amdgpu_tdep");
 #if defined GDB_SELF_TEST
   selftests::register_test ("amdgpu-register-type-parse-flags-fields",
 			    amdgpu_register_type_parse_test);

--- a/gdb/configure
+++ b/gdb/configure
@@ -25347,19 +25347,19 @@ if test "$gdb_require_amd_dbgapi" = true \
   # version of the library.
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for amd-dbgapi >= 0.77.0" >&5
-$as_echo_n "checking for amd-dbgapi >= 0.77.0... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for amd-dbgapi >= 0.80.0" >&5
+$as_echo_n "checking for amd-dbgapi >= 0.80.0... " >&6; }
 
 if test -n "$AMD_DBGAPI_CFLAGS"; then
     pkg_cv_AMD_DBGAPI_CFLAGS="$AMD_DBGAPI_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.77.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.77.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.80.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.80.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_AMD_DBGAPI_CFLAGS=`$PKG_CONFIG --cflags "amd-dbgapi >= 0.77.0" 2>/dev/null`
+  pkg_cv_AMD_DBGAPI_CFLAGS=`$PKG_CONFIG --cflags "amd-dbgapi >= 0.80.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -25371,12 +25371,12 @@ if test -n "$AMD_DBGAPI_LIBS"; then
     pkg_cv_AMD_DBGAPI_LIBS="$AMD_DBGAPI_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.77.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.77.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.80.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.80.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_AMD_DBGAPI_LIBS=`$PKG_CONFIG --libs "amd-dbgapi >= 0.77.0" 2>/dev/null`
+  pkg_cv_AMD_DBGAPI_LIBS=`$PKG_CONFIG --libs "amd-dbgapi >= 0.80.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -25421,9 +25421,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "amd-dbgapi >= 0.77.0" 2>&1`
+	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "amd-dbgapi >= 0.80.0" 2>&1`
         else
-	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "amd-dbgapi >= 0.77.0" 2>&1`
+	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "amd-dbgapi >= 0.80.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$AMD_DBGAPI_PKG_ERRORS" >&5

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -327,7 +327,7 @@ if test "$gdb_require_amd_dbgapi" = true \
   # stability until amd-dbgapi hits 1.0, but for convenience, still check for
   # greater or equal that version.  It can be handy when testing with a newer
   # version of the library.
-  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.77.0],
+  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.80.0],
 		    [has_amd_dbgapi=yes], [has_amd_dbgapi=no])
 
   if test "$has_amd_dbgapi" = "yes"; then

--- a/gdb/testsuite/gdb.rocm/mi-aspace.exp
+++ b/gdb/testsuite/gdb.rocm/mi-aspace.exp
@@ -161,9 +161,9 @@ proc_with_prefix test_mi_data_read_memory {} {
 	     "nr-bytes=\"1\"," \
 	     "total-bytes=\"1\"," \
 	     "next-row=\"private_lane#0x0000000000000001\"," \
-	     "prev-row=\"0x00ffffffffffffff\"," \
+	     "prev-row=\"${::hex}\"," \
 	     "next-page=\"private_lane#0x0000000000000001\"," \
-	     "prev-page=\"0x00ffffffffffffff\"," \
+	     "prev-page=\"${::hex}\"," \
 	     "memory=\\\[\\\{addr=\"private_lane#0x0000000000000000\",data=\\\[\"$hex\"\\\]\\\}\\\]"]
 }
 


### PR DESCRIPTION
Relies on dbgapi's PR: [Add AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS](https://github.com/ROCm/rocm-systems/pull/3287)

To support the various address-spaces from AMDGPU, amdgpu-tdep implements gdbarch hooks to encode the address-space ID in the top bits of a CORE_ADDR.  Exactly which bits to use out of the CORE_ADDR is currently statically built into GDB.  However, for AMDGPU, the "flat" address-space (also known as generic) is configured by the driver, and it is not part of the ABI which bits out of the top byte are used or not to carry meaning.

To address this, librocm-dbgapi >= 0.80 provides a mask of bits which carry information for the current process.  GDB can use this mask to deduce which bits out of a CORE_ADDR can safely be used to encode address space IDs.

This patch provides an implementation for GDB to encode the address-space ID into the top bits reported as unused by dbgapi.  Note that dbgapi reports which bits can be used by any address space, including "global".  This means that the unused bits must be the top ones, and we should account for the fact that "normalized" addresses are sign extended in the top bits.  This means that the top bits of a valid address can be either all 0s or all 1s.  For this reason, we do not support encoding an address space ID whose binary representation on the available bits of a CORE_ADDR is all 1s, so the all 1s case can be reserved for sign-extended addresses.

Bug: AIROCGDB-26
Change-Id: I4cbb41a922443d64003ebc6415547c02ab43afcf