### PR TITLE
Add pre-commit workflow for rocgdb

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,43 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [amd-staging]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine base ref
+        id: base-ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+          else
+            BASE_REF="amd-staging"
+          fi
+          echo "base_ref=${BASE_REF}" >> $GITHUB_OUTPUT
+          echo "Base ref: ${BASE_REF}"
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ steps.base-ref.outputs.base_ref }}:${{ steps.base-ref.outputs.base_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --from-ref origin/${{ steps.base-ref.outputs.base_ref }} --to-ref HEAD


### PR DESCRIPTION
Add GitHub Actions workflow to run pre-commit checks on all commits beyond the PR's base branch. The workflow dynamically determines the base branch:
- For pull requests: Uses the PR's base branch
- For direct pushes: Defaults to amd-staging

This ensures code quality standards are enforced and correctly handles PRs targeting different branches (amd-staging, amd-staging-rocgdb-*, etc).