### PR TITLE
Fix ROCgdb CI trigger

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: c9529ebdedc2e52c7b4dc26d209725a31f616ac7 # 2026-03-13 commit
+  THEROCK_COMMIT_REF: 65a2a9cd5895a9cdb2a1352767377f35e70254d1 # 14/04/2026
 
 jobs:
   therock-build-linux:
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:583d473f263a289222c48d4b493e2956b2354a45796f09dee6f2c8ecd4504ab6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:latest
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout rocGDB repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          path: rocgdb
+          path: rocgdb_under_test
 
       - name: Install python deps
         run: |
@@ -56,7 +56,7 @@ jobs:
       - name: Setup ccache
         run: |
           ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
+            --config-preset "github-oss-dev" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -55,7 +55,10 @@ jobs:
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 
         -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
-        -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb
+        -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
+        -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
+        -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
+        -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: c9529ebdedc2e52c7b4dc26d209725a31f616ac7 # 2026-03-13 commit
+  THEROCK_COMMIT_REF: 65a2a9cd5895a9cdb2a1352767377f35e70254d1 # 14/04/2026
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
   THEROCK_BIN_DIR: "./build/bin"


### PR DESCRIPTION
- Pick up TheRock's revision that contains a fix to allow ROCgdb to be built
from an external source directory.

- Pass Python options to TheRock.

- Always use the latest manylinux image for the builds.