### PR TITLE
gdb/dwarf2/expr: Fix cherrx-pick of "Cache the register reads"

### DIFF
--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -1306,9 +1306,12 @@ private:
 	  enum lval_type lval;
 	  CORE_ADDR address;
 	  int realnum;
+	  int optimized, unavailable;
 	  frame_register_unwind (get_next_frame_sentinel_okay (frame), regnum,
-				 &m_optimized_out, &m_unavailable, &lval,
-				 &address, &realnum, m_data);
+				 &optimized, &unavailable, &lval,
+				 &address, &realnum, m_data.data ());
+	  m_optimized_out = optimized;
+	  m_unavailable = unavailable;
 	}
 
       bool outdated (const frame_info_ptr &frame) const
@@ -4783,7 +4786,9 @@ expr_observer_memory_changed (CORE_ADDR /* addr */, ssize_t /* len */,
   context_generation++;
 }
 
-INIT_GDB_FILE (expr)
+void _initialize_dwarf2_expr ();
+void
+_initialize_dwarf2_expr ()
 {
   /* Register the observers we need to invalidate our internal caches.
 


### PR DESCRIPTION
The cherry-pick of "Cache the register reads" into the amd-staging-rocgdb-16 was incorrect, and was not detected by CI.

This patch fixes things.

Tested locally (build and gdb.rocm/*.exp + gdb.dwarf2/*.exp).

Change-Id: I054f684e5c17038252dd49980607b39992f21a2a