### PR TITLE
[workflows] Add support for extended tests via a label

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -6,6 +6,7 @@ on:
       - amd-staging
       - amd-staging-rocgdb-*
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - amd-staging
       - amd-staging-rocgdb-*
@@ -60,12 +61,97 @@ jobs:
         -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
         -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
 
+  extended-test-check-read1:
+    name: "--check-type check-read1"
+    if: (success() || failure()) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing:extended')
+    needs: extended-test-optimization
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
+    with:
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
+      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-read1 --parallel"
+
+  extended-test-check-readmore:
+    name: "--check-type check-readmore"
+    if: (success() || failure()) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing:extended')
+    needs: extended-test-check-read1
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
+    with:
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
+      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-readmore --parallel"
+
+  extended-test-parallel:
+    name: "--parallel"
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing:extended')
+    needs: therock-ci-linux
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
+    with:
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
+      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--parallel"
+
+  extended-test-hip-board:
+    name: "hip board gdb.base/break.exp"
+    if: (success() || failure()) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing:extended')
+    needs: extended-test-check-readmore
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
+    with:
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
+      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--runtestflags=--target_board=hip --tests gdb.base/break.exp"
+
+  extended-test-optimization:
+    name: "--optimization=-O3"
+    if: (success() || failure()) && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing:extended')
+    needs: extended-test-parallel
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
+    with:
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
+      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--optimization=-O3 --max-failed-retries=0 --parallel"
+
   therock_ci_summary:
     name: TheRock CI Summary
     if: always()
     needs:
       - setup
       - therock-ci-linux
+      - extended-test-check-read1
+      - extended-test-check-readmore
+      - extended-test-parallel
+      - extended-test-hip-board
+      - extended-test-optimization
     runs-on: ubuntu-24.04
     steps:
       - name: Output failed jobs

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -11,6 +11,10 @@ on:
         type: string
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Options to pass to test_rocgdb.py (e.g., "--parallel", "--optimization", "--timeout")'
+        default: ''
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -21,6 +25,10 @@ on:
         type: string
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Options to pass to test_rocgdb.py (e.g., "--parallel", "--optimization", "--timeout")'
+        default: ''
 
 permissions:
   contents: read
@@ -67,5 +75,6 @@ jobs:
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: Run rocgdb tests
+        continue-on-error: ${{ inputs.continue_on_failure }}
         run: |
-          python build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+          python build_tools/github_actions/test_executable_scripts/test_rocgdb.py ${{ inputs.test_options }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -75,6 +75,5 @@ jobs:
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: Run rocgdb tests
-        continue-on-error: ${{ inputs.continue_on_failure }}
         run: |
           python build_tools/github_actions/test_executable_scripts/test_rocgdb.py ${{ inputs.test_options }}


### PR DESCRIPTION
[Add configurable test options to therock-test-packages workflow](https://github.com/ROCm/ROCgdb/commit/156f7eb4125c381d4497ad9c440e9f9ee4c0c36b) 

Make the test workflow a reusable template by adding test_options.

This allows running tests with different configurations (e.g., --parallel,
--optimization, --check-type) without creating separate workflow files.

[Add extended testing support with testing:extended label](https://github.com/ROCm/ROCgdb/commit/5517250d786a02b217dfa71d120c03692f352d82) 

Add support for triggering extended test suite when testing:extended label
is added to a PR. Five additional test jobs run serially after the standard
build, each with different test options: --parallel, --optimization=-O3,
--check-type check-read1, --check-type check-readmore, and a HIP board test
with --runtestflags=--target_board=hip --tests gdb.base/break.exp.

Extended test jobs use `if: success() || failure()` to ensure all tests run
even if one fails, while still showing which tests failed in the UI. This
provides complete test coverage on demand without slowing down the standard
CI pipeline.