### PR TITLE
gdb: Remove unnecessary defs.h includes in downstream rocgdb

### DIFF
--- a/gdb/gdb-hip-test-mode.c
+++ b/gdb/gdb-hip-test-mode.c
@@ -24,7 +24,6 @@
    code and provide the illusion that the kernel/device's main is
    really called main.  */
 
-#include "defs.h"
 #include "gdb-hip-test-mode.h"
 #include "objfiles.h"
 

--- a/gdb/local-fileio-target.c
+++ b/gdb/local-fileio-target.c
@@ -18,7 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#include "defs.h"
 #include "local-fileio-target.h"
 #include "gdbsupport/fileio.h"
 #include "gdbsupport/filestuff.h"


### PR DESCRIPTION
Since the following commit, it is not necessary to include defs.h anyore

    commit 18d2988e5da8919514c76b83e2c0b56e439018bd
    Date:   Tue Mar 26 15:06:46 2024 -0400

        gdb, gdbserver, gdbsupport: remove includes of early headers

This commit made sure to include defs.h via a "-include" flag, and we never did the cleanup on the downstream branch.  An upstream patch (eb221802ed0 [gdb] Remove unnecessary defs.h/common-defs.h includes) will make including defs.h an error, so this patch cleans things up to avoid build breakage when we will pull this change from upstream.

Change-Id: I3cbc9260f95816e5dc4587b92f42cf2ca4dd1504