### PR TITLE
Use a fixed manylinux container SHA

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64:latest
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858 # 2026-02-12T04:27:43.622Z
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}


### PR DESCRIPTION
Use of the latest image has proven to be unreliable at the moment. For now switch to using a fixed SHA that we manually update.

(cherry picked from commit 3de63a83bdc458463bef1f97056b8b8d1112c740)