### PR TITLE
gdb.rocm: replace hipcc with amdclang++ as the HIP compiler

### DIFF
--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -29155,6 +29155,14 @@ to compile a HIP program that can utilize ``Vega 10'' and ``Vega 7nm''
 @acronym{AMD GPU} devices, with no optimization:
 
 @smallexample
+amdclang++ -x hip --hip-link -O0 -g --offload-arch=gfx900 --offload-arch=gfx906 bit_extract.cpp -o bit_extract
+@end smallexample
+
+@noindent
+The legacy @command{hipcc} wrapper is deprecated.  If you are still
+using @command{hipcc}, the equivalent command is:
+
+@smallexample
 hipcc -O0 -g --offload-arch=gfx900 --offload-arch=gfx906 bit_extract.cpp -o bit_extract
 @end smallexample
 

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -29274,6 +29274,14 @@ to compile a HIP program that can utilize ``Vega 10'' and ``Vega 7nm''
 @acronym{AMD} @acronym{GPU} devices, with no optimization:
 
 @smallexample
+amdclang++ -x hip --hip-link -O0 -g --offload-arch=gfx900 --offload-arch=gfx906 bit_extract.cpp -o bit_extract
+@end smallexample
+
+@noindent
+The legacy @command{hipcc} wrapper is deprecated.  If you are still
+using @command{hipcc}, the equivalent command is:
+
+@smallexample
 hipcc -O0 -g --offload-arch=gfx900 --offload-arch=gfx906 bit_extract.cpp -o bit_extract
 @end smallexample
 

--- a/gdb/testsuite/boards/hip.exp
+++ b/gdb/testsuite/boards/hip.exp
@@ -302,6 +302,10 @@ proc gdb_compile {source dest type options} {
 	#    '-mllvm -amdgpu-spill-cfi-saved-regs'
 	#    [-Wunused-command-line-argument]
 	#
+	# Pass --rocm-path explicitly so amdclang++ can locate the HIP
+	# headers and device libraries when it's invoked from the board
+	# via PATH rather than an absolute path.  rocm_path comes from
+	# rocm.exp and defaults to /opt/rocm if ROCM_PATH is not set.
 	global rocm_path
 	set hip_options "early_flags=\
 			 --rocm-path=$rocm_path\

--- a/gdb/testsuite/boards/hip.exp
+++ b/gdb/testsuite/boards/hip.exp
@@ -302,7 +302,9 @@ proc gdb_compile {source dest type options} {
 	#    '-mllvm -amdgpu-spill-cfi-saved-regs'
 	#    [-Wunused-command-line-argument]
 	#
+	global rocm_path
 	set hip_options "early_flags=\
+			 --rocm-path=$rocm_path\
 			 -O0\
 			 -std=gnu++11\
 			 -fgpu-rdc\
@@ -377,6 +379,7 @@ proc gdb_compile {source dest type options} {
 		lappend options "ldflags=$gdb_saved_hip_driver_obj"
 
 		lappend options $hip_options
+		lappend options "early_flags=--hip-link"
 
 		# All compiled.  Now link, and we're done.
 		return [hip_org_gdb_compile $source $dest $type $options]
@@ -422,6 +425,7 @@ proc gdb_compile {source dest type options} {
 	    }
 
 	    lappend options $hip_options
+	    lappend options "early_flags=-x hip"
 	}
     }
     hip_org_gdb_compile $source $dest $type $options

--- a/gdb/testsuite/boards/hip.exp
+++ b/gdb/testsuite/boards/hip.exp
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # This file is a dejagnu "board file" and is used to run the testsuite
-# against C/C++ device code compiled with hipcc.
+# against C/C++ device code compiled with amdclang++ (HIP).
 #
 # Example usage:
 #  bash$ make check RUNTESTFLAGS='--target_board=hip'
@@ -80,8 +80,8 @@ load_lib rocm.exp
 load_generic_config "unix"
 process_multilib_options ""
 
-set_board_info compiler [find_hipcc]
-set_board_info c++compiler [find_hipcc]
+set_board_info compiler [find_hip_compiler]
+set_board_info c++compiler [find_hip_compiler]
 
 set_board_info gdb,cannot_call_functions 1
 
@@ -149,8 +149,16 @@ proc skip_opencl_tests {} {
 # Yup, we don't want to run the gdb.rocm/ tests against this board.
 # That would be kind of recursive.  Those tests really expect that
 # "main()" is host code and start kernels themselves.
-proc allow_hipcc_tests {} {
+proc allow_hip_tests {} {
     return 0
+}
+
+# Backwards compatibility alias.  The testsuite previously used
+# allow_hipcc_tests when hipcc was the HIP compiler wrapper.  Keep
+# this alias so that any out-of-tree board files or scripts that
+# reference the old name continue to work.
+proc allow_hipcc_tests {} {
+    return [allow_hip_tests]
 }
 
 # Override this to fail faster.  If we let the default run, tests
@@ -271,10 +279,14 @@ proc gdb_compile {source dest type options} {
 
 	# We need:
 	#
-	# . explicit -O0, because hipcc optimizes by default.
+	# . explicit -O0, because the legacy hipcc wrapper optimized by
+	#   default.  amdclang++ does not, but we keep -O0 explicit for
+	#   clarity and to stay safe if defaults ever change.
 	#
-	# . -std=gnu++11 because hipcc defaults to -std=c++11, and
-	#   some testcases assume GNU extensions.
+	# . -std=gnu++11 because the legacy hipcc wrapper defaulted to
+	#   -std=c++11, and some testcases assume GNU extensions.
+	#   amdclang++ defaults to a later standard but we keep this
+	#   for consistency.
 	#
 	# . -fgpu-rdc enables separate compilation mode, so we can
 	#   compile the kernel from multiple translation units.
@@ -303,7 +315,7 @@ proc gdb_compile {source dest type options} {
 	} elseif {[info exists CC_FOR_TARGET]} {
 	    set compiler $CC_FOR_TARGET
 	}
-	if {[string first "hipcc" $compiler] != -1} {
+	if {[string first "amdclang++" $compiler] != -1} {
 
 	    # Remove "c++" from the options when linking, otherwise we
 	    # would get:

--- a/gdb/testsuite/boards/hip.exp
+++ b/gdb/testsuite/boards/hip.exp
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # This file is a dejagnu "board file" and is used to run the testsuite
-# against C/C++ device code compiled with hipcc.
+# against C/C++ device code compiled with amdclang++ (HIP).
 #
 # Example usage:
 #  bash$ make check RUNTESTFLAGS='--target_board=hip'
@@ -80,8 +80,8 @@ load_lib rocm.exp
 load_generic_config "unix"
 process_multilib_options ""
 
-set_board_info compiler [find_hipcc]
-set_board_info c++compiler [find_hipcc]
+set_board_info compiler [find_hip_compiler]
+set_board_info c++compiler [find_hip_compiler]
 
 set_board_info gdb,cannot_call_functions 1
 
@@ -149,7 +149,7 @@ proc skip_opencl_tests {} {
 # Yup, we don't want to run the gdb.rocm/ tests against this board.
 # That would be kind of recursive.  Those tests really expect that
 # "main()" is host code and start kernels themselves.
-proc allow_hipcc_tests {} {
+proc allow_hip_tests {} {
     return 0
 }
 
@@ -271,10 +271,7 @@ proc gdb_compile {source dest type options} {
 
 	# We need:
 	#
-	# . explicit -O0, because hipcc optimizes by default.
-	#
-	# . -std=gnu++11 because hipcc defaults to -std=c++11, and
-	#   some testcases assume GNU extensions.
+	# . -std=gnu++11 because some testcases rely on GNU extensions.
 	#
 	# . -fgpu-rdc enables separate compilation mode, so we can
 	#   compile the kernel from multiple translation units.
@@ -290,8 +287,15 @@ proc gdb_compile {source dest type options} {
 	#    '-mllvm -amdgpu-spill-cfi-saved-regs'
 	#    [-Wunused-command-line-argument]
 	#
-	set hip_options "early_flags=\
-			 -O0\
+	# When ROCM_PATH is set in the environment, pass --rocm-path
+	# so amdclang++ uses that specific ROCm install for HIP.
+	# When unset, let amdclang++ auto-discover (parent of its own
+	# LLVM dir, falling back on /opt/rocm).
+	set rocm_path_arg ""
+	if {[info exists ::env(ROCM_PATH)] && $::env(ROCM_PATH) ne ""} {
+	    set rocm_path_arg "--rocm-path=$::env(ROCM_PATH)"
+	}
+	set hip_options "early_flags=$rocm_path_arg\
 			 -std=gnu++11\
 			 -fgpu-rdc\
 			 -mllvm -amdgpu-spill-cfi-saved-regs\
@@ -303,7 +307,7 @@ proc gdb_compile {source dest type options} {
 	} elseif {[info exists CC_FOR_TARGET]} {
 	    set compiler $CC_FOR_TARGET
 	}
-	if {[string first "hipcc" $compiler] != -1} {
+	if {[string first "amdclang++" $compiler] != -1} {
 
 	    # Remove "c++" from the options when linking, otherwise we
 	    # would get:
@@ -362,9 +366,13 @@ proc gdb_compile {source dest type options} {
 		    # original may be automatically deleted.
 		    remote_download host $hip_driver_obj $gdb_saved_hip_driver_obj
 		}
-		lappend options "ldflags=$gdb_saved_hip_driver_obj"
+		# Prefix "-x none" so amdclang++ does not treat the
+		# driver .o as HIP source (the preceding inputs on
+		# the command line are .cpp tagged "-x hip").
+		lappend options "ldflags=-x none $gdb_saved_hip_driver_obj"
 
 		lappend options $hip_options
+		lappend options "early_flags=--hip-link"
 
 		# All compiled.  Now link, and we're done.
 		return [hip_org_gdb_compile $source $dest $type $options]
@@ -410,6 +418,7 @@ proc gdb_compile {source dest type options} {
 	    }
 
 	    lappend options $hip_options
+	    lappend options "early_flags=-x hip"
 	}
     }
     hip_org_gdb_compile $source $dest $type $options

--- a/gdb/testsuite/gdb.perf/rocm-break-cond-false.exp
+++ b/gdb/testsuite/gdb.perf/rocm-break-cond-false.exp
@@ -22,7 +22,7 @@
 load_lib rocm.exp
 load_lib perftest.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/addr-bp-gpu-no-deb-info.exp
+++ b/gdb/testsuite/gdb.rocm/addr-bp-gpu-no-deb-info.exp
@@ -20,7 +20,7 @@ load_lib rocm.exp
 
 standard_testfile .cpp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if {[build_executable "failed to prepare" $testfile $srcfile {hip}]} {
     return

--- a/gdb/testsuite/gdb.rocm/alu-exceptions.exp
+++ b/gdb/testsuite/gdb.rocm/alu-exceptions.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/aspace-user-input.exp
+++ b/gdb/testsuite/gdb.rocm/aspace-user-input.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile bit-extract.cpp
 

--- a/gdb/testsuite/gdb.rocm/aspace-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/aspace-watchpoint.exp
@@ -24,7 +24,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/bit-extract.exp
+++ b/gdb/testsuite/gdb.rocm/bit-extract.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/branch-fault.exp
+++ b/gdb/testsuite/gdb.rocm/branch-fault.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/break-kernel-no-debug-info.exp
+++ b/gdb/testsuite/gdb.rocm/break-kernel-no-debug-info.exp
@@ -25,7 +25,7 @@ load_lib rocm.exp
 
 standard_testfile .cpp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 # Build for hip, explicitly without debug infos
 if {[build_executable "failed to prepare" $testfile $srcfile {hip nodebug}]} {

--- a/gdb/testsuite/gdb.rocm/breakpoint-after-exit.exp
+++ b/gdb/testsuite/gdb.rocm/breakpoint-after-exit.exp
@@ -24,7 +24,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/code-object-load-while-breakpoint-hit.exp
+++ b/gdb/testsuite/gdb.rocm/code-object-load-while-breakpoint-hit.exp
@@ -34,7 +34,7 @@
 
 load_lib rocm.exp
 standard_testfile .cpp
-require allow_hipcc_tests
+require allow_hip_tests
 
 # Build the host executable.
 if { [build_executable "failed to prepare" \

--- a/gdb/testsuite/gdb.rocm/code-object-load-while-breakpoint-hit.exp
+++ b/gdb/testsuite/gdb.rocm/code-object-load-while-breakpoint-hit.exp
@@ -34,7 +34,7 @@
 
 load_lib rocm.exp
 standard_testfile .cpp
-require allow_hipcc_tests
+require allow_hip_tests
 
 # Build the host executable.
 if { [build_executable "failed to prepare" \
@@ -47,7 +47,7 @@ set hipmodule_path [standard_output_file ${testfile}.co]
 # Build the kernel object file.
 if { [gdb_compile $srcdir/$subdir/$srcfile \
 	$hipmodule_path object \
-	{ debug hip additional_flags=--genco additional_flags=-DDEVICE } ] != "" } {
+	{ debug hip additional_flags=--cuda-device-only additional_flags=-DDEVICE } ] != "" } {
     return -1
 }
 

--- a/gdb/testsuite/gdb.rocm/continue-over-kernel-exit.exp
+++ b/gdb/testsuite/gdb.rocm/continue-over-kernel-exit.exp
@@ -23,7 +23,7 @@ load_lib rocm.exp
 
 standard_testfile .cpp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if { [build_executable "failed to prepare" \
 	  $testfile $srcfile {debug hip}] == -1 } {

--- a/gdb/testsuite/gdb.rocm/convenience_variables.exp
+++ b/gdb/testsuite/gdb.rocm/convenience_variables.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
+++ b/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
@@ -31,7 +31,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require supports_cooperative_groups
 
 standard_testfile .cpp

--- a/gdb/testsuite/gdb.rocm/core-no-read-special-files.exp
+++ b/gdb/testsuite/gdb.rocm/core-no-read-special-files.exp
@@ -25,7 +25,7 @@ load_lib rocm.exp
 require {istarget *-linux*}
 
 require allow_rocm_core_tests
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/corefile.exp
+++ b/gdb/testsuite/gdb.rocm/corefile.exp
@@ -22,7 +22,7 @@
 load_lib rocm.exp
 
 require allow_rocm_core_tests
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/debugtrap.exp
+++ b/gdb/testsuite/gdb.rocm/debugtrap.exp
@@ -22,7 +22,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/deep-stack.exp
+++ b/gdb/testsuite/gdb.rocm/deep-stack.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/deref-scoped-pointer.exp
+++ b/gdb/testsuite/gdb.rocm/deref-scoped-pointer.exp
@@ -26,7 +26,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/detach-while-breakpoints-inserted.exp
+++ b/gdb/testsuite/gdb.rocm/detach-while-breakpoints-inserted.exp
@@ -27,7 +27,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/device-attach.exp
+++ b/gdb/testsuite/gdb.rocm/device-attach.exp
@@ -15,7 +15,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 set escapedbinfile [string_to_regexp $binfile]

--- a/gdb/testsuite/gdb.rocm/device-barrier.exp
+++ b/gdb/testsuite/gdb.rocm/device-barrier.exp
@@ -19,7 +19,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/device-interrupt.exp
+++ b/gdb/testsuite/gdb.rocm/device-interrupt.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/devicecode-breakpoint.exp
+++ b/gdb/testsuite/gdb.rocm/devicecode-breakpoint.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/disassemble.exp
+++ b/gdb/testsuite/gdb.rocm/disassemble.exp
@@ -26,7 +26,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/displaced-stepping.exp
+++ b/gdb/testsuite/gdb.rocm/displaced-stepping.exp
@@ -22,7 +22,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/exec-bit-extract.exp
+++ b/gdb/testsuite/gdb.rocm/exec-bit-extract.exp
@@ -22,7 +22,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if { ![istarget "*-linux*"] } then {
     continue

--- a/gdb/testsuite/gdb.rocm/finish.exp
+++ b/gdb/testsuite/gdb.rocm/finish.exp
@@ -22,7 +22,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu.exp
+++ b/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require allow_fork_tests
 
 standard_testfile -execer.cpp -execee.cpp

--- a/gdb/testsuite/gdb.rocm/fork-exec-non-gpu-to-gpu.exp
+++ b/gdb/testsuite/gdb.rocm/fork-exec-non-gpu-to-gpu.exp
@@ -19,7 +19,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require allow_fork_tests
 
 standard_testfile -execer.cpp -execee.cpp

--- a/gdb/testsuite/gdb.rocm/gcore-after-attach.exp
+++ b/gdb/testsuite/gdb.rocm/gcore-after-attach.exp
@@ -26,7 +26,7 @@
 load_lib rocm.exp
 
 require allow_rocm_core_tests
-require allow_hipcc_tests
+require allow_hip_tests
 require can_spawn_for_attach
 
 standard_testfile .cpp

--- a/gdb/testsuite/gdb.rocm/generic-address.exp
+++ b/gdb/testsuite/gdb.rocm/generic-address.exp
@@ -25,7 +25,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
@@ -26,7 +26,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile hip-builtin-variables.cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -31,7 +31,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
+++ b/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile hip-builtin-variables.cpp
 

--- a/gdb/testsuite/gdb.rocm/illegal-insn-sigill.exp
+++ b/gdb/testsuite/gdb.rocm/illegal-insn-sigill.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/info-dispatches.exp
+++ b/gdb/testsuite/gdb.rocm/info-dispatches.exp
@@ -22,7 +22,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/info-sharedlibrary.exp
+++ b/gdb/testsuite/gdb.rocm/info-sharedlibrary.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/instruction-stepping-commands.exp
+++ b/gdb/testsuite/gdb.rocm/instruction-stepping-commands.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/interrupt-twice.exp
+++ b/gdb/testsuite/gdb.rocm/interrupt-twice.exp
@@ -19,7 +19,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/lane-execution.exp
+++ b/gdb/testsuite/gdb.rocm/lane-execution.exp
@@ -34,7 +34,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/lane-info.exp
+++ b/gdb/testsuite/gdb.rocm/lane-info.exp
@@ -28,7 +28,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/lane-pc-vega20.exp
+++ b/gdb/testsuite/gdb.rocm/lane-pc-vega20.exp
@@ -20,7 +20,7 @@
 load_lib dwarf.exp
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 # Return the memory address of SYMBOL.
 

--- a/gdb/testsuite/gdb.rocm/line-breakpoint-in-kernel.exp
+++ b/gdb/testsuite/gdb.rocm/line-breakpoint-in-kernel.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/load-core-remote-system.exp
+++ b/gdb/testsuite/gdb.rocm/load-core-remote-system.exp
@@ -29,7 +29,7 @@ load_lib rocm.exp
 
 require allow_rocm_core_tests
 require {!is_remote host}
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/mi-aspace.exp
+++ b/gdb/testsuite/gdb.rocm/mi-aspace.exp
@@ -20,7 +20,7 @@ load_lib rocm.exp
 load_lib mi-support.exp
 set MIFLAGS "-i=mi"
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/mi-attach.exp
+++ b/gdb/testsuite/gdb.rocm/mi-attach.exp
@@ -17,7 +17,7 @@ load_lib rocm.exp
 load_lib mi-support.exp
 set MIFLAGS "-i=mi"
 
-require can_spawn_for_attach allow_hipcc_tests
+require can_spawn_for_attach allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/mi-lanes.exp
+++ b/gdb/testsuite/gdb.rocm/mi-lanes.exp
@@ -20,7 +20,7 @@ load_lib rocm.exp
 load_lib mi-support.exp
 set MIFLAGS "-i=mi"
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile lane-execution.cpp
 

--- a/gdb/testsuite/gdb.rocm/multi-inferior-fork.exp
+++ b/gdb/testsuite/gdb.rocm/multi-inferior-fork.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require allow_fork_tests
 
 standard_testfile .cpp

--- a/gdb/testsuite/gdb.rocm/multi-inferior-gpu.exp
+++ b/gdb/testsuite/gdb.rocm/multi-inferior-gpu.exp
@@ -20,7 +20,7 @@ load_lib rocm.exp
 
 standard_testfile .cpp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require hip_devices_support_debug_multi_process
 require allow_fork_tests
 

--- a/gdb/testsuite/gdb.rocm/multi-inferior-run-spurious-waves.exp
+++ b/gdb/testsuite/gdb.rocm/multi-inferior-run-spurious-waves.exp
@@ -27,7 +27,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require allow_multi_inferior_tests
 
 if { [hip_device_is_less_than gfx90a] } {

--- a/gdb/testsuite/gdb.rocm/names.exp
+++ b/gdb/testsuite/gdb.rocm/names.exp
@@ -17,7 +17,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/nonstop-displaced.exp
+++ b/gdb/testsuite/gdb.rocm/nonstop-displaced.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/nonstop-mode.exp
+++ b/gdb/testsuite/gdb.rocm/nonstop-mode.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/ocp_mx.exp
+++ b/gdb/testsuite/gdb.rocm/ocp_mx.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests allow_python_tests
+require allow_hip_tests allow_python_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/precise-memory-exec.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-exec.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .c
 

--- a/gdb/testsuite/gdb.rocm/precise-memory-fork.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-fork.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 require allow_fork_tests
 
 standard_testfile .c

--- a/gdb/testsuite/gdb.rocm/precise-memory-multi-inferiors.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-multi-inferiors.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 clean_restart
 

--- a/gdb/testsuite/gdb.rocm/precise-memory-warning-sigsegv.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-warning-sigsegv.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/precise-memory-warning-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-warning-watchpoint.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if { ![istarget "*-linux*"] } then {
     continue

--- a/gdb/testsuite/gdb.rocm/precise-memory.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/program-execution.exp
+++ b/gdb/testsuite/gdb.rocm/program-execution.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/register-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/register-watchpoint.exp
@@ -20,7 +20,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile bit-extract.cpp
 

--- a/gdb/testsuite/gdb.rocm/resume-exception.exp
+++ b/gdb/testsuite/gdb.rocm/resume-exception.exp
@@ -23,7 +23,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -24,7 +24,7 @@
 load_lib rocm.exp
 
 require allow_rocm_core_tests
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/scheduler-locking.exp
+++ b/gdb/testsuite/gdb.rocm/scheduler-locking.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/shared-memory.exp
+++ b/gdb/testsuite/gdb.rocm/shared-memory.exp
@@ -20,7 +20,7 @@
 load_lib rocm.exp
 
 # Python support is required to use $_streq.
-require allow_hipcc_tests allow_python_tests
+require allow_hip_tests allow_python_tests
 
 standard_testfile .cpp -size.cpp
 

--- a/gdb/testsuite/gdb.rocm/show-info.exp
+++ b/gdb/testsuite/gdb.rocm/show-info.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/simple-outside-debugger.exp
+++ b/gdb/testsuite/gdb.rocm/simple-outside-debugger.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile simple.cpp
 

--- a/gdb/testsuite/gdb.rocm/simple.exp
+++ b/gdb/testsuite/gdb.rocm/simple.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
+++ b/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
@@ -42,7 +42,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
+++ b/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
@@ -42,7 +42,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 
@@ -50,7 +50,7 @@ set hipmodule_path [standard_output_file ${testfile}.hipfb]
 
 if { [gdb_compile  $srcdir/$subdir/$srcfile \
 	$hipmodule_path object \
-	{ debug hip additional_flags=--genco } ] != "" } {
+	{ debug hip additional_flags=--cuda-device-only } ] != "" } {
     return -1
 }
 

--- a/gdb/testsuite/gdb.rocm/static-global.exp
+++ b/gdb/testsuite/gdb.rocm/static-global.exp
@@ -38,7 +38,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/step-over-kernel-exit.exp
+++ b/gdb/testsuite/gdb.rocm/step-over-kernel-exit.exp
@@ -23,7 +23,7 @@ load_lib rocm.exp
 
 standard_testfile .cpp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if { [build_executable "failed to prepare" \
 	  $testfile $srcfile {debug hip}] == -1 } {

--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
@@ -28,7 +28,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 if { [hip_device_is_less_than gfx90a] } {
     # Scheduler locking does not work in an intuitive manner before gfx90a due

--- a/gdb/testsuite/gdb.rocm/unaligned-memory-access.exp
+++ b/gdb/testsuite/gdb.rocm/unaligned-memory-access.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/until-tests.exp
+++ b/gdb/testsuite/gdb.rocm/until-tests.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/update-thread-list.exp
+++ b/gdb/testsuite/gdb.rocm/update-thread-list.exp
@@ -21,7 +21,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/watchpoint-at-end-of-shader.exp
+++ b/gdb/testsuite/gdb.rocm/watchpoint-at-end-of-shader.exp
@@ -18,7 +18,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/watchpoint-basic.exp
+++ b/gdb/testsuite/gdb.rocm/watchpoint-basic.exp
@@ -17,7 +17,7 @@
 
 load_lib rocm.exp
 
-require allow_hipcc_tests
+require allow_hip_tests
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/lib/future.exp
+++ b/gdb/testsuite/lib/future.exp
@@ -121,20 +121,28 @@ proc gdb_find_rustc {} {
     return $rustc
 }
 
-proc gdb_find_hipcc {} {
+proc gdb_find_hip_compiler {} {
     global tool_root_dir
     if {![is_remote host]} {
-	set hipcc [lookfor_file $tool_root_dir hipcc]
-	if {$hipcc eq "" && [info exists ::env(ROCM_PATH)]} {
-	    set hipcc [lookfor_file $::env(ROCM_PATH)/bin hipcc]
+	set compiler [lookfor_file $tool_root_dir amdclang++]
+	if {$compiler eq "" && [info exists ::env(ROCM_PATH)]} {
+	    set compiler [lookfor_file $::env(ROCM_PATH)/llvm/bin amdclang++]
 	}
-	if {$hipcc eq ""} {
-	    set hipcc hipcc
+	if {$compiler eq ""} {
+	    set compiler [lookfor_file /opt/rocm/llvm/bin amdclang++]
+	}
+	if {$compiler eq ""} {
+	    set compiler amdclang++
 	}
     } else {
-	set hipcc ""
+	set compiler ""
     }
-    return $hipcc
+    return $compiler
+}
+
+# Backwards compatibility alias.
+proc gdb_find_hipcc {} {
+    return [gdb_find_hip_compiler]
 }
 
 proc gdb_find_ldd {} {
@@ -343,7 +351,7 @@ proc gdb_default_target_compile_1 {source destfile type options} {
 	    if {[board_info $dest exists hipcompiler]} {
 		set compiler [target_info hipcompiler]
 	    } else {
-		set compiler [find_hipcc]
+		set compiler [find_hip_compiler]
 	    }
 	}
 
@@ -409,6 +417,7 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     global GO_FOR_TARGET
     global GO_LD_FOR_TARGET
     global RUSTC_FOR_TARGET
+    global HIP_COMPILER_FOR_TARGET
     global HIPCC_FOR_TARGET
 
     if {[info exists GNATMAKE_FOR_TARGET]} {
@@ -456,7 +465,11 @@ proc gdb_default_target_compile_1 {source destfile type options} {
 	}
     }
 
-    if {[info exists HIPCC_FOR_TARGET]} {
+    if {[info exists HIP_COMPILER_FOR_TARGET]} {
+	if {$compiler_type == "hip"} {
+	    set compiler $HIP_COMPILER_FOR_TARGET
+	}
+    } elseif {[info exists HIPCC_FOR_TARGET]} {
 	if {$compiler_type == "hip"} {
 	    set compiler $HIPCC_FOR_TARGET
 	}
@@ -762,12 +775,20 @@ if {[info procs find_rustc] == ""} {
     rename gdb_find_rustc ""
 }
 
-if {[info procs find_hipcc] == ""} {
-    rename gdb_find_hipcc find_hipcc
+if {[info procs find_hip_compiler] == ""} {
+    rename gdb_find_hip_compiler find_hip_compiler
     set use_gdb_compile(hip) 1
     gdb_note [join [list $note_prefix "HIP" $note_suffix] ""]
 } else {
-    rename gdb_find_hipcc ""
+    rename gdb_find_hip_compiler ""
+}
+
+# Backwards compatibility: provide find_hipcc as an alias that always
+# delegates to find_hip_compiler (which is guaranteed to exist at this
+# point, either from the rename above or from an external definition).
+catch {rename gdb_find_hipcc ""}
+if {[info procs find_hipcc] == ""} {
+    proc find_hipcc {} { return [find_hip_compiler] }
 }
 
 # If dejagnu's default_target_compile is missing support for any language,

--- a/gdb/testsuite/lib/future.exp
+++ b/gdb/testsuite/lib/future.exp
@@ -121,20 +121,20 @@ proc gdb_find_rustc {} {
     return $rustc
 }
 
-proc gdb_find_hipcc {} {
+proc gdb_find_hip_compiler {} {
     global tool_root_dir
     if {![is_remote host]} {
-	set hipcc [lookfor_file $tool_root_dir hipcc]
-	if {$hipcc eq "" && [info exists ::env(ROCM_PATH)]} {
-	    set hipcc [lookfor_file $::env(ROCM_PATH)/bin hipcc]
+	set compiler [lookfor_file $tool_root_dir amdclang++]
+	if {$compiler eq "" && [info exists ::env(ROCM_PATH)]} {
+	    set compiler [lookfor_file $::env(ROCM_PATH)/lib/llvm/bin amdclang++]
 	}
-	if {$hipcc eq ""} {
-	    set hipcc hipcc
+	if {$compiler eq ""} {
+	    set compiler amdclang++
 	}
     } else {
-	set hipcc ""
+	set compiler ""
     }
-    return $hipcc
+    return $compiler
 }
 
 proc gdb_find_ldd {} {
@@ -343,7 +343,7 @@ proc gdb_default_target_compile_1 {source destfile type options} {
 	    if {[board_info $dest exists hipcompiler]} {
 		set compiler [target_info hipcompiler]
 	    } else {
-		set compiler [find_hipcc]
+		set compiler [find_hip_compiler]
 	    }
 	}
 
@@ -409,7 +409,7 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     global GO_FOR_TARGET
     global GO_LD_FOR_TARGET
     global RUSTC_FOR_TARGET
-    global HIPCC_FOR_TARGET
+    global HIP_COMPILER_FOR_TARGET
 
     if {[info exists GNATMAKE_FOR_TARGET]} {
 	if { $compiler_type == "ada" } {
@@ -456,9 +456,9 @@ proc gdb_default_target_compile_1 {source destfile type options} {
 	}
     }
 
-    if {[info exists HIPCC_FOR_TARGET]} {
+    if {[info exists HIP_COMPILER_FOR_TARGET]} {
 	if {$compiler_type == "hip"} {
-	    set compiler $HIPCC_FOR_TARGET
+	    set compiler $HIP_COMPILER_FOR_TARGET
 	}
     }
 
@@ -762,12 +762,12 @@ if {[info procs find_rustc] == ""} {
     rename gdb_find_rustc ""
 }
 
-if {[info procs find_hipcc] == ""} {
-    rename gdb_find_hipcc find_hipcc
+if {[info procs find_hip_compiler] == ""} {
+    rename gdb_find_hip_compiler find_hip_compiler
     set use_gdb_compile(hip) 1
     gdb_note [join [list $note_prefix "HIP" $note_suffix] ""]
 } else {
-    rename gdb_find_hipcc ""
+    rename gdb_find_hip_compiler ""
 }
 
 # If dejagnu's default_target_compile is missing support for any language,

--- a/gdb/testsuite/lib/future.exp
+++ b/gdb/testsuite/lib/future.exp
@@ -126,10 +126,7 @@ proc gdb_find_hip_compiler {} {
     if {![is_remote host]} {
 	set compiler [lookfor_file $tool_root_dir amdclang++]
 	if {$compiler eq "" && [info exists ::env(ROCM_PATH)]} {
-	    set compiler [lookfor_file $::env(ROCM_PATH)/llvm/bin amdclang++]
-	}
-	if {$compiler eq ""} {
-	    set compiler [lookfor_file /opt/rocm/llvm/bin amdclang++]
+	    set compiler [lookfor_file $::env(ROCM_PATH)/lib/llvm/bin amdclang++]
 	}
 	if {$compiler eq ""} {
 	    set compiler amdclang++
@@ -138,11 +135,6 @@ proc gdb_find_hip_compiler {} {
 	set compiler ""
     }
     return $compiler
-}
-
-# Backwards compatibility alias.
-proc gdb_find_hipcc {} {
-    return [gdb_find_hip_compiler]
 }
 
 proc gdb_find_ldd {} {
@@ -776,14 +768,6 @@ if {[info procs find_hip_compiler] == ""} {
     gdb_note [join [list $note_prefix "HIP" $note_suffix] ""]
 } else {
     rename gdb_find_hip_compiler ""
-}
-
-# Backwards compatibility: provide find_hipcc as an alias that always
-# delegates to find_hip_compiler (which is guaranteed to exist at this
-# point, either from the rename above or from an external definition).
-catch {rename gdb_find_hipcc ""}
-if {[info procs find_hipcc] == ""} {
-    proc find_hipcc {} { return [find_hip_compiler] }
 }
 
 # If dejagnu's default_target_compile is missing support for any language,

--- a/gdb/testsuite/lib/future.exp
+++ b/gdb/testsuite/lib/future.exp
@@ -418,7 +418,6 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     global GO_LD_FOR_TARGET
     global RUSTC_FOR_TARGET
     global HIP_COMPILER_FOR_TARGET
-    global HIPCC_FOR_TARGET
 
     if {[info exists GNATMAKE_FOR_TARGET]} {
 	if { $compiler_type == "ada" } {
@@ -468,10 +467,6 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     if {[info exists HIP_COMPILER_FOR_TARGET]} {
 	if {$compiler_type == "hip"} {
 	    set compiler $HIP_COMPILER_FOR_TARGET
-	}
-    } elseif {[info exists HIPCC_FOR_TARGET]} {
-	if {$compiler_type == "hip"} {
-	    set compiler $HIPCC_FOR_TARGET
 	}
     }
 

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6248,6 +6248,52 @@ proc gdb_compile {source dest type options} {
 	}
     }
 
+    # For HIP executables, amdclang++ needs -x hip to treat .cpp/.c as
+    # HIP source, but -x hip applied to a .o file makes amdclang++ try
+    # to parse the object as HIP source, which fails.  Since gdb_compile
+    # may later inject additional .o inputs (e.g. set_unbuffered_mode.o),
+    # we cannot safely mix any source files with any .o inputs in a
+    # single amdclang++ invocation.  To avoid that, pre-compile each
+    # source file to its own .o first (with -x hip), then recurse with
+    # an all-.o source list.  The recursive call will not add -x hip
+    # and the final link will work correctly.
+    if {[lsearch -exact $options hip] != -1
+	&& $type eq "executable"
+	&& [lsearch -exact $options getting_compiler_info] == -1} {
+	set has_source 0
+	foreach src $source {
+	    set ext [file extension $src]
+	    if {$ext ne ".o" && $ext ne ".a"} {
+		set has_source 1
+		break
+	    }
+	}
+	if {$has_source} {
+	    set new_source {}
+	    set idx 0
+	    foreach src $source {
+		set ext [file extension $src]
+		if {$ext eq ".o" || $ext eq ".a"} {
+		    lappend new_source $src
+		} else {
+		    # Include an index in the temp filename so that
+		    # two source files with the same basename (e.g.
+		    # dir1/foo.cpp and dir2/foo.cpp) do not collide
+		    # to the same intermediate .o.
+		    set out \
+			[standard_temp_file \
+			     ${idx}-[file tail $src].hip.o]
+		    set res [gdb_compile $src $out object $options]
+		    if {$res ne ""} {
+			return $res
+		    }
+		    lappend new_source $out
+		}
+		incr idx
+	    }
+	    return [gdb_compile $new_source $dest $type $options]
+	}
+    }
 
     set outdir [file dirname $dest]
 
@@ -6559,11 +6605,16 @@ proc gdb_compile {source dest type options} {
 	#
 	# amdclang++ needs -x hip to treat .cpp/.c as HIP source when
 	# compiling, and --hip-link to link the HIP runtime when
-	# linking.  When linking only .o files, -x hip must NOT be
-	# passed, otherwise amdclang++ tries to parse them as HIP
-	# source.  Add -O0 as default optimization.  If "optimize"
-	# is also requested, another -O flag (e.g. -O2) will be added
-	# to the flags, overriding -O0.
+	# linking.  -x hip must NOT be passed when any .o input is
+	# present, otherwise amdclang++ tries to parse the .o file
+	# as HIP source.  The executable-linking path above pre-
+	# compiles all sources to .o first, so by the time we get
+	# here with $type == "executable" all inputs are .o files.
+	# For the $type == "object" path, $source is always a single
+	# source file, so -x hip is safe.  Add -O0 as default
+	# optimization.  If "optimize" is also requested, another
+	# -O flag (e.g. -O2) will be added to the flags, overriding
+	# -O0.
 	set has_source_files 0
 	foreach src $source {
 	    set ext [file extension $src]
@@ -6581,6 +6632,15 @@ proc gdb_compile {source dest type options} {
 	}
 	if {$type eq "executable"} {
 	    set hip_early_flags "--hip-link $hip_early_flags"
+	}
+	# Pass --rocm-path explicitly so amdclang++ can locate the HIP
+	# headers and device libraries regardless of how it was invoked
+	# (full path vs bare name on PATH) or whether ROCM_PATH is set
+	# in the environment.  rocm_path comes from rocm.exp and
+	# defaults to /opt/rocm if ROCM_PATH is not set.
+	global rocm_path
+	if {[info exists rocm_path] && $rocm_path ne ""} {
+	    set hip_early_flags "--rocm-path=$rocm_path $hip_early_flags"
 	}
 	lappend new_options "early_flags=$hip_early_flags"
 
@@ -6807,52 +6867,14 @@ proc gdb_compile {source dest type options} {
 		    lappend options \
 			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
 		} else {
-		    # For HIP, amdclang++ needs -x hip to treat
-		    # sources as HIP, but -x hip applied to a .o
-		    # file makes amdclang++ try to parse the object
-		    # as HIP source, which fails.  To avoid mixing
-		    # sources and the unbuffered .o in a single
-		    # amdclang++ invocation, pre-compile each source
-		    # file to its own .o first (with -x hip), then
-		    # replace the source list with the resulting
-		    # .o files plus the unbuffered .o.  The final
-		    # link step must use only .o inputs, so also
-		    # strip -x hip from the accumulated early_flags
-		    # so the link sees just --hip-link.
-		    set new_source {}
-		    foreach src $source {
-			set ext [file extension $src]
-			if {$ext eq ".o" || $ext eq ".a"} {
-			    lappend new_source $src
-			} else {
-			    set out \
-				[standard_temp_file [file tail $src].hip.o]
-			    set res [gdb_compile $src $out object $options]
-			    if {$res ne ""} {
-				return $res
-			    }
-			    lappend new_source $out
-			}
-		    }
-		    lappend new_source \
-			$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)
-		    set source $new_source
-
-		    # Strip -x hip from early_flags in options since
-		    # we no longer have any source files in the
-		    # final link invocation.
-		    set stripped_options {}
-		    foreach opt $options {
-			if {[regexp {^early_flags=(.*)} $opt -> val]} {
-			    regsub -all {(^| )-x hip( |$)} \
-				$val { } val
-			    set val [string trim $val]
-			    lappend stripped_options "early_flags=$val"
-			} else {
-			    lappend stripped_options $opt
-			}
-		    }
-		    set options $stripped_options
+		    # For HIP, the generalized pre-compile step at
+		    # the top of gdb_compile has already turned any
+		    # source files into .o files.  Prepending the
+		    # unbuffered .o to the (all-.o) source list is
+		    # safe -- no mixed source/.o invocation happens.
+		    set source \
+			[linsert $source 0 \
+			     $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)]
 		}
 	    }
 	}

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6268,10 +6268,6 @@ proc gdb_compile {source dest type options} {
     set new_options {}
     if {[lsearch -exact $options rust] != -1} {
 	# -fdiagnostics-color is not a rustcc option.
-    } elseif {[lsearch -exact $options hip] != -1} {
-	# The legacy hipcc wrapper did not support -fdiagnostics-color.
-	# amdclang++ does support it, but we skip it for HIP compilation
-	# to keep the behavior consistent.
     } else {
 	# icx/clang compilers support the -fdiagnostics-color option for
 	# ".S" files and only it is not supported for ".s" files.
@@ -6760,10 +6756,6 @@ proc gdb_compile {source dest type options} {
 		set unbuf_obj_options {nowarnings}
 		if {[lsearch -exact $options hip] != -1} {
 		    lappend unbuf_obj_options hip
-		    # While amdclang++ treats .cc/.cpp files as HIP
-		    # files (via '-x hip'), it treats .c files as C
-		    # files (via '-x c').  Since we have a .c file,
-		    # force compilation in HIP mode ourselves.
 		    lappend unbuf_obj_options "additional_flags=-x hip"
 
 		    # Compile without --offload-arch (which is fine
@@ -6815,23 +6807,14 @@ proc gdb_compile {source dest type options} {
 			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
 		} else {
 		    # With ldflags, the .o file would be placed last
-		    # in the HIP compiler invocation, like:
-		    #
-		    #  $ amdclang++ source.cc set_unbuffered_mode_obj.o
-		    #
-		    # Unfortunately, if a foo.o file appears after a
-		    # bar.cc file, the compiler treats the foo.o file
-		    # as a source file, and invokes Clang with
-		    # "clang -x hip foo.o", which fails.
-		    #
-		    # It works correctly if we put the .o file first,
-		    # though, like:
-		    #
-		    #  $ amdclang++ set_unbuffered_mode_obj.o source.cc
-		    #
-		    # So for HIP, we prepend the
-		    # set_unbuffered_mode_obj.o file to the sources
-		    # list.
+		    # in the compiler invocation.  With -x hip in
+		    # early_flags, amdclang++ would treat the .o
+		    # file as HIP source, which fails.  By
+		    # prepending the .o to the sources list, it
+		    # appears before the .cc file.  The conditional
+		    # -x hip logic in gdb_compile only adds -x hip
+		    # when source files are present, so the .o is
+		    # handled correctly during linking.
 		    set source \
 			[linsert $source 0 \
 			     $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)]

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6861,21 +6861,14 @@ proc gdb_compile {source dest type options} {
 	    # used.  Thus, we need to disable it if -nostdlib option
 	    # is used.
 	    if {[lsearch -regexp $options "-nostdlib"] < 0 } {
-		if {[lsearch -exact $options hip] == -1} {
-		    # Use ldflags to avoid copying the object file to
-		    # the host multiple times.
-		    lappend options \
-			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
-		} else {
-		    # For HIP, the generalized pre-compile step at
-		    # the top of gdb_compile has already turned any
-		    # source files into .o files.  Prepending the
-		    # unbuffered .o to the (all-.o) source list is
-		    # safe -- no mixed source/.o invocation happens.
-		    set source \
-			[linsert $source 0 \
-			     $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)]
-		}
+		# Use ldflags to avoid copying the object file to
+		# the host multiple times.  For HIP, the generalized
+		# pre-compile at the top of gdb_compile ensures
+		# $source is all-.o by the time we get here, so
+		# -x hip is not in early_flags and appending another
+		# .o via ldflags is safe.
+		lappend options \
+		    "ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
 	    }
 	}
     }

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6203,7 +6203,7 @@ proc quote_for_host { args } {
 #   - column-info/no-column-info: Enable/Disable generation of column table
 #     information.
 #   - dwarf5: Force compilation with dwarf-5 debug information.
-#   - hip_no_offload_arch: Do not pass --offload-arch to HIPCC.
+#   - hip_no_offload_arch: Do not pass --offload-arch to the HIP compiler.
 #
 # And here are some of the not too obscure options understood by DejaGnu that
 # influence the compilation:
@@ -6269,7 +6269,9 @@ proc gdb_compile {source dest type options} {
     if {[lsearch -exact $options rust] != -1} {
 	# -fdiagnostics-color is not a rustcc option.
     } elseif {[lsearch -exact $options hip] != -1} {
-	# -fdiagnostics-color is not a hipcc option.
+	# The legacy hipcc wrapper did not support -fdiagnostics-color.
+	# amdclang++ does support it, but we skip it for HIP compilation
+	# to keep the behavior consistent.
     } else {
 	# icx/clang compilers support the -fdiagnostics-color option for
 	# ".S" files and only it is not supported for ".s" files.
@@ -6556,14 +6558,34 @@ proc gdb_compile {source dest type options} {
 	#    '-mllvm=-amdgpu-spill-cfi-saved-regs' [-Wunused-command-line-argument]
 	#
 	# These happen when we're compiling an executable _and_ all
-	# the input files are .o files, like: hipcc foo.o -o foo ...
+	# the input files are .o files, like: amdclang++ foo.o -o foo ...
 	#
-	# HIPCC defaults to -O2, so add -O0 to early flags for the HIP
-	# language.  If "optimize" is also requested, another -O flag
-	# (e.g. -O2) will be added to the flags, overriding this -O0.
-	lappend new_options "early_flags=-O0\
+	# amdclang++ needs -x hip to treat .cpp/.c as HIP source when
+	# compiling, and --hip-link to link the HIP runtime when
+	# linking.  When linking only .o files, -x hip must NOT be
+	# passed, otherwise amdclang++ tries to parse them as HIP
+	# source.  Add -O0 as default optimization.  If "optimize"
+	# is also requested, another -O flag (e.g. -O2) will be added
+	# to the flags, overriding -O0.
+	set has_source_files 0
+	foreach src $source {
+	    set ext [file extension $src]
+	    if {$ext ne ".o" && $ext ne ".a"} {
+		set has_source_files 1
+		break
+	    }
+	}
+
+	set hip_early_flags "-O0\
 			     -mllvm=-amdgpu-spill-cfi-saved-regs\
 			     -Wno-unused-command-line-argument"
+	if {$has_source_files} {
+	    set hip_early_flags "-x hip $hip_early_flags"
+	}
+	if {$type eq "executable"} {
+	    set hip_early_flags "--hip-link $hip_early_flags"
+	}
+	lappend new_options "early_flags=$hip_early_flags"
 
 	if {[istarget "*-*-mingw*"]} {
 	    # This tells Clang to emit DWARF, but only if -g, or -gN
@@ -6585,12 +6607,9 @@ proc gdb_compile {source dest type options} {
 	    lappend new_options "ldflags=-Wl,-debug:none -Wl,-debug:dwarf"
 	}
 
-	# Unlike on Linux, on Windows, HIPCC doesn't automatically
-	# pick the available GPUs, and --offload-arch=native doesn't
-	# work either.  Explicitly pass one --offload-arch for each
-	# available device.  Do it on Linux too, just to minimize
-	# potential behavior differences between OSs.  But don't do it
-	# if the testcase explicitly used --offload-arch.
+	# amdclang++ requires explicit --offload-arch.  Explicitly
+	# pass one --offload-arch for each available device.  But
+	# don't do it if the testcase explicitly used --offload-arch.
 	if {[lsearch -exact $options hip_no_offload_arch] == -1
 	    && [lsearch -regexp $options "--offload-arch="] == -1} {
 	    foreach gpu_target [hcc_amdgpu_targets] {
@@ -6722,7 +6741,7 @@ proc gdb_compile {source dest type options} {
 
 	    # For most C-based languages, we compile the special
 	    # object with the C compiler.  For HIP, compile it with
-	    # HIPCC.
+	    # the HIP compiler.
 	    if {[lsearch -exact $options hip] != -1} {
 		set unbuf_obj_lang hip
 	    } {
@@ -6741,9 +6760,9 @@ proc gdb_compile {source dest type options} {
 		set unbuf_obj_options {nowarnings}
 		if {[lsearch -exact $options hip] != -1} {
 		    lappend unbuf_obj_options hip
-		    # While HIPCC makes Clang treat .cc/.cpp files as
-		    # HIP files (via '-x hip'), it treats .c files as
-		    # C files (via '-x c').  Since we have a .c file,
+		    # While amdclang++ treats .cc/.cpp files as HIP
+		    # files (via '-x hip'), it treats .c files as C
+		    # files (via '-x c').  Since we have a .c file,
 		    # force compilation in HIP mode ourselves.
 		    lappend unbuf_obj_options "additional_flags=-x hip"
 
@@ -6752,9 +6771,9 @@ proc gdb_compile {source dest type options} {
 		    # otherwise, when compiling the GPU device
 		    # enumerator (see find_amdgpu_devices),
 		    # gdb_compile would call hcc_amdgpu_targets to
-		    # know which --offload-arch flags to pass to
-		    # HIPCC, and we'd end up here again, resulting in
-		    # infinite recursion.
+		    # know which --offload-arch flags to pass to the
+		    # HIP compiler, and we'd end up here again,
+		    # resulting in infinite recursion.
 		    lappend unbuf_obj_options hip_no_offload_arch
 		}
 
@@ -6796,19 +6815,19 @@ proc gdb_compile {source dest type options} {
 			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
 		} else {
 		    # With ldflags, the .o file would be placed last
-		    # in the HIPCC invocation, like:
+		    # in the HIP compiler invocation, like:
 		    #
-		    #  $ hipcc source.cc set_unbuffered_mode_obj.o
+		    #  $ amdclang++ source.cc set_unbuffered_mode_obj.o
 		    #
 		    # Unfortunately, if a foo.o file appears after a
-		    # bar.cc file, HIPCC treats the foo.o file as a
-		    # source file, and invokes Clang with "clang -x
-		    # hip foo.o", which fails.
+		    # bar.cc file, the compiler treats the foo.o file
+		    # as a source file, and invokes Clang with
+		    # "clang -x hip foo.o", which fails.
 		    #
-		    # HIPCC works correctly if we put the .o file
-		    # first, though, like:
+		    # It works correctly if we put the .o file first,
+		    # though, like:
 		    #
-		    #  $ hipcc set_unbuffered_mode_obj.o source.cc
+		    #  $ amdclang++ set_unbuffered_mode_obj.o source.cc
 		    #
 		    # So for HIP, we prepend the
 		    # set_unbuffered_mode_obj.o file to the sources

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6248,6 +6248,7 @@ proc gdb_compile {source dest type options} {
 	}
     }
 
+
     set outdir [file dirname $dest]
 
     # GDB doesn't support minimal symbols in AIX, so fail the compilation
@@ -6806,18 +6807,52 @@ proc gdb_compile {source dest type options} {
 		    lappend options \
 			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
 		} else {
-		    # With ldflags, the .o file would be placed last
-		    # in the compiler invocation.  With -x hip in
-		    # early_flags, amdclang++ would treat the .o
-		    # file as HIP source, which fails.  By
-		    # prepending the .o to the sources list, it
-		    # appears before the .cc file.  The conditional
-		    # -x hip logic in gdb_compile only adds -x hip
-		    # when source files are present, so the .o is
-		    # handled correctly during linking.
-		    set source \
-			[linsert $source 0 \
-			     $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)]
+		    # For HIP, amdclang++ needs -x hip to treat
+		    # sources as HIP, but -x hip applied to a .o
+		    # file makes amdclang++ try to parse the object
+		    # as HIP source, which fails.  To avoid mixing
+		    # sources and the unbuffered .o in a single
+		    # amdclang++ invocation, pre-compile each source
+		    # file to its own .o first (with -x hip), then
+		    # replace the source list with the resulting
+		    # .o files plus the unbuffered .o.  The final
+		    # link step must use only .o inputs, so also
+		    # strip -x hip from the accumulated early_flags
+		    # so the link sees just --hip-link.
+		    set new_source {}
+		    foreach src $source {
+			set ext [file extension $src]
+			if {$ext eq ".o" || $ext eq ".a"} {
+			    lappend new_source $src
+			} else {
+			    set out \
+				[standard_temp_file [file tail $src].hip.o]
+			    set res [gdb_compile $src $out object $options]
+			    if {$res ne ""} {
+				return $res
+			    }
+			    lappend new_source $out
+			}
+		    }
+		    lappend new_source \
+			$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)
+		    set source $new_source
+
+		    # Strip -x hip from early_flags in options since
+		    # we no longer have any source files in the
+		    # final link invocation.
+		    set stripped_options {}
+		    foreach opt $options {
+			if {[regexp {^early_flags=(.*)} $opt -> val]} {
+			    regsub -all {(^| )-x hip( |$)} \
+				$val { } val
+			    set val [string trim $val]
+			    lappend stripped_options "early_flags=$val"
+			} else {
+			    lappend stripped_options $opt
+			}
+		    }
+		    set options $stripped_options
 		}
 	    }
 	}

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6415,7 +6415,7 @@ proc quote_for_host { args } {
 #   - column-info/no-column-info: Enable/Disable generation of column table
 #     information.
 #   - dwarf5: Force compilation with dwarf-5 debug information.
-#   - hip_no_offload_arch: Do not pass --offload-arch to HIPCC.
+#   - hip_no_offload_arch: Do not pass --offload-arch to the HIP compiler.
 #
 # And here are some of the not too obscure options understood by DejaGnu that
 # influence the compilation:
@@ -6444,12 +6444,12 @@ proc gdb_compile {source dest type options} {
 	&& [istarget "*-*-mingw*"]} {
 	# target_compile by default links with -lm, if the target
 	# board does not have 'mathlib' set to point to an alternative
-	# math library.  Windows HIPCC targets the MSVC ABI and uses
-	# the MSVC headers and libraries, and there is no separate
-	# math lib in that case, the math functions are found in the C
-	# runtime library instead.  If mathlib is not set already in
-	# the target board, set it to empty and recurse, to override
-	# target_compile's default.
+	# math library.  The Windows HIP compiler targets the MSVC ABI
+	# and uses the MSVC headers and libraries, and there is no
+	# separate math lib in that case, the math functions are found
+	# in the C runtime library instead.  If mathlib is not set
+	# already in the target board, set it to empty and recurse, to
+	# override target_compile's default.
 	global board
 	set board [target_info name]
 	if {![board_info $board exists mathlib]} {
@@ -6480,8 +6480,6 @@ proc gdb_compile {source dest type options} {
     set new_options {}
     if {[lsearch -exact $options rust] != -1} {
 	# -fdiagnostics-color is not a rustcc option.
-    } elseif {[lsearch -exact $options hip] != -1} {
-	# -fdiagnostics-color is not a hipcc option.
     } else {
 	# icx/clang compilers support the -fdiagnostics-color option for
 	# ".S" files and only it is not supported for ".s" files.
@@ -6768,14 +6766,33 @@ proc gdb_compile {source dest type options} {
 	#    '-mllvm=-amdgpu-spill-cfi-saved-regs' [-Wunused-command-line-argument]
 	#
 	# These happen when we're compiling an executable _and_ all
-	# the input files are .o files, like: hipcc foo.o -o foo ...
+	# the input files are .o files, like: amdclang++ foo.o -o foo ...
 	#
-	# HIPCC defaults to -O2, so add -O0 to early flags for the HIP
-	# language.  If "optimize" is also requested, another -O flag
-	# (e.g. -O2) will be added to the flags, overriding this -O0.
-	lappend new_options "early_flags=-O0\
-			     -mllvm=-amdgpu-spill-cfi-saved-regs\
+	# amdclang++ does not infer the input language from the file
+	# extension.  Rather than passing a single global "-x hip" in
+	# early_flags (which would also be applied to any .o inputs,
+	# e.g. set_unbuffered_mode.o injected via ldflags, causing
+	# amdclang++ to try to parse the object as HIP source), we tag
+	# each input individually just before target_compile: "-x hip"
+	# before .cpp/.c sources and "-x none" before .o/.a files.
+	# --hip-link is still required when linking to bring in the HIP
+	# runtime.
+	set hip_early_flags "-mllvm=-amdgpu-spill-cfi-saved-regs\
 			     -Wno-unused-command-line-argument"
+	if {$type eq "executable"} {
+	    set hip_early_flags "--hip-link $hip_early_flags"
+	}
+	# When ROCM_PATH is set in the environment, pass --rocm-path
+	# so amdclang++ uses that specific ROCm install for HIP
+	# headers and device libraries.  When ROCM_PATH is not set,
+	# defer to amdclang++'s own HIP discovery, which looks under
+	# the parent of its own LLVM directory and falls back on
+	# /opt/rocm; overriding that here would silently mask the
+	# user's actual compiler-side install.
+	if {[info exists ::env(ROCM_PATH)] && $::env(ROCM_PATH) ne ""} {
+	    set hip_early_flags "--rocm-path=$::env(ROCM_PATH) $hip_early_flags"
+	}
+	lappend new_options "early_flags=$hip_early_flags"
 
 	if {[istarget "*-*-mingw*"]} {
 	    # This tells Clang to emit DWARF, but only if -g, or -gN
@@ -6797,12 +6814,9 @@ proc gdb_compile {source dest type options} {
 	    lappend new_options "ldflags=-Wl,-debug:none -Wl,-debug:dwarf"
 	}
 
-	# Unlike on Linux, on Windows, HIPCC doesn't automatically
-	# pick the available GPUs, and --offload-arch=native doesn't
-	# work either.  Explicitly pass one --offload-arch for each
-	# available device.  Do it on Linux too, just to minimize
-	# potential behavior differences between OSs.  But don't do it
-	# if the testcase explicitly used --offload-arch.
+	# amdclang++ requires explicit --offload-arch.  Explicitly
+	# pass one --offload-arch for each available device.  But
+	# don't do it if the testcase explicitly used --offload-arch.
 	if {[lsearch -exact $options hip_no_offload_arch] == -1
 	    && [lsearch -regexp $options "--offload-arch="] == -1} {
 	    foreach gpu_target [hcc_amdgpu_targets] {
@@ -6934,7 +6948,7 @@ proc gdb_compile {source dest type options} {
 
 	    # For most C-based languages, we compile the special
 	    # object with the C compiler.  For HIP, compile it with
-	    # HIPCC.
+	    # the HIP compiler.
 	    if {[lsearch -exact $options hip] != -1} {
 		set unbuf_obj_lang hip
 	    } {
@@ -6953,20 +6967,15 @@ proc gdb_compile {source dest type options} {
 		set unbuf_obj_options {nowarnings}
 		if {[lsearch -exact $options hip] != -1} {
 		    lappend unbuf_obj_options hip
-		    # While HIPCC makes Clang treat .cc/.cpp files as
-		    # HIP files (via '-x hip'), it treats .c files as
-		    # C files (via '-x c').  Since we have a .c file,
-		    # force compilation in HIP mode ourselves.
-		    lappend unbuf_obj_options "additional_flags=-x hip"
 
 		    # Compile without --offload-arch (which is fine
 		    # because this object has no device code), because
 		    # otherwise, when compiling the GPU device
 		    # enumerator (see find_amdgpu_devices),
 		    # gdb_compile would call hcc_amdgpu_targets to
-		    # know which --offload-arch flags to pass to
-		    # HIPCC, and we'd end up here again, resulting in
-		    # infinite recursion.
+		    # know which --offload-arch flags to pass to the
+		    # HIP compiler, and we'd end up here again,
+		    # resulting in infinite recursion.
 		    lappend unbuf_obj_options hip_no_offload_arch
 		}
 
@@ -7001,33 +7010,17 @@ proc gdb_compile {source dest type options} {
 	    # used.  Thus, we need to disable it if -nostdlib option
 	    # is used.
 	    if {[lsearch -regexp $options "-nostdlib"] < 0 } {
-		if {[lsearch -exact $options hip] == -1} {
-		    # Use ldflags to avoid copying the object file to
-		    # the host multiple times.
+		# Use ldflags to avoid copying the object file to
+		# the host multiple times.  For HIP, prefix "-x none"
+		# so amdclang++ does not treat the .o as HIP source
+		# (the immediately preceding command-line input may
+		# have been a .cpp/.c tagged with "-x hip").
+		if {$unbuf_obj_lang eq "hip"} {
+		    lappend options \
+			"ldflags=-x none $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
+		} else {
 		    lappend options \
 			"ldflags=$gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)"
-		} else {
-		    # With ldflags, the .o file would be placed last
-		    # in the HIPCC invocation, like:
-		    #
-		    #  $ hipcc source.cc set_unbuffered_mode_obj.o
-		    #
-		    # Unfortunately, if a foo.o file appears after a
-		    # bar.cc file, HIPCC treats the foo.o file as a
-		    # source file, and invokes Clang with "clang -x
-		    # hip foo.o", which fails.
-		    #
-		    # HIPCC works correctly if we put the .o file
-		    # first, though, like:
-		    #
-		    #  $ hipcc set_unbuffered_mode_obj.o source.cc
-		    #
-		    # So for HIP, we prepend the
-		    # set_unbuffered_mode_obj.o file to the sources
-		    # list.
-		    set source \
-			[linsert $source 0 \
-			     $gdb_saved_set_unbuffered_mode_obj($unbuf_obj_lang)]
 		}
 	    }
 	}
@@ -7035,6 +7028,27 @@ proc gdb_compile {source dest type options} {
 
     # Automatically handle includes in testsuite/lib/.
     auto_lappend_include_files options $source
+
+    # For HIP, amdclang++ does not infer the input language from the
+    # file extension, so explicitly tag each input: "-x hip" before
+    # C/C++/HIP source files, and "-x none" before everything else
+    # (object files, archives, shared libraries), so the compiler
+    # does not try to parse those as HIP source.  This lets a single
+    # amdclang++ invocation correctly handle a mix of sources and
+    # non-source inputs (e.g. when set_unbuffered_mode.o is appended
+    # via ldflags later in the command line).
+    if {[lsearch -exact $options hip] != -1 && !$getting_compiler_info} {
+	set new_source {}
+	foreach src $source {
+	    set ext [string tolower [file extension $src]]
+	    if {$ext in {".c" ".cc" ".cp" ".cxx" ".cpp" ".c++" ".hip"}} {
+		lappend new_source "-x" "hip" $src
+	    } else {
+		lappend new_source "-x" "none" $src
+	    }
+	}
+	set source $new_source
+    }
 
     cond_wrap [expr {$pie != -1 || $nopie != -1}] \
 	with_PIE_multilib_flags_filtered {

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -18,7 +18,7 @@
 
 # tclint-disable redefined-builtin
 
-# ROCM_PATH is used by hipcc as well.
+# ROCM_PATH is used by the HIP toolchain.
 if {[info exists ::env(ROCM_PATH)]} {
     set rocm_path $::env(ROCM_PATH)
 } else {
@@ -60,8 +60,8 @@ gdb_caching_proc find_amdgpu_devices {} {
     # Compile without --offload-arch (which is fine because this is a
     # host-only program), because otherwise gdb_compile would call
     # hcc_amdgpu_targets to know which --offload-arch flags to pass to
-    # HIPCC, and we'd end up here again, resulting in infinite
-    # recursion.
+    # the HIP compiler, and we'd end up here again, resulting in
+    # infinite recursion.
     set options {hip hip_no_offload_arch}
     if {![gdb_simple_compile device_enumerator {
 	    #include <hip/hip_runtime.h>
@@ -107,7 +107,7 @@ gdb_caching_proc find_amdgpu_devices {} {
 # Otherwise, consider the devices available on the system.
 
 proc hcc_amdgpu_targets {} {
-    # First, look for HCC_AMDGPU_TARGET (same env var hipcc uses).
+    # First, look for HCC_AMDGPU_TARGET (same env var the HIP toolchain uses).
     if {[info exists ::env(HCC_AMDGPU_TARGET)]} {
 	# We don't verify the contents of HCC_AMDGPU_TARGET.
 	# That's the toolchain's job.
@@ -117,7 +117,7 @@ proc hcc_amdgpu_targets {} {
     return [find_amdgpu_devices]
 }
 
-gdb_caching_proc allow_hipcc_tests {} {
+gdb_caching_proc allow_hip_tests {} {
     # Only the native target supports ROCm debugging.  E.g., when
     # testing against GDBserver, there's no point in running the ROCm
     # tests.
@@ -140,7 +140,7 @@ gdb_caching_proc allow_hipcc_tests {} {
     }
 
     # Check if there's any GPU device to run the tests on.  If this
-    # works, then we also know we have a working hipcc compiler
+    # works, then we also know we have a working HIP compiler
     # available.
     set devices [find_amdgpu_devices]
     if {[llength $devices] == 0} {
@@ -148,6 +148,14 @@ gdb_caching_proc allow_hipcc_tests {} {
     }
 
     return 1
+}
+
+# Backwards compatibility alias.  The testsuite previously used
+# allow_hipcc_tests when the legacy hipcc wrapper was the HIP
+# compiler.  Keep this alias so that any out-of-tree test files
+# or scripts referencing the old name continue to work.
+gdb_caching_proc allow_hipcc_tests {} {
+    return [allow_hip_tests]
 }
 
 # Return true if GPU core dump tests are allowed.
@@ -175,7 +183,7 @@ proc rocm_assemble {source dest {options ""}} {
     global objdir
 
     # Pick the first target as the default one.
-    # The list can't be empty.  Else, allow_hipcc_tests would've caught it.
+    # The list can't be empty.  Else, allow_hip_tests would've caught it.
     set gpu_target [lindex [hcc_amdgpu_targets] 0]
 
     global rocm_path
@@ -418,7 +426,7 @@ proc hip_devices_support_debug_multi_process {} {
 
 proc hip_device_is_less_than { version } {
   # Pick the first device as the current one.
-  # The list can't be empty.  Else, allow_hipcc_tests would've caught it.
+  # The list can't be empty.  Else, allow_hip_tests would've caught it.
   set target [lindex [find_amdgpu_devices] 0]
 
   # Strip "gfx" prefix.

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -18,7 +18,7 @@
 
 # tclint-disable redefined-builtin
 
-# ROCM_PATH is used by hipcc as well.
+# ROCM_PATH is used by the HIP toolchain.
 if {[info exists ::env(ROCM_PATH)]} {
     set rocm_path $::env(ROCM_PATH)
 } else {
@@ -60,8 +60,8 @@ gdb_caching_proc find_amdgpu_devices {} {
     # Compile without --offload-arch (which is fine because this is a
     # host-only program), because otherwise gdb_compile would call
     # hcc_amdgpu_targets to know which --offload-arch flags to pass to
-    # HIPCC, and we'd end up here again, resulting in infinite
-    # recursion.
+    # the HIP compiler, and we'd end up here again, resulting in
+    # infinite recursion.
     set options {hip hip_no_offload_arch}
     if {![gdb_simple_compile device_enumerator {
 	    #include <hip/hip_runtime.h>
@@ -107,7 +107,7 @@ gdb_caching_proc find_amdgpu_devices {} {
 # Otherwise, consider the devices available on the system.
 
 proc hcc_amdgpu_targets {} {
-    # First, look for HCC_AMDGPU_TARGET (same env var hipcc uses).
+    # First, look for HCC_AMDGPU_TARGET (same env var the HIP toolchain uses).
     if {[info exists ::env(HCC_AMDGPU_TARGET)]} {
 	# We don't verify the contents of HCC_AMDGPU_TARGET.
 	# That's the toolchain's job.
@@ -117,7 +117,7 @@ proc hcc_amdgpu_targets {} {
     return [find_amdgpu_devices]
 }
 
-gdb_caching_proc allow_hipcc_tests {} {
+gdb_caching_proc allow_hip_tests {} {
     # Only the native target supports ROCm debugging.  E.g., when
     # testing against GDBserver, there's no point in running the ROCm
     # tests.
@@ -140,7 +140,7 @@ gdb_caching_proc allow_hipcc_tests {} {
     }
 
     # Check if there's any GPU device to run the tests on.  If this
-    # works, then we also know we have a working hipcc compiler
+    # works, then we also know we have a working HIP compiler
     # available.
     set devices [find_amdgpu_devices]
     if {[llength $devices] == 0} {
@@ -175,7 +175,7 @@ proc rocm_assemble {source dest {options ""}} {
     global objdir
 
     # Pick the first target as the default one.
-    # The list can't be empty.  Else, allow_hipcc_tests would've caught it.
+    # The list can't be empty.  Else, allow_hip_tests would've caught it.
     set gpu_target [lindex [hcc_amdgpu_targets] 0]
 
     global rocm_path
@@ -457,7 +457,7 @@ proc supports_cooperative_groups {} {
 
 proc hip_device_is_less_than { version } {
   # Pick the first device as the current one.
-  # The list can't be empty.  Else, allow_hipcc_tests would've caught it.
+  # The list can't be empty.  Else, allow_hip_tests would've caught it.
   set target [lindex [find_amdgpu_devices] 0]
 
   # Strip "gfx" prefix.


### PR DESCRIPTION
## Motivation

The GDB testsuite uses `hipcc` for HIP compiler discovery, naming, and
documentation. `hipcc` is deprecated and will be removed at some point, so this
switches the testsuite over to `amdclang++`.

## What changes

### Compiler discovery (`lib/future.exp`)
- Look for `amdclang++` under `$ROCM_PATH/lib/llvm/bin` instead of `hipcc`.
- Rename `HIPCC_FOR_TARGET` to `HIP_COMPILER_FOR_TARGET` (the environment
  override).
- Rename `gdb_find_hipcc` / `find_hipcc` to `gdb_find_hip_compiler` /
  `find_hip_compiler`.

### Compile and link flags (`lib/gdb.exp`, `boards/hip.exp`)
- `amdclang++` does not infer the input language from the file extension, so
  tag each input explicitly: `-x hip` before C/C++/HIP sources and `-x none`
  before object files/archives. A single invocation can then handle a mix of
  sources and objects (e.g. `set_unbuffered_mode.o` / `hip-driver.o` injected
  via `ldflags`).
- Pass `--hip-link` only when producing an executable.
- Pass `--rocm-path` only when `ROCM_PATH` is set; otherwise defer to
  `amdclang++`'s own HIP discovery.
- Drop the explicit `-O0` (`amdclang++` already defaults to `-O0`).
- `amdclang++` is clang-based and accepts `-fdiagnostics-color`, so stop
  skipping it for HIP; this keeps color escape sequences out of `gdb.log`.

### Testcases
- Rename `allow_hipcc_tests` to `allow_hip_tests` in `lib/rocm.exp`,
  `boards/hip.exp`, and all `gdb.rocm/` and `gdb.perf/` testcases.
- Replace `hipcc`'s `--genco` with `amdclang++`'s `--cuda-device-only` in the
  two code-object tests (`code-object-load-while-breakpoint-hit.exp`,
  `snapshot-objfile-on-load.exp`).

### Documentation (`gdb/doc/gdb.texinfo`)
- Update the example compile command to `amdclang++ -x hip --hip-link ...`,
  keeping the note about the equivalent `hipcc` invocation.
