### PR TITLE
WIP: Fix gdb.rocm/watch-gpu-global-from-host.exp on non-ReBar systems

### DIFF
--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
@@ -16,26 +16,53 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include <hip/hip_runtime.h>
-
-__device__ int global = 0;
+#include <stdio.h>
+#include "rocm-test-utils.h"
 
 __global__ void
-kern ()
+kern (int *ptr)
 {
+  (*ptr)++;
 }
 
+int *managed_var = nullptr;
+
 int
-main (int argc, char* argv[])
+main ()
 {
-  kern<<<1, 1>>> ();
-  if (hipDeviceSynchronize () != hipSuccess)
-    return 1;
+  int device_id = 0;
 
-  int *devGlobal;
-  if (hipGetSymbolAddress (reinterpret_cast<void **> (&devGlobal), global))
-    return 2;
+  /* Allocate a variable using managed memory so that we can allocate
+     the variable in the 256MB aperture on non-ReBar systems.  A
+     __device__ global would only be guaranteed to be in the aperture
+     on ReBar systems.  */
+  CHECK (hipMallocManaged (&managed_var, sizeof (int)));
 
-  /* Now update the device global from a CPU thread.  */
-  *devGlobal = 8;
+  /* Apply hints before any access.  On non-ReBar systems, force the
+     driver to find a spot on the GPU, CPU-visible in the 256MB BAR
+     aperture.  */
+  CHECK (hipMemAdvise (managed_var, sizeof (int),
+		       hipMemAdviseSetAccessedBy, hipCpuDeviceId));
+  CHECK (hipMemAdvise (managed_var, sizeof (int),
+		       hipMemAdviseSetPreferredLocation, device_id));
+
+  /* Ensure the physical pages are on the GPU.  */
+  CHECK (hipMemPrefetchAsync (managed_var, sizeof (int), device_id, 0));
+
+  /* Warm up the GPU.  */
+  kern<<<1, 1>>> (managed_var);
+  CHECK (hipDeviceSynchronize ());
+
+  printf ("Pointer address: %p\n", (void *) managed_var);
+  printf ("Attempting host write...\n");
+
+  /* Now update the device global from the host.  On ReBar systems,
+     and on non-ReBar systems (if the hints worked), this writes
+     across the PCIe BAR into the GPU's memory controller.  */
+  *managed_var = 8;
+
+  printf ("Write successful.  Value: %d\n", *managed_var);
+
+  CHECK (hipFree (managed_var));
   return 0;
 }

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -35,16 +35,43 @@ proc do_test {} {
 	    return
 	}
 
+	gdb_test "print managed_var" " = \\(int \\*\\) 0x0" \
+	    "print managed_var from host"
+
 	gdb_test "with breakpoint pending on -- break kern" \
 	    "Breakpoint $::decimal \\(kern\\) pending."
 
 	gdb_test "continue" \
 	    "Thread $::decimal \"kern\" hit Breakpoint $::decimal, with lane 0, kern .*"
 
-	gdb_test "watch global" "Hardware watchpoint $::decimal: global"
+	# Sigh, from a GPU context, we get:
+	#
+	#  (gdb) print managed_var
+	#  'managed_var' has unknown type; cast it to its declared type
+	#
+	# why???
+	setup_kfail "*-*-*" "xxxx"
+	gdb_test "print managed_var" " = \\(int \\*\\) 0x0" \
+	    "print managed_var from device"
+
+	set watch_expr "*(int *)managed_var"
+	set watch_expr_re [string_to_regexp $watch_expr]
+
+	# The kernel argument should be the same pointer as the host's
+	# MANAGED_PTR global.
+	gdb_test "print ptr == (int *)managed_var" " = true"
+
+	gdb_test "watch $watch_expr" \
+	    "Hardware watchpoint $::decimal: $watch_expr_re"
+
+	# XXX we should catch the write in the kernel too!
+	#
+	# If we set a watchpoint on "*ptr" instead, then we catch the
+	# kernel write, but not the CPU write!
+	#
 
 	gdb_test "continue" \
-	    "Hardware watchpoint $::decimal: global.*Old value = 0\r\nNew value = 8\r\nmain.*" \
+	    "Hardware watchpoint $::decimal: $watch_expr_re.*Old value = 0\r\nNew value = 8\r\nmain.*" \
 	    "hit watchpoint in main"
     }
 }


### PR DESCRIPTION
On a non-ReBar system, you get:

 Thread 1 "watch-gpu-globa" received signal SIGSEGV, Segmentation fault.
 [Switching to thread 1 (Thread 0x7ffff62d0f80 (LWP 590038))]
 0x0000000000211c43 in main (argc=1, argv=0x7fffffffcf88) at /home/pedro/rocm/gdb/build/gdb/testsuite/../../../src/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp:39
 39        *devGlobal = 8;
 (gdb) FAIL: gdb.rocm/watch-gpu-global-from-host.exp: hit watchpoint in main

Change-Id: I052f2858357ef34d0dbaaa6479d5131571cea112
commit-id:c99ccb02