### PR TITLE
[cherry-pick-amd-staging-rocgdb-16] gdb/dwarf2/expr: Cache the register reads

### DIFF
--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -32,11 +32,20 @@
 #include "dwarf2/read.h"
 #include "frame.h"
 #include "gdbsupport/underlying.h"
+#include "gdbsupport/refcounted-object.h"
 #include "gdbarch.h"
 #include "gdbthread.h"
 #include "inferior.h"
 #include "objfiles.h"
 #include "observable.h"
+
+using context_generation_t = ULONGEST;
+
+/* A monotically increasing counter modified every time any inferior memory
+   is touched or any register in any target is modified.  This can be used to
+   know if state (register value) cached by the evaluator might be stale.  */
+
+static context_generation_t context_generation = 0;
 
 /* This holds gdbarch-specific types used by the DWARF expression
    evaluator.  See comments in execute_stack_op.  */
@@ -1243,13 +1252,12 @@ public:
 		  bool on_entry = false, LONGEST offset = 0,
 		  LONGEST bit_suboffset = 0)
     : dwarf_location (arch, offset, bit_suboffset),
-      m_regnum (regnum), m_on_entry (on_entry)
+      m_storage {register_storage_ptr::new_reference
+		   (new register_storage (regnum, on_entry))}
   {}
 
   dwarf_register (const dwarf_register &reg)
-    : dwarf_location (reg),
-      m_regnum (reg.m_regnum),
-      m_on_entry (reg.m_on_entry)
+    : dwarf_location (reg), m_storage (reg.m_storage)
   {}
 
   std::shared_ptr<dwarf_entry> clone () const override
@@ -1275,12 +1283,62 @@ public:
 			 size_t location_bit_limit) const override;
 
 private:
-  /* DWARF register number.  */
-  unsigned int m_regnum;
+  struct register_storage : public refcounted_object
+  {
+    register_storage (unsigned int regnum, bool on_entry)
+      : m_regnum { regnum }, m_on_entry { on_entry }
+      , m_read_cache {}
+    {}
 
-  /* True if location is on the frame entry, described
-     in CFI of the previous frame.  */
-  bool m_on_entry;
+    /* DWARF register number.  */
+    unsigned int m_regnum;
+
+    /* True if location is on the frame entry, described
+       in CFI of the previous frame.  */
+    bool m_on_entry;
+
+    struct read_cache
+    {
+      read_cache (gdbarch *arch, const frame_info_ptr &frame, int regnum)
+	: m_frame { frame }, m_context_generation { context_generation }
+	, m_data (register_size (arch, regnum))
+	{
+	  enum lval_type lval;
+	  CORE_ADDR address;
+	  int realnum;
+	  frame_register_unwind (get_next_frame_sentinel_okay (frame), regnum,
+				 &m_optimized_out, &m_unavailable, &lval,
+				 &address, &realnum, m_data);
+	}
+
+      bool outdated (const frame_info_ptr &frame) const
+      {
+	return (m_context_generation != context_generation
+		|| frame != m_frame);
+      }
+
+      bool optimized_out () const { return m_optimized_out; }
+      bool unavailable () const { return m_unavailable; }
+      gdb::array_view<const gdb_byte> data () const
+      {
+	return {m_data};
+      }
+
+    private:
+      frame_info_ptr m_frame;
+      context_generation_t m_context_generation;
+      bool m_optimized_out;
+      bool m_unavailable;
+      gdb::byte_vector m_data;
+    };
+    std::optional<read_cache> m_read_cache;
+  };
+
+  using register_storage_ptr
+    = gdb::ref_ptr<register_storage,
+		   refcounted_object_delete_ref_policy<register_storage>>;
+
+  register_storage_ptr m_storage;
 };
 
 void
@@ -1293,7 +1351,7 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   LONGEST total_bits_to_skip = bits_to_skip;
   size_t read_bit_limit = location_bit_limit;
   gdbarch *arch = get_frame_arch (frame);
-  int reg = dwarf_reg_to_regnum_or_error (arch, m_regnum);
+  int reg = dwarf_reg_to_regnum_or_error (arch, m_storage->m_regnum);
   ULONGEST reg_bits = HOST_CHAR_BIT * register_size (arch, reg);
   gdb::byte_vector temp_buf;
 
@@ -1311,21 +1369,28 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   LONGEST this_size = bits_to_bytes (total_bits_to_skip, bit_size);
   temp_buf.resize (this_size);
 
-  if (m_on_entry)
+  if (m_storage->m_on_entry)
     frame = get_prev_frame_always (frame);
 
   if (frame == NULL)
     internal_error (_("invalid frame information"));
 
-  /* Can only read from a register on byte granularity so an
-     additional buffer is required.  */
-  read_from_register (frame, reg, total_bits_to_skip / HOST_CHAR_BIT,
-		      temp_buf, optimized, unavailable);
+  /* Populate or refresh the cache if needed.  */
+  if (m_storage->m_read_cache.has_value ()
+      && m_storage->m_read_cache->outdated (frame))
+    m_storage->m_read_cache.reset ();
 
-  /* Only copy data if valid.  */
+  if (!m_storage->m_read_cache.has_value ())
+    m_storage->m_read_cache.emplace (arch, frame, reg);
+
+  *optimized = m_storage->m_read_cache->optimized_out ();
+  *unavailable = m_storage->m_read_cache->unavailable ();
+
   if (!*optimized && !*unavailable)
-    copy_bitwise (buf, buf_bit_offset, temp_buf.data (),
-		  total_bits_to_skip % HOST_CHAR_BIT, bit_size, big_endian);
+    copy_bitwise (buf, buf_bit_offset,
+		  m_storage->m_read_cache->data ().data (),
+		  total_bits_to_skip, bit_size, big_endian);
+
 }
 
 void
@@ -1334,15 +1399,18 @@ dwarf_register::write (const frame_info_ptr &initial_frame, const gdb_byte *buf,
 		       LONGEST bits_to_skip, size_t location_bit_limit,
 		       bool big_endian, int *optimized, int *unavailable) const
 {
+  /* Invalidate the cache.  */
+  m_storage->m_read_cache.reset ();
+
   frame_info_ptr frame = initial_frame;
   LONGEST total_bits_to_skip = bits_to_skip;
   size_t write_bit_limit = location_bit_limit;
   gdbarch *arch = get_frame_arch (frame);
-  int gdb_regnum = dwarf_reg_to_regnum_or_error (arch, m_regnum);
+  int gdb_regnum = dwarf_reg_to_regnum_or_error (arch, m_storage->m_regnum);
   ULONGEST reg_bits = HOST_CHAR_BIT * register_size (arch, gdb_regnum);
   gdb::byte_vector temp_buf;
 
-  if (m_on_entry)
+  if (m_storage->m_on_entry)
     frame = get_prev_frame_always (frame);
 
   if (frame == NULL)
@@ -1386,12 +1454,12 @@ dwarf_register::to_gdb_value (const frame_info_ptr &initial_frame,
 {
   frame_info_ptr frame = initial_frame;
   gdbarch *arch = get_frame_arch (frame);
-  int gdb_regnum = dwarf_reg_to_regnum_or_error (arch, m_regnum);
+  int gdb_regnum = dwarf_reg_to_regnum_or_error (arch, m_storage->m_regnum);
 
   if (subobj_type == nullptr)
     subobj_type = type;
 
-  if (m_on_entry)
+  if (m_storage->m_on_entry)
     frame = get_prev_frame_always (frame);
 
   if (frame == NULL)
@@ -4700,4 +4768,39 @@ dwarf2_evaluate (const gdb_byte *addr, size_t len, bool as_lval,
   return ctx.evaluate (addr, len, as_lval, per_cu,
 		       frame, init_values, addr_info,
 		       type, subobj_type, subobj_offset);
+}
+
+static void
+expr_observer_target_changed (struct target_ops * /* target */)
+{
+  context_generation++;
+}
+
+static void
+expr_observer_memory_changed (CORE_ADDR /* addr */, ssize_t /* len */,
+			      const bfd_byte * /* data */)
+{
+  context_generation++;
+}
+
+INIT_GDB_FILE (expr)
+{
+  /* Register the observers we need to invalidate our internal caches.
+
+     Every time a register is modified (every time a value is assigned to
+     really, also applies to lval_memory values), target_changed ends-up being
+     called.  Any such assignment should invalidate any cached value we hold
+     in the expression evaluator.  */
+  gdb::observers::target_changed.attach (expr_observer_target_changed,
+					 "dwarf2_expr");
+
+  /* Note that we can implicitly cache register values which are not currently
+     stored in a register.  For example, if a register was spilled to memory
+     from the previous frame, a memory change could impact a register value
+     we cached.  It is possible to modify such memory without triggering
+     target_changed for example using "Inferior.write_memory" in Python or
+     "-data-write-memory-bytes" with MI.  Use the memory_changed observable to
+     invalidate our caches if such access is done.  */
+  gdb::observers::memory_changed.attach (expr_observer_memory_changed,
+					 "dwarf2_expr");
 }


### PR DESCRIPTION
A recent change in the ROCm compiler started to show some timeout in the gdb.rocm/deep-stack.exp testcase.  In that test, we have a 12 frames deep stack, and we print a stack trace.  With the new compiler output, building this stacktrace would take about 190 seconds... Yes, about 3 minutes to unwind 12 frames.

Looking at the unwind information, we now see this new pattern for unwinding vector registers:

    VGPR40=[
      DW_OP_regx VGPR40
      DW_OP_swap
      DW_OP_LLVM_user
      DW_OP_LLVM_offset_uconst 0x0
      DW_OP_LLVM_user DW_OP_LLVM_call_frame_entry_reg EXEC
      DW_OP_deref_size 0x8
      DW_OP_LLVM_user DW_OP_LLVM_select_bit_piece 0x20 0x40
    ]

This new construct uses DW_OP_LLVM_select_bit_piece, which allows us to build a composite which has one piece per lane of the vector register, each piece referencing either
- the register itself (not touched because the lane was not active, so no need to spill), or
- a saved copy of the register to memory (at CFA).

The issue turned out to be that when building the composite, we ended up creating up to 64 pieces (one per lane), each can be a dwarf_register instance.  And even if all of those reference the same register, they do not share anything more than the regnum.

When we evaluate something like dwarf_composite::is_optimized_out, we end-up calling dwarf_register::is_optimized_out for each piece in sequence.  Each one of those calls will call dwarf_register::read and eventually frame_register_wind, i.e. we fully unwind the register once for each lane.  If the next frame, and the next, and the next use the same pattern, we end-up with an impossible complexity of O(lanes ** depth), which explains how we can end-up with 3 minutes to do a 12 frames unwinding.

This pattern does not only happen when calling value::optimized_out, this also happens when calling value->entirely_available for example, making things very inefficient..

To solve this, this patch makes two things:
- Make it so when we use DW_OP_LLVM_select_bit_piece, all the dwarf_register in the resulting composite share a storage,
- Make that storage cache the result of calling frame_register_unwind, so we do not have to repeat this for every piece.

The cache is cleared any time we call dwarf_register::write, or if we detect that it might be outdated (target_changed or memory_changed got called since we cached the data).

With this, doing the backtrace from the test now takes slightly more than .5 seconds, which is back to acceptable territory.

    (gdb) bt
    2026-04-02 17:40:05.195 - command started
    #0  base_case () at /home/.../gdb.rocm/deep-stack.cpp:40
    #1  0x00007ffff637649c in deep<0u> () at /home/.../gdb.rocm/deep-stack.cpp:54
    #2  0x00007ffff637655c in deep<1u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #3  0x00007ffff637661c in deep<2u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #4  0x00007ffff63766e4 in deep<3u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #5  0x00007ffff63767a4 in deep<4u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #6  0x00007ffff6376864 in deep<5u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #7  0x00007ffff6376924 in deep<6u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #8  0x00007ffff63769e4 in deep<7u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #9  0x00007ffff6376aa4 in deep<8u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #10 0x00007ffff6376b64 in deep<9u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #11 0x00007ffff6376c24 in deep<10u> () at /home/.../gdb.rocm/deep-stack.cpp:47
    #12 0x00007ffff6376d40 in hip_deep () at /home/.../gdb.rocm/deep-stack.cpp:60
    2026-04-02 17:40:05.753 - command finished
    Command execution time: 0.558060 (cpu), 0.558099 (wall)

Change-Id: I976af7fc7d6a946967d3aa986bce5b990891da20
(cherry picked from commit f204e6a13acc73c30ebe029dfa81d0e95932bbd8)
