### PR TITLE
[amd-staging-rocgdb-16] gdb/testsuite: fix dw2-entry-pc.exp with ASLR

### DIFF
--- a/gdb/testsuite/gdb.dwarf2/dw2-entry-pc.exp
+++ b/gdb/testsuite/gdb.dwarf2/dw2-entry-pc.exp
@@ -28,7 +28,7 @@ standard_testfile
 get_func_info foo
 
 if { [prepare_for_testing "failed to prepare" ${testfile} \
-	  [list ${srcfile}]] } {
+	  [list ${srcfile}] {debug nopie}]} {
     return -1
 }
 
@@ -83,7 +83,7 @@ proc get_next_suffix {} {
 
 proc build_and_runto_main { suffix asm_file } {
     if {[prepare_for_testing "failed to prepare" "${::testfile}-${suffix}" \
-	     [list $::srcfile $asm_file] {nodebug}]} {
+	     [list $::srcfile $asm_file] {nodebug nopie}]} {
 	return false
     }
 


### PR DESCRIPTION
Following Simon Marchi's fix for dw2-empty-inline-ranges.exp [1], this test exhibits the same failure pattern when running in an environment where GDB can't disable address space randomization (such as in a container where that capability is removed) with a toolchain generating position-independent executables.

The test does a first run to grab addresses of labels and function boundaries (foo_middle, foo_start, foo_end, and range labels).  It then crafts DWARF using these addresses across multiple test iterations. When the executable is PIE and ASLR is active, the addresses in each subsequent run don't match the addresses from the initial run.

The failure manifests in the 'maint info blocks' output comparisons, where the expected addresses (from the first run) don't match the actual addresses in the test runs.

The simplest fix, following Simon's approach, is to use "nopie" when building the binaries.  This doesn't affect the effectiveness of the test, which is exercising different ways DW_AT_entry_pc can be expressed in DWARF.

Also, with a non-PIE executable, it is no longer necessary to run the inferior before grabbing the addresses in the initial run, as they are stable.  So remove that runto_main call.

[1] https://inbox.sourceware.org/gdb-patches/20260205204257.422150-1-simon.marchi@efficios.com/

Approved-By: Simon Marchi <simon.marchi@efficios.com>
(cherry picked from commit c0f7609cd19ca79c34a1b68550ceb79ff8189775) Change-Id: Id041ff336609cb23ef7a0f378397c9a5566967b2
