### PR TITLE
gdb/dwarf2/frame: Fix unwinding constant value

### DIFF
--- a/gdb/dwarf2/frame.c
+++ b/gdb/dwarf2/frame.c
@@ -257,7 +257,7 @@ execute_stack_op (const gdb_byte *exp, ULONGEST len, int addr_size,
   init_values.push_back (init_value);
 
   value *result_val
-    = dwarf2_evaluate (exp, len, true, per_objfile, nullptr,
+    = dwarf2_evaluate (exp, len, as_lval, per_objfile, nullptr,
 		       this_frame, addr_size, &init_values, nullptr, type);
 
   /* We need to clean up all the values that are not needed any more.


### PR DESCRIPTION
A recent testcase introduced upstream showed a failure in our downstream DWARF evaluation machinery.  The testcase exercises an unwind rule where the register value is known at compile time (and not spilled):

    R14=DW_OP_constu 0x99aabbcc

But when running the test, instead of showing this value for the register,  GDB tries to go and read the register value at that address:

     (gdb) p/x $r14
     Cannot access memory at address 0x99aabbcc

The issue comes down to the implementation of execute_stack_op.  It receives a "as_lavl" flag telling it if the result of the evaluation is meant to be an address or a value, but does not forward that flag to dwarf2_evaluate.  Instead it always calls dwarf2_evaluate with as_lval=true, which is what causes the incorrect behavior.

This patch fixes this oversight.

Change-Id: I1ae64a4e23a5b43cc1c6c64b5b3b28cc25b7546c
