### PR TITLE
Update In Memoriam text of ROCgdb

### DIFF
--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -44393,20 +44393,20 @@ things without first using the debugger to find the facts.
 @node In Memoriam
 @appendix In Memoriam
 
-The @value{GDBN} project mourns the loss of the following long-time
+The @sc{gdb} project mourns the loss of the following long-time
 contributors:
 
 @table @code
 @item Fred Fish
-Fred was a long-standing contributor to @value{GDBN} (1991-2006), and
-to Free Software in general.  Outside of @value{GDBN}, he was known in
+Fred was a long-standing contributor to @sc{gdb} (1991-2006), and
+to Free Software in general.  Outside of @sc{gdb}, he was known in
 the Amiga world for his series of Fish Disks, and the GeekGadget project.
 
 @item Michael Snyder
-Michael was one of the Global Maintainers of the @value{GDBN} project,
+Michael was one of the Global Maintainers of the @sc{gdb} project,
 with contributions recorded as early as 1996, until 2011.  In addition
 to his day to day participation, he was a large driving force behind
-adding Reverse Debugging to @value{GDBN}.
+adding Reverse Debugging to @sc{gdb}.
 @end table
 
 Beyond their technical contributions to the project, they were also


### PR DESCRIPTION
## Motivation

The “In Memoriam” section incorrectly includes a mention of the ROCgdb project, which was flagged by technical writers.

## Technical Details

In the “In Memoriam” section, “GDB” should be hardcoded, as shown in the following commit:
https://github.com/ROCm/ROCgdb/commit/a4add9e5975a696ad729235202354a18b487c3ae

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
