### PR TITLE
lib/rocm.exp: rework compiler_dwarf_language{}

### DIFF
--- a/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
@@ -89,17 +89,7 @@ with_rocm_gpu_lock {
     }
 
     with_test_prefix "before running program" {
-	if {$dw_lang == "hip"} {
-	    # Check if the language is HIP.  This guarantees that the
-	    # conditions of (pending) breakpoints in the device code
-	    # will be parsed and evaluated in HIP context.
-	    gdb_test "show language" \
-		"The current source language is \"auto; currently hip\"\." \
-		"HIP as the auto language on the host side"
-	} elseif {$dw_lang == "cpp"} {
-	    gdb_test "show language" \
-		"The current source language is \"auto; currently c\\+\\+\"\." \
-		"C++ as the auto language on the host side"
+	if {$dw_lang == "cpp"} {
 	    no_hip_completions
 
 	    # Set the language to HIP.  This guarantees that the

--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
@@ -177,18 +177,7 @@ with_rocm_gpu_lock {
     }
 
     with_test_prefix "before running program" {
-	if {$dw_lang == "hip"} {
-	    # Check if the language is HIP.  This guarantees that the
-	    # conditions of (pending) breakpoints in the device code
-	    # will be parsed and evaluated in HIP context.
-	    gdb_test "show language" \
-		"The current source language is \"auto; currently hip\"\." \
-		"HIP as the auto language on the host side"
-
-	} elseif {$dw_lang == "cpp"} {
-	    gdb_test "show language" \
-		"The current source language is \"auto; currently c\\+\\+\"\." \
-		"C++ as the auto language on the host side"
+	if {$dw_lang == "cpp"} {
 	    check_builtin_variables_notfound
 
 	    # Set the language to HIP.  This guarantees that the

--- a/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
+++ b/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Verify that GDB detects the HIP program language correctly based
+# on what the compiler has emitted as the DW_LANG attribute.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+
+standard_testfile hip-builtin-variables.cpp
+
+if {[prepare_for_testing "failed to prepare ${testfile}" \
+	$testfile $srcfile {debug hip}]} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return -1
+    }
+
+    set dw_lang [compiler_dwarf_language]
+    set test "expected compiler language"
+    if {$dw_lang == "hip"} {
+	set expected_re "hip"
+    } elseif {$dw_lang == "cpp"} {
+	set expected_re "c\\+\\+"
+    } else {
+	fail "$test (found \"$dw_lang\")"
+	return
+    }
+    pass $test
+
+    gdb_test "show language" \
+	"The current source language is \"auto; currently $expected_re\"\." \
+	"expected gdb language"
+}

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -568,54 +568,68 @@ proc enable_alu_exception {excp_name} {
 	"= .*$excp_name.*"
 }
 
+# Try to find llvm-dwardump first in the PATH, then in
+# (assumed) ROCM_PATH.  If not found, return empty string.
+
+gdb_caching_proc find_dwarfdump {} {
+    global rocm_path
+    foreach ddump [list "llvm-dwarfdump" \
+			"${rocm_path}/lib/llvm/bin/llvm-dwarfdump" ] {
+	set res [catch {exec $ddump --version} output]
+	if {$res == 0} {
+	    return $ddump
+	  }
+    }
+    return ""
+}
+
 # Read the DW_AT_language of the output binary and return:
 #
-#   "hip"       -- if DW_LANG_HIP   (48, 0x30)
-#   "cpp"       -- if DW_LANG_C++14 (33, 0x21)
-#   "unknown"   -- otherwise
+#   "hip"       -- if DW_LANG_HIP (48, 0x30)
+#   "cpp"       -- if DW_LANG_C_plus_plus_14 (33, 0x21)
+#   "others"    -- if other languages
+#   "unknown"   -- in case of failure
 
-proc compiler_dwarf_language {} {
-    # Use objdump because
-    #
-    # 1. readelf cannot process non-elf binaries such as PE/COFF.
-    # 2. If warnings are emitted, objdump still returns 0, unlike readelf.
-    #
-    # In "objdump ... | grep ..." command, if there's any text printed to
-    # stderr by "objdump", DejaGnu will add them to the final "output".
-    # Moreover, DejaGnu will set the "result" to "1" if it finds anything
-    # is printed to stderr.  Therefore warnings [1], if any, must be
-    # redirected from stderr to stdout.  This redirection also has the
-    # benefit of keeping "output" clean from any unwanted patterns in it
-    # because "grep" will filter them out.  If "objdump" encounters an
-    # error and returns a non-zero result, then that will be reflected in
-    # "result" by holding value "1".
-    #
-    # [1] an example of such warnings
-    # Warning: Unrecognized form: 0x23
-    set objdump_program [gdb_find_objdump]
-    set bin [standard_output_file $::binfile]
-    set cmd [list $objdump_program -Wi $bin 2>&1 | grep "DW_AT_language.*:"]
+gdb_caching_proc compiler_dwarf_language {} {
+    if {![gdb_simple_compile check_my_lang {
+	    int foo (void) { return 42; }
+	  } object {hip}]} {
+	fail "language detection (compiling a sample program)"
+	return "unknown"
+    }
+
+    set dwarfdump [find_dwarfdump]
+    if {$dwarfdump == ""} {
+	fail "language detection (dwarfdump not found)"
+	return "unknown"
+    }
+
+    set cmd [list $dwarfdump $obj |& grep "DW_AT_language"]
     set res [catch {exec {*}$cmd} output]
     verbose -log "running: $cmd"
     verbose -log "result: $res"
     verbose -log "output: $output"
-
     if {$res != 0} {
-	fail "language detection (objdump execution)"
+	fail "language detection (dwarfdump execution)"
 	return "unknown"
     }
 
-    set matches [regexp -inline "DW_AT_language\[ \t\]*:\[ \t\]*($::decimal)\[ \t\]*" $output]
+    set matches [regexp -inline -all \
+		   "DW_AT_language\[ \t\]*\\((DW_LANG_.*)\\)" \
+		   $output]
+    # There must be only one instance (1 line found + 1 match group -> 2)
+    if {[llength $matches] != 2} {
+	fail "language detection (extracting language)"
+	return "unknown"
+    }
     set lang [lindex $matches 1]
+    verbose -log "language: $lang"
 
-    # "48" (decimal) represents "HIP".
-    # "33" (decimal) represents "C++14".
-    if {$lang == 48} {
+    if {$lang == "DW_LANG_HIP"} {
 	return "hip"
-    } elseif {$lang == 33} {
+    } elseif {$lang == "DW_LANG_C_plus_plus_14"} {
 	return "cpp"
     } else {
-	fail "language detection (unknown language)"
-	return "unknown"
+	return "others"
     }
 }


### PR DESCRIPTION
```
This change introduces a few alterations to the
"compiler_dwarf_language{}" procedure in rocm.exp:

1. "llvm-dwarfdump" is used instead of "objdump", because
that's the dump tool officially delivered by our releases.

2. Since looking at a fully-linked test binary may result
in multiple CUs, each with their own language, we switch
to an object file compiled from a simple function, as a
reference, to capture the compiler behaviour (if it emits
C++ or HIP as the DWARF language when compiling).

3. Now that we use the same input (a simple function),
make it a cached procedure.

-------------------------------------------------------------------

Also, add a new test: hip-lang-detect. As a result, two other
hip-builtin-* tests become a tad simpler.
```