### PR TITLE
[amd-temp-windows] Cherry-pick changes to use dbgapi-0.80.0

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1660,7 +1660,7 @@ amdgpu_address_spaces (struct gdbarch *gdbarch)
 }
 
 static location_scope
-amdgpu_address_scope (struct gdbarch *gdbarch, CORE_ADDR address)
+amdgpu_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
 {
   amd_dbgapi_segment_address_dependency_t segment_address_dependency;
 
@@ -1683,10 +1683,28 @@ amdgpu_address_scope (struct gdbarch *gdbarch, CORE_ADDR address)
       != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_dwarf_address_space_to_address_space failed"));
 
-  if (amd_dbgapi_address_dependency (address_space_id,
-				     segment_address,
-				     &segment_address_dependency)
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  amd_dbgapi_status_t ret;
+#if AMD_DBGAPI_VERSION_MAJOR > 0 || AMD_DBGAPI_VERSION_MINOR >= 79
+  /* Access to GPU globals can be made from host threads.  When we place a
+     watchpoint on such global GPU variable, a matching watchpoint is also
+     added on the CPU side for the same address, so it is possible to call here
+     with a ptid that belongs to a non-GPU thread.  */
+  const amd_dbgapi_wave_id_t wave_id = (ptid_is_gpu (ptid)
+					? get_amd_dbgapi_wave_id (ptid)
+					: AMD_DBGAPI_WAVE_NONE);
+
+  amd_dbgapi_process_id_t process_id
+    = get_amd_dbgapi_process_id (current_inferior ());
+
+  ret = amd_dbgapi_address_dependency (process_id, wave_id,
+				       address_space_id, segment_address,
+				       &segment_address_dependency);
+#else
+  ret = amd_dbgapi_address_dependency (address_space_id,
+				       segment_address,
+				       &segment_address_dependency);
+#endif
+  if (ret != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_address_dependency failed"));
 
   switch (segment_address_dependency)

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -30,40 +30,68 @@
 #include "gdbtypes.h"
 #include "inferior.h"
 #include "language.h"
+#include "observable.h"
 #include "producer.h"
 #include "reggroups.h"
 #include "extract-store-integer.h"
+#include <optional>
 
+struct amdgpu_per_inferior
+{
+  amdgpu_per_inferior ()
+    : significant_bits {}
+  {}
 
-/* Bit mask of the address space information in the core address.
-   This uses bits 56, 57, 58, 59, 62 and 63.  This pattern is meant to avoid
-   conflicts with common AMDGPU configurations on both Linux and Windows.
+  std::optional<amd_dbgapi_segment_address_t> significant_bits = {};
+};
 
-   On Windows, bits 60 and 61 are used to mark the base of the local and
-   private apertures in generic.  On Linux, bits 48 and 49 are used for that
-   purpose:
-	      +-------------------------+------------------------+
-	      |  Local aperture range   | Private aperture range |
-    +---------+-------------------------+------------------------+
-    | Windows |  0x2000'0000'0000'0000  | 0x1000'0000'0000'0000  |
-    |         |  0x2000'0000'ffff'ffff  | 0x1000'0000'ffff'ffff  |
-    +---------+-------------------------+------------------------+
-    | Linux   |  0x0001'0000'0000'0000  | 0x0002'0000'0000'0000  |
-    |         |  0x0001'0000'ffff'ffff  | 0x0002'0000'ffff'ffff  |
-    +---------+-------------------------+------------------------+  */
-constexpr CORE_ADDR AMDGPU_ADDRESS_SPACE_MASK = 0xcf00000000000000;
+static const registry<inferior>::key<amdgpu_per_inferior> amdgpu_per_inf;
 
-/* There are 6 bits available to encode address spaces, making possible
-   values range from 0 to 63.  */
-constexpr arch_addr_space_id AMDGPU_MAX_ASPACE_ID = 63;
+static void
+amdgpu_observer_inferior_appeared (inferior *inf)
+{
+  /* Invalidate the cached data by clearing it.  */
+  amdgpu_per_inf.clear(inf);
+}
 
-constexpr size_t AMDGPU_ADDRESS_SPACE_1_BIT_OFFSET = 56;
-constexpr CORE_ADDR AMDGPU_ADDRESS_SPACE_MASK_1 = 0xf00000000000000;
-constexpr size_t AMDGPU_ADDRESS_SPACE_2_BIT_OFFSET = 58;
-constexpr CORE_ADDR AMDGPU_ADDRESS_SPACE_MASK_2 = 0xc000000000000000;
+static amdgpu_per_inferior &
+get_amdgpu_per_inferior (inferior *inf)
+{
+  amdgpu_per_inferior *data;
 
-static_assert (AMDGPU_ADDRESS_SPACE_MASK
-	       == (AMDGPU_ADDRESS_SPACE_MASK_1 | AMDGPU_ADDRESS_SPACE_MASK_2));
+  data = amdgpu_per_inf.get (inf);
+  if (data == nullptr)
+    data = amdgpu_per_inf.emplace (inf);
+
+  return *data;
+}
+
+/* Return a bit-mask showing which bits of a segment address are significant
+   for at least one address space in at least one agent.  Any bits outside
+   this mask can be modified by GDB and cleared before sending the address to
+   dbgapi without affecting the address value.  */
+
+static amd_dbgapi_segment_address_t
+amdgpu_get_segment_address_significant_bits (inferior *inf)
+{
+  amdgpu_per_inferior &per_inf = get_amdgpu_per_inferior (inf);
+
+  if (!per_inf.significant_bits.has_value ())
+    {
+      amd_dbgapi_process_id_t process_id = get_amd_dbgapi_process_id (inf);
+
+      amd_dbgapi_segment_address_t sb;
+      if (amd_dbgapi_process_get_info
+	  (process_id, AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS,
+	   sizeof (sb), &sb)
+	  != AMD_DBGAPI_STATUS_SUCCESS)
+	error (_("amd_dbgapi_process_get_info failed"));
+
+      per_inf.significant_bits = sb;
+    }
+
+  return *per_inf.significant_bits;
+}
 
 /* Return true if INFO is of an AMDGPU architecture.  */
 
@@ -1460,20 +1488,37 @@ static CORE_ADDR
 amdgpu_segment_address_to_core_address (arch_addr_space_id address_space_id,
 					CORE_ADDR address)
 {
-  gdb_assert (address_space_id <= AMDGPU_MAX_ASPACE_ID);
-  return ((address & ~AMDGPU_ADDRESS_SPACE_MASK)
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
 
-	  /* ret[59:56] := aspace[3:0]  */
-	 | (((CORE_ADDR) address_space_id
-	     & (AMDGPU_ADDRESS_SPACE_MASK_1
-		>> AMDGPU_ADDRESS_SPACE_1_BIT_OFFSET))
-	    << AMDGPU_ADDRESS_SPACE_1_BIT_OFFSET)
+  /* The address must not have bits set outside of the significant bits.  */
+  gdb_assert ((significant_bits & address) == address);
 
-	  /* ret[63:62] := aspace[5:4]  */
-	 | (((CORE_ADDR) address_space_id
-	     & (AMDGPU_ADDRESS_SPACE_MASK_2
-		>> AMDGPU_ADDRESS_SPACE_2_BIT_OFFSET))
-	    << AMDGPU_ADDRESS_SPACE_2_BIT_OFFSET));
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  uint64_t id = address_space_id;
+  uint64_t mask = aspace_id_mask;
+  while (id != 0)
+    {
+      /* Isolate the lowest set bit in the mask.  */
+      uint64_t lowbit = mask & ~(mask - 1);
+
+      if (id & 1)
+	address |= lowbit;
+
+      mask ^= lowbit; /* Clear bit from mask.  */
+      id >>= 1;	      /* Move on to the next bit in ID.  */
+
+      /* As long as there's ID bits, there should be some MASK bits too.  */
+      gdb_assert (!(mask == 0 && id != 0));
+    }
+
+  /* If all the bits are set, then this could collide with the
+     sign extension of the address.  */
+  if ((address & aspace_id_mask) == aspace_id_mask)
+    error (_("Address-space ID overflow"));
+
+  return address;
 }
 
 /* Convert an integer to an address of a given segment address.  */
@@ -1482,7 +1527,6 @@ amdgpu_integer_to_address (struct gdbarch *gdbarch,
 			   struct type *type, const gdb_byte *buf,
 			   arch_addr_space_id address_space_id)
 {
-  gdb_assert (address_space_id <= AMDGPU_MAX_ASPACE_ID);
   return amdgpu_segment_address_to_core_address (address_space_id,
 						 unpack_long (type, buf));
 }
@@ -1492,11 +1536,36 @@ amdgpu_integer_to_address (struct gdbarch *gdbarch,
 arch_addr_space_id
 amdgpu_address_space_id_from_core_address (CORE_ADDR addr)
 {
-  /* ret = 0b0, addr[63:62], addr[59:56]  */
-  return (((addr & AMDGPU_ADDRESS_SPACE_MASK_1)
-	   >> AMDGPU_ADDRESS_SPACE_1_BIT_OFFSET)
-	  | ((addr & AMDGPU_ADDRESS_SPACE_MASK_2)
-	     >> (AMDGPU_ADDRESS_SPACE_2_BIT_OFFSET)));
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  /* Shortcut for aspace 0 (global).  */
+  if ((addr & aspace_id_mask) == 0)
+    return 0;
+
+  /* The all 1s address space is not valid, so 0.  */
+  if ((addr & aspace_id_mask) == aspace_id_mask)
+    return 0;
+
+  arch_addr_space_id aspace_id = 0;
+  uint64_t mask = aspace_id_mask;
+  uint64_t set_bit = 1;    /* A set bit in the lowest position.  */
+  while (mask != 0)
+    {
+      /* Isolate the lowest set bit in the mask.  */
+      uint64_t lowbit = mask & ~(mask - 1);
+
+      if (addr & lowbit)
+	aspace_id |= set_bit;
+
+      /* Move on to the next bit position.  */
+      set_bit <<= 1;
+      /* Clear bit from mask.  */
+      mask ^= lowbit;
+    }
+
+  return aspace_id;
 }
 
 /* See amdgpu-tdep.h.  */
@@ -1504,7 +1573,16 @@ amdgpu_address_space_id_from_core_address (CORE_ADDR addr)
 CORE_ADDR
 amdgpu_segment_address_from_core_address (CORE_ADDR addr)
 {
-  return addr & ~AMDGPU_ADDRESS_SPACE_MASK;
+  const amd_dbgapi_segment_address_t significant_bits
+    = amdgpu_get_segment_address_significant_bits (current_inferior ());
+  const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  /* The all-1s address-space is not valid, this must be the original
+     address.  */
+  if ((addr & aspace_id_mask) == aspace_id_mask)
+    return addr;
+
+  return addr & significant_bits;
 }
 
 /* Address class to address space mapping.
@@ -2335,53 +2413,16 @@ amdgpu_register_type_parse_test ()
   }
 }
 
-static void
-amdgpu_aspace_encoding_test ()
-{
-  std::vector<CORE_ADDR> addresses {
-    0x1000'0000'0000'0000, /* private_base on Windows.  */
-    0x1000'0000'ffff'ffff, /* Maximum address in the private aperture on
-			      Windows.  */
-    0x2000'0000'0000'0000, /* local_base on Windows.  */
-    0x2000'0000'ffff'ffff, /* Maximum address in the local aperture on
-			      Windows.  */
-    0x0001'0000'0000'0000, /* local_base on Linux.  */
-    0x0001'0000'ffff'ffff, /* Maximum address in the private aperture on
-			      Linux.  */
-    0x0002'0000'0000'0000, /* private_base on Linux.  */
-    0x0002'0000'ffff'ffff, /* Maximum address int the local aperture on
-			      Linux.  */
-    0x0000'7fff'ffff'ffff, /* Maximum userspace address on Windows.  */
-    0x00ff'ffff'ffff'ffff  /* Maximum userspace address on Linux when using 5
-			      level page tables.  */
-  };
-
-  for (CORE_ADDR aspace = 0; aspace < AMDGPU_MAX_ASPACE_ID; aspace++)
-    {
-      for (auto addr: addresses)
-	{
-	  /* The selected ADDRESS_SPACE_MASK must not collide with any
-	     possible address.  */
-	  gdb_assert (addr == (addr & ~AMDGPU_ADDRESS_SPACE_MASK));
-
-	  auto enc = amdgpu_segment_address_to_core_address (aspace, addr);
-	  gdb_assert (aspace
-		      == amdgpu_address_space_id_from_core_address (enc));
-	  gdb_assert (addr == amdgpu_segment_address_from_core_address (enc));
-	}
-    }
-}
-
 #endif
 
 INIT_GDB_FILE (amdgpu_tdep)
 {
   gdbarch_register (bfd_arch_amdgcn, amdgpu_gdbarch_init, NULL,
 		    amdgpu_supports_arch_info);
+  gdb::observers::inferior_appeared.attach (amdgpu_observer_inferior_appeared,
+					    "amdgpu_tdep");
 #if defined GDB_SELF_TEST
   selftests::register_test ("amdgpu-register-type-parse-flags-fields",
 			    amdgpu_register_type_parse_test);
-  selftests::register_test ("amdgpu-aspace-encoding-test",
-			    amdgpu_aspace_encoding_test);
 #endif
 }

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1165,7 +1165,7 @@ default_dwarf_address_space_to_address_space_id (LONGEST dwarf_addr_space)
 
 /* See arch-utils.h.  */
 location_scope
-default_address_scope (struct gdbarch *gdbarch, CORE_ADDR address)
+default_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
 {
   return LOCATION_SCOPE_INFERIOR;
 }

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -448,7 +448,7 @@ extern CORE_ADDR default_segment_address_to_core_address
 
 /* Return the address's scope.  */
 extern location_scope default_address_scope (struct gdbarch *gdbarch,
-					     CORE_ADDR address);
+					     ptid_t ptid, CORE_ADDR address);
 
 extern int default_supported_lanes_count (struct gdbarch *gdbarch,
 					  thread_info *tp);

--- a/gdb/breakpoint.c
+++ b/gdb/breakpoint.c
@@ -10668,7 +10668,8 @@ watch_command_1 (const char *arg, int accessflag, int from_tty,
       value_free_to_mark (mark);
 
       CORE_ADDR addr = value_as_address (val.get ());
-      scope = gdbarch_address_scope (val->type ()->arch (), addr);
+      scope = gdbarch_address_scope (val->type ()->arch (), inferior_ptid,
+				     addr);
 
       if (use_mask)
 	{
@@ -10692,7 +10693,7 @@ watch_command_1 (const char *arg, int accessflag, int from_tty,
 	     and so it needs to be reconfirmed now.  */
 	  if (iter->lval () == lval_memory)
 	    scope |= gdbarch_address_scope (iter->type ()->arch (),
-					    iter->address ());
+					    inferior_ptid, iter->address ());
 	  scope |= iter->scope ();
 	}
 

--- a/gdb/c-lang.c
+++ b/gdb/c-lang.c
@@ -38,6 +38,7 @@
 #include "gdbarch.h"
 #include "c-exp.h"
 #include "arch-utils.h"
+#include "inferior.h"
 
 /* Given a C string type, STR_TYPE, return the corresponding target
    character set name.  */
@@ -711,7 +712,8 @@ value *aspace_operation::evaluate (struct type *expect_type,
     lookup_pointer_type (builtin_type (exp->gdbarch)->builtin_void);
 
   val = value_from_pointer (generic_ptr_type, adddress);
-  val->set_scope (gdbarch_address_scope (exp->gdbarch, adddress));
+  val->set_scope (gdbarch_address_scope (exp->gdbarch, inferior_ptid,
+					 adddress));
   return val;
 }
 

--- a/gdb/configure
+++ b/gdb/configure
@@ -25375,19 +25375,19 @@ if test "$gdb_require_amd_dbgapi" = true \
   # version of the library.
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for amd-dbgapi >= 0.77.0" >&5
-$as_echo_n "checking for amd-dbgapi >= 0.77.0... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for amd-dbgapi >= 0.80.0" >&5
+$as_echo_n "checking for amd-dbgapi >= 0.80.0... " >&6; }
 
 if test -n "$AMD_DBGAPI_CFLAGS"; then
     pkg_cv_AMD_DBGAPI_CFLAGS="$AMD_DBGAPI_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.77.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.77.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.80.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.80.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_AMD_DBGAPI_CFLAGS=`$PKG_CONFIG --cflags "amd-dbgapi >= 0.77.0" 2>/dev/null`
+  pkg_cv_AMD_DBGAPI_CFLAGS=`$PKG_CONFIG --cflags "amd-dbgapi >= 0.80.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -25399,12 +25399,12 @@ if test -n "$AMD_DBGAPI_LIBS"; then
     pkg_cv_AMD_DBGAPI_LIBS="$AMD_DBGAPI_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.77.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.77.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"amd-dbgapi >= 0.80.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "amd-dbgapi >= 0.80.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_AMD_DBGAPI_LIBS=`$PKG_CONFIG --libs "amd-dbgapi >= 0.77.0" 2>/dev/null`
+  pkg_cv_AMD_DBGAPI_LIBS=`$PKG_CONFIG --libs "amd-dbgapi >= 0.80.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -25449,9 +25449,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "amd-dbgapi >= 0.77.0" 2>&1`
+	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "amd-dbgapi >= 0.80.0" 2>&1`
         else
-	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "amd-dbgapi >= 0.77.0" 2>&1`
+	        AMD_DBGAPI_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "amd-dbgapi >= 0.80.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$AMD_DBGAPI_PKG_ERRORS" >&5

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -341,7 +341,7 @@ if test "$gdb_require_amd_dbgapi" = true \
   # stability until amd-dbgapi hits 1.0, but for convenience, still check for
   # greater or equal that version.  It can be handy when testing with a newer
   # version of the library.
-  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.77.0],
+  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.80.0],
 		    [has_amd_dbgapi=yes], [has_amd_dbgapi=no])
 
   if test "$has_amd_dbgapi" = "yes"; then

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -3538,7 +3538,8 @@ dwarf_expr_context::execute_llvm_stack_op (dwarf_llvm_user op,
 	  address
 	    = gdbarch_segment_address_to_core_address (arch, address_space,
 						       address);
-	  location_scope scope = gdbarch_address_scope (arch, address);
+	  location_scope scope
+	    = gdbarch_address_scope (arch, inferior_ptid, address);
 
 	  if (scope_matches (scope, LOCATION_SCOPE_LANE))
 	    {
@@ -3692,7 +3693,8 @@ dwarf_expr_context::execute_llvm_stack_op (dwarf_llvm_user op,
 	  CORE_ADDR address
 	    = gdbarch_segment_address_to_core_address
 		(arch, address_space, address_value->to_long ());
-	  location_scope scope = gdbarch_address_scope (arch, address);
+	  location_scope scope
+	    = gdbarch_address_scope (arch, inferior_ptid, address);
 
 	  /* Only need to check if there is a SIMD lane in focus,
 	     previous check ensured that there is a frame so there

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -2896,13 +2896,13 @@ set_gdbarch_dwarf_address_space_to_address_space_id (struct gdbarch *gdbarch,
 }
 
 location_scope
-gdbarch_address_scope (struct gdbarch *gdbarch, CORE_ADDR address)
+gdbarch_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address)
 {
   gdb_assert (gdbarch != NULL);
   gdb_assert (gdbarch->address_scope != NULL);
   if (gdbarch_debug >= 2)
     gdb_printf (gdb_stdlog, "gdbarch_address_scope called\n");
-  return gdbarch->address_scope (gdbarch, address);
+  return gdbarch->address_scope (gdbarch, ptid, address);
 }
 
 void

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -515,8 +515,8 @@ extern void set_gdbarch_dwarf_address_space_to_address_space_id (struct gdbarch 
 
 /* Return the address's scope. */
 
-typedef location_scope (gdbarch_address_scope_ftype) (struct gdbarch *gdbarch, CORE_ADDR address);
-extern location_scope gdbarch_address_scope (struct gdbarch *gdbarch, CORE_ADDR address);
+typedef location_scope (gdbarch_address_scope_ftype) (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address);
+extern location_scope gdbarch_address_scope (struct gdbarch *gdbarch, ptid_t ptid, CORE_ADDR address);
 extern void set_gdbarch_address_scope (struct gdbarch *gdbarch, gdbarch_address_scope_ftype *address_scope);
 
 /* Return preferred watchpoint locations for the given to-be-watched

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -975,7 +975,7 @@ Return the address's scope.
 """,
     type="location_scope",
     name="address_scope",
-    params=[("CORE_ADDR", "address")],
+    params=[("ptid_t", "ptid"), ("CORE_ADDR", "address")],
     postdefault="default_address_scope",
     invalid=False,
 )

--- a/gdb/mi/mi-interp.c
+++ b/gdb/mi/mi-interp.c
@@ -820,7 +820,7 @@ mi_interp::on_memory_changed (CORE_ADDR memaddr, ssize_t len,
     return;
 
   location_scope scope
-    = gdbarch_address_scope (get_current_arch (), memaddr);
+    = gdbarch_address_scope (get_current_arch (), inferior_ptid, memaddr);
 
   ui_out *mi_uiout = this->interp_ui_out ();
 

--- a/gdb/testsuite/gdb.rocm/mi-aspace.exp
+++ b/gdb/testsuite/gdb.rocm/mi-aspace.exp
@@ -177,9 +177,9 @@ proc_with_prefix test_mi_data_read_memory {} {
 	     "nr-bytes=\"1\"," \
 	     "total-bytes=\"1\"," \
 	     "next-row=\"private_lane#0x0000000000000001\"," \
-	     "prev-row=\"0x00ffffffffffffff\"," \
+	     "prev-row=\"${::hex}\"," \
 	     "next-page=\"private_lane#0x0000000000000001\"," \
-	     "prev-page=\"0x00ffffffffffffff\"," \
+	     "prev-page=\"${::hex}\"," \
 	     "memory=\\\[\\\{addr=\"private_lane#0x0000000000000000\",data=\\\[\"$hex\"\\\]\\\}\\\]"]
 }
 

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
@@ -1,0 +1,41 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2025-2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <hip/hip_runtime.h>
+
+__device__ int global = 0;
+
+__global__ void
+kern ()
+{
+}
+
+int
+main (int argc, char* argv[])
+{
+  kern<<<1, 1>>> ();
+  if (hipDeviceSynchronize () != hipSuccess)
+    return 1;
+
+  int *devGlobal;
+  if (hipGetSymbolAddress (reinterpret_cast<void **> (&devGlobal), global))
+    return 2;
+
+  /* Now update the device global from a CPU thread.  */
+  *devGlobal = 8;
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Example where we place a watchpoint on a GPU global (from a GPU context),
+# and later reach CPU code that triggers it by modifying that global value.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+
+standard_testfile .cpp
+
+if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+proc do_test {} {
+    clean_restart
+    gdb_load $::binfile
+
+    with_rocm_gpu_lock {
+	if {![runto_main]} {
+	    return
+	}
+
+	gdb_test "with breakpoint pending on -- break kern" \
+	    "Breakpoint $::decimal \\(kern\\) pending."
+
+	gdb_test "continue" \
+	    "Thread $::decimal \"kern\" hit Breakpoint $::decimal, with lane 0, kern .*"
+
+	gdb_test "watch global" "Hardware watchpoint $::decimal: global"
+
+	gdb_test "continue" \
+	    "Hardware watchpoint $::decimal: global.*Old value = 0\r\nNew value = 8\r\nmain.*" \
+	    "hit watchpoint in main"
+    }
+}
+
+do_test
+


### PR DESCRIPTION
Cherry-pick the following patches:

- c388bfa797d gdb/amdgcn: Dynamically select which bits to use to hold CORE_ADDR
- bee0a5144c8 gdb/amdgpu-tdep: Add process_id and wave_id args to address_dependency