### PR TITLE
gdb/testsuite: Fix pre-commit errors

### DIFF
--- a/gdb/testsuite/gdb.rocm/generic-address.exp
+++ b/gdb/testsuite/gdb.rocm/generic-address.exp
@@ -39,7 +39,7 @@ proc do_test {} {
     gdb_load $::binfile
 
     with_rocm_gpu_lock {
-	if ![runto_main] {
+	if {![runto_main]} {
 	    return
 	}
 

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -50,4 +50,3 @@ proc do_test {} {
 }
 
 do_test
-


### PR DESCRIPTION
When running pre-commit, I see 2 issues reported:

    check-whitespace.........................................................Failed
    - hook id: check-whitespace
    - exit code: 2

    gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp:53: new blank line at EOF.

    pre-commit-setup.........................................................Passed
    tclint...................................................................Failed
    - hook id: tclint
    - exit code: 1

    gdb/testsuite/gdb.rocm/generic-address.exp:42:2: expected braced word or word without substitutions in argument interpreted as expr [command-args]

Fix those.

Change-Id: I18d208cdfd3e2673932e56bb19dc5599fec9f386
