### PR TITLE
binutils/readelf: Remove unused static variables

### DIFF
--- a/binutils/readelf.c
+++ b/binutils/readelf.c
@@ -239,8 +239,6 @@ static bool do_dump = false;
 static bool do_version = false;
 static bool do_histogram = false;
 static bool do_debugging = false;
-static bool do_ctf = false;
-static bool do_sframe = false;
 static bool do_arch = false;
 static bool do_notes = false;
 static bool do_archive_index = false;
@@ -6569,7 +6567,6 @@ parse_args (struct dump_data *dumpdata, int argc, char ** argv)
 	  dwarf_check = true;
 	  break;
 	case OPTION_CTF_DUMP:
-	  do_ctf = true;
 	  request_dump (dumpdata, CTF_DUMP);
 	  break;
 	case OPTION_CTF_SYMBOLS:
@@ -6585,7 +6582,6 @@ parse_args (struct dump_data *dumpdata, int argc, char ** argv)
 	  dump_ctf_parent_name = strdup (optarg);
 	  break;
 	case OPTION_SFRAME_DUMP:
-	  do_sframe = true;
 	  /* Providing section name is optional.  request_dump (), however,
 	     thrives on non NULL optarg.  Handle it explicitly here.  */
 	  if (optarg != NULL)


### PR DESCRIPTION
Remove static variables do_ctf and do_sframe that are set but never
read, causing build failures with LLVM's extended
-Wunused-but-set-variable warning.

These variables are dead code:
- Declared at lines 244-245 as static booleans
- Set to true when --ctf or --sframe options are parsed
- Never actually used or read anywhere in the code
- The actual dump functionality is triggered by request_dump() calls

Build error with -Werror enabled:

binutils/readelf.c:244:13: error: variable 'do_ctf' set but not used
  [-Werror,-Wunused-but-set-variable]
binutils/readelf.c:245:13: error: variable 'do_sframe' set but not used
  [-Werror,-Wunused-but-set-variable]

(cherry picked from commit https://github.com/ROCm/ROCgdb/commit/a04e10c4b7b0a7621e452fdfce716aacab633bed)