### PR TITLE
[amd-staging-rocgdb-16] Bump TheRock SHA to 00439e98624e206a06effc64d0c717a86f62cbb6

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 65a2a9cd5895a9cdb2a1352767377f35e70254d1 # 14/04/2026
+  THEROCK_COMMIT_REF: 00439e98624e206a06effc64d0c717a86f62cbb6 # 16/04/2026
 
 jobs:
   therock-build-linux:

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 65a2a9cd5895a9cdb2a1352767377f35e70254d1 # 14/04/2026
+  THEROCK_COMMIT_REF: 00439e98624e206a06effc64d0c717a86f62cbb6 # 16/04/2026
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
   THEROCK_BIN_DIR: "./build/bin"


### PR DESCRIPTION
Picks up dbgapi version update for CI.

(cherry picked from commit 3d7559f73254ae9d47f3db032c679c9b39ecbe26)