### PR TITLE
gdb/amd-dbgapi: fix -Wdeprecated-enum-enum-conversion warning

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -4714,27 +4714,30 @@ info_dispatches_command (const char *args, int from_tty)
 	      error (_("amd_dbgapi_dispatch_get_info failed (%s)"),
 		     get_status_string (status));
 
-	    std::stringstream ss;
-	    if (barrier == AMD_DBGAPI_DISPATCH_BARRIER_PRESENT)
-	      ss << "B";
+	    std::string str;
 
-	    if (barrier && acquire)
-	      ss << "|";
+	    auto append_str = [&str] (const char *s)
+	      {
+		if (!str.empty ())
+		  str += "|";
+
+		str += s;
+	      };
+
+	    if (barrier == AMD_DBGAPI_DISPATCH_BARRIER_PRESENT)
+	      append_str ("B");
 
 	    if (acquire == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_AGENT)
-	      ss << "Aa";
+	      append_str ("Aa");
 	    else if (acquire == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_SYSTEM)
-	      ss << "As";
-
-	    if ((barrier | acquire) && release)
-	      ss << "|";
+	      append_str ("As");
 
 	    if (release == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_AGENT)
-	      ss << "Ra";
+	      append_str ("Ra");
 	    else if (release == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_SYSTEM)
-	      ss << "Rs";
+	      append_str ("Rs");
 
-	    uiout->field_string ("fence", ss.str ());
+	    uiout->field_string ("fence", str);
 
 	    if (opts.full || uiout->is_mi_like_p ())
 	      {


### PR DESCRIPTION
With gcc 16, I get:

    /home/smarchi/src/binutils-gdb/gdb/amd-dbgapi-target.c: In function ‘void info_dispatches_command(const char*, int)’:
    /home/smarchi/src/binutils-gdb/gdb/amd-dbgapi-target.c:4729:26: error: bitwise operation between different enumeration types ‘amd_dbgapi_dispatch_barrier_t’ and ‘amd_dbgapi_dispatch_fence_scope_t’ is deprecated [-Werror=deprecated-enum-enum-conversion]
     4729 |             if ((barrier | acquire) && release)
          |                  ~~~~~~~~^~~~~~~~~

IIUC, the intent of this is just to know if we've written something in `ss` already, and if we're going to write more.  And if so, write a `|` separator.  The `|` should probably have been a `||`, or because we like to be explicit in GDB:

    if ((barrier != AMD_DBGAPI_DISPATCH_BARRIER_NONE
         || acquire != AMD_DBGAPI_DISPATCH_FENCE_SCOPE_NONE)
        && release != AMD_DBGAPI_DISPATCH_FENCE_SCOPE_NONE)
      ss << "|";

But I think it's simpler to rewrite this to append to a string, and append a `|` if we're about to append something and the string is not empty.  A stringstream has no advantage over using a string in this case.

Change-Id: I48307186f00a9943f6be388960c85ce53d10b0c3

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
