### PR TITLE
[05-05-2026] Merge upstream/master into amd-staging

### DIFF
--- a/bfd/elf-bfd.h
+++ b/bfd/elf-bfd.h
@@ -2497,8 +2497,6 @@ extern long _bfd_elf_get_reloc_upper_bound
   (bfd *, sec_ptr) ATTRIBUTE_HIDDEN;
 extern long _bfd_elf_canonicalize_reloc
   (bfd *, sec_ptr, arelent **, asymbol **) ATTRIBUTE_HIDDEN;
-extern asection * _bfd_elf_get_dynamic_reloc_section
-  (bfd *, asection *, bool) ATTRIBUTE_HIDDEN;
 extern asection * _bfd_elf_make_dynamic_reloc_section
   (asection *, bfd *, unsigned int, bfd *, bool) ATTRIBUTE_HIDDEN;
 extern long _bfd_elf_get_dynamic_reloc_upper_bound

--- a/bfd/elf-m10300.c
+++ b/bfd/elf-m10300.c
@@ -1431,7 +1431,6 @@ mn10300_elf_final_link_relocate (reloc_howto_type *howto,
   dynobj = elf_hash_table (info)->dynobj;
   sgot   = NULL;
   splt   = NULL;
-  sreloc = NULL;
 
   switch (r_type)
     {
@@ -1531,13 +1530,9 @@ mn10300_elf_final_link_relocate (reloc_howto_type *howto,
 	  /* When generating a shared object, these relocations are
 	     copied into the output file to be resolved at run
 	     time.  */
+	  sreloc = elf_section_data (input_section)->sreloc;
 	  if (sreloc == NULL)
-	    {
-	      sreloc = _bfd_elf_get_dynamic_reloc_section
-		(input_bfd, input_section, /*rela?*/ true);
-	      if (sreloc == NULL)
-		return false;
-	    }
+	    return false;
 
 	  skip = false;
 

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -1812,9 +1812,7 @@ elf_arc_relocate_section (bfd *			  output_bfd,
 		bfd_byte *loc;
 		bool skip = false;
 		bool relocate = false;
-		asection *sreloc = _bfd_elf_get_dynamic_reloc_section
-				 (input_bfd, input_section,
-				  /*RELA*/ true);
+		asection *sreloc = elf_section_data (input_section)->sreloc;
 
 		BFD_ASSERT (sreloc != NULL);
 

--- a/bfd/elf32-arm.c
+++ b/bfd/elf32-arm.c
@@ -10211,7 +10211,7 @@ elf32_arm_final_link_relocate (reloc_howto_type *	    howto,
   bfd_vma *			local_tlsdesc_gotents;
   asection *			sgot;
   asection *			splt;
-  asection *			sreloc = NULL;
+  asection *			sreloc;
   asection *			srelgot;
   bfd_vma			addend;
   bfd_signed_vma		signed_addend;
@@ -10502,16 +10502,6 @@ elf32_arm_final_link_relocate (reloc_howto_type *	    howto,
 	    }
 
 	  *unresolved_reloc_p = false;
-
-	  if (sreloc == NULL && globals->root.dynamic_sections_created)
-	    {
-	      sreloc = _bfd_elf_get_dynamic_reloc_section (input_bfd, input_section,
-							   ! globals->use_rel);
-
-	      if (sreloc == NULL)
-		return bfd_reloc_notsupported;
-	    }
-
 	  skip = false;
 	  relocate = false;
 
@@ -10565,7 +10555,12 @@ elf32_arm_final_link_relocate (reloc_howto_type *	    howto,
 	  if (isrofixup)
 	    arm_elf_add_rofixup (output_bfd, globals->srofixup, outrel.r_offset);
 	  else
-	    elf32_arm_add_dynreloc (output_bfd, info, sreloc, &outrel);
+	    {
+	      sreloc = elf_section_data (input_section)->sreloc;
+	      if (sreloc == NULL)
+		return bfd_reloc_notsupported;
+	      elf32_arm_add_dynreloc (output_bfd, info, sreloc, &outrel);
+	    }
 
 	  /* If this reloc is against an external symbol, we do not want to
 	     fiddle with the addend.  Otherwise, we need to include the symbol

--- a/bfd/elf32-cris.c
+++ b/bfd/elf32-cris.c
@@ -1457,18 +1457,14 @@ cris_elf_relocate_section (bfd *output_bfd ATTRIBUTE_UNUSED,
 		 are copied into the output file to be resolved at run
 		 time.  */
 
+	      sreloc = elf_section_data (input_section)->sreloc;
+	      /* The section should have been created in cris_elf_check_relocs,
+		 but that function will not be called for objects which fail in
+		 cris_elf_merge_private_bfd_data.  */
 	      if (sreloc == NULL)
 		{
-		  sreloc = _bfd_elf_get_dynamic_reloc_section
-		    (dynobj, input_section, /*rela?*/ true);
-		  /* The section should have been created in cris_elf_check_relocs,
-		     but that function will not be called for objects which fail in
-		     cris_elf_merge_private_bfd_data.  */
-		  if (sreloc == NULL)
-		    {
-		      bfd_set_error (bfd_error_bad_value);
-		      return false;
-		    }
+		  bfd_set_error (bfd_error_bad_value);
+		  return false;
 		}
 
 	      skip = false;
@@ -3678,11 +3674,7 @@ elf_cris_discard_excess_dso_dynamics (struct elf_cris_link_hash_entry *h,
     {
       for (s = h->pcrel_relocs_copied; s != NULL; s = s->next)
 	{
-	  asection *sreloc
-	    = _bfd_elf_get_dynamic_reloc_section (elf_hash_table (info)
-						  ->dynobj,
-						  s->section,
-						  /*rela?*/ true);
+	  asection *sreloc = elf_section_data (s->section)->sreloc;
 	  sreloc->size -= s->count * sizeof (Elf32_External_Rela);
 	}
       return true;

--- a/bfd/elf32-m32r.c
+++ b/bfd/elf32-m32r.c
@@ -2237,7 +2237,6 @@ m32r_elf_relocate_section (bfd *output_bfd ATTRIBUTE_UNUSED,
 
   sgot = htab->sgot;
   splt = htab->splt;
-  sreloc = NULL;
 
   rel = relocs;
   relend = relocs + input_section->reloc_count;
@@ -2694,13 +2693,9 @@ m32r_elf_relocate_section (bfd *output_bfd ATTRIBUTE_UNUSED,
 		  /* When generating a shared object, these relocations
 		     are copied into the output file to be resolved at run
 		     time.  */
+		  sreloc = elf_section_data (input_section)->sreloc;
 		  if (sreloc == NULL)
-		    {
-		      sreloc = _bfd_elf_get_dynamic_reloc_section
-			(input_bfd, input_section, /*rela?*/ true);
-		      if (sreloc == NULL)
-			return false;
-		    }
+		    return false;
 
 		  skip = false;
 		  relocate = false;

--- a/bfd/elf32-sh.c
+++ b/bfd/elf32-sh.c
@@ -3394,7 +3394,7 @@ sh_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
   asection *sgot = NULL;
   asection *sgotplt = NULL;
   asection *splt = NULL;
-  asection *sreloc = NULL;
+  asection *sreloc;
   asection *srelgot = NULL;
   bool is_vxworks_tls;
   unsigned isec_segment, got_segment, plt_segment, check_segment[2];
@@ -3864,13 +3864,9 @@ sh_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
 		 are copied into the output file to be resolved at run
 		 time.  */
 
+	      sreloc = elf_section_data (input_section)->sreloc;
 	      if (sreloc == NULL)
-		{
-		  sreloc = _bfd_elf_get_dynamic_reloc_section
-		    (input_bfd, input_section, /*rela?*/ true);
-		  if (sreloc == NULL)
-		    return false;
-		}
+		return false;
 
 	      skip = false;
 	      relocate = false;
@@ -4974,13 +4970,9 @@ sh_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
 		goto final_link_relocate;
 	      }
 
+	    sreloc = elf_section_data (input_section)->sreloc;
 	    if (sreloc == NULL)
-	      {
-		sreloc = _bfd_elf_get_dynamic_reloc_section
-		  (input_bfd, input_section, /*rela?*/ true);
-		if (sreloc == NULL)
-		  return false;
-	      }
+	      return false;
 
 	    if (h == NULL || h->dynindx == -1)
 	      indx = 0;

--- a/bfd/elf32-vax.c
+++ b/bfd/elf32-vax.c
@@ -1226,7 +1226,6 @@ elf_vax_relocate_section (bfd *output_bfd,
   sgot = NULL;
   splt = NULL;
   sgotplt = NULL;
-  sreloc = NULL;
 
   rel = relocs;
   relend = relocs + input_section->reloc_count;
@@ -1423,13 +1422,9 @@ elf_vax_relocate_section (bfd *output_bfd,
 	      /* When generating a shared object, these relocations
 		 are copied into the output file to be resolved at run
 		 time.  */
+	      sreloc = elf_section_data (input_section)->sreloc;
 	      if (sreloc == NULL)
-		{
-		  sreloc = _bfd_elf_get_dynamic_reloc_section
-		    (input_bfd, input_section, /*rela?*/ true);
-		  if (sreloc == NULL)
-		    return false;
-		}
+		return false;
 
 	      skip = false;
 	      relocate = false;

--- a/bfd/elf64-alpha.c
+++ b/bfd/elf64-alpha.c
@@ -4117,7 +4117,7 @@ elf64_alpha_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
   Elf_Internal_Rela *rel;
   Elf_Internal_Rela *relend;
   asection *sgot, *srel, *srelgot;
-  bfd *dynobj, *gotobj;
+  bfd *gotobj;
   bfd_vma gp, tp_base, dtp_base;
   struct alpha_elf_got_entry **local_got_entries;
   bool ret_val;
@@ -4136,20 +4136,8 @@ elf64_alpha_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
 
   symtab_hdr = &elf_symtab_hdr (input_bfd);
 
-  dynobj = elf_hash_table (info)->dynobj;
   srelgot = elf_hash_table (info)->srelgot;
-
-  if (input_section->flags & SEC_ALLOC)
-    {
-      const char *section_name;
-      section_name = (bfd_elf_string_from_elf_section
-		      (input_bfd, elf_elfheader(input_bfd)->e_shstrndx,
-		       _bfd_elf_single_rel_hdr (input_section)->sh_name));
-      BFD_ASSERT(section_name != NULL);
-      srel = bfd_get_linker_section (dynobj, section_name);
-    }
-  else
-    srel = NULL;
+  srel = elf_section_data (input_section)->sreloc;
 
   /* Find the gp value for this input bfd.  */
   gotobj = alpha_elf_tdata (input_bfd)->gotobj;

--- a/bfd/elflink.c
+++ b/bfd/elflink.c
@@ -15584,34 +15584,6 @@ get_dynamic_reloc_section_name (bfd *       abfd,
   return name;
 }
 
-/* Returns the dynamic reloc section associated with SEC.
-   If necessary compute the name of the dynamic reloc section based
-   on SEC's name (looked up in ABFD's string table) and the setting
-   of IS_RELA.  */
-
-asection *
-_bfd_elf_get_dynamic_reloc_section (bfd *abfd,
-				    asection *sec,
-				    bool is_rela)
-{
-  asection *reloc_sec = elf_section_data (sec)->sreloc;
-
-  if (reloc_sec == NULL)
-    {
-      const char *name = get_dynamic_reloc_section_name (abfd, sec, is_rela);
-
-      if (name != NULL)
-	{
-	  reloc_sec = bfd_get_linker_section (abfd, name);
-
-	  if (reloc_sec != NULL)
-	    elf_section_data (sec)->sreloc = reloc_sec;
-	}
-    }
-
-  return reloc_sec;
-}
-
 /* Returns the dynamic reloc section associated with SEC.  If the
    section does not exist it is created and attached to the DYNOBJ
    bfd and stored in the SRELOC field of SEC's elf_section_data

--- a/bfd/elflink.c
+++ b/bfd/elflink.c
@@ -1162,7 +1162,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
   bfd *oldbfd;
   bool newdyn, olddyn, olddef, newdef, newdyncommon, olddyncommon;
   bool newweak, oldweak, newfunc, oldfunc;
-  elf_backend_data *bed;
+  elf_backend_data *bed, *obed;
   const char *new_version;
   bool default_sym = *matched;
   struct elf_link_hash_table *htab;
@@ -1183,6 +1183,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
   *sym_hash = h;
 
   bed = get_elf_backend_data (abfd);
+  obed = get_elf_backend_data (info->output_bfd);
 
   htab = elf_hash_table (info);
 
@@ -1434,7 +1435,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	  && olddyn)
 	{
 	  h = hi;
-	  (*bed->elf_backend_hide_symbol) (info, h, true);
+	  obed->elf_backend_hide_symbol (info, h, true);
 	  h->forced_local = 0;
 	  h->ref_dynamic = 0;
 	  h->def_dynamic = 0;
@@ -1550,14 +1551,14 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	    {
 	      hi->root.type = h->root.type;
 	      h->root.type = bfd_link_hash_indirect;
-	      (*bed->elf_backend_copy_indirect_symbol) (info, hi, h);
+	      obed->elf_backend_copy_indirect_symbol (info, hi, h);
 
 	      h->root.u.i.link = (struct bfd_link_hash_entry *) hi;
 	      if (ELF_ST_VISIBILITY (sym->st_other) != STV_PROTECTED)
 		{
 		  /* If the new symbol is hidden or internal, completely undo
 		     any dynamic link state.  */
-		  (*bed->elf_backend_hide_symbol) (info, h, true);
+		  obed->elf_backend_hide_symbol (info, h, true);
 		  h->forced_local = 0;
 		  h->ref_dynamic = 0;
 		}
@@ -1597,7 +1598,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	{
 	  /* If the new symbol is hidden or internal, completely undo
 	     any dynamic link state.  */
-	  (*bed->elf_backend_hide_symbol) (info, h, true);
+	  obed->elf_backend_hide_symbol (info, h, true);
 	  h->forced_local = 0;
 	  h->ref_dynamic = 0;
 	}
@@ -1700,9 +1701,9 @@ _bfd_elf_merge_symbol (bfd *abfd,
 
   /* We now know everything about the old and new symbols.  We ask the
      backend to check if we can merge them.  */
-  if (bed->merge_symbol != NULL)
+  if (obed->merge_symbol != NULL)
     {
-      if (!bed->merge_symbol (h, sym, psec, newdef, olddef, oldbfd, oldsec))
+      if (!obed->merge_symbol (h, sym, psec, newdef, olddef, oldbfd, oldsec))
 	return false;
       sec = *psec;
     }
@@ -1819,7 +1820,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	  {
 	  case STV_INTERNAL:
 	  case STV_HIDDEN:
-	    (*bed->elf_backend_hide_symbol) (info, h, true);
+	    obed->elf_backend_hide_symbol (info, h, true);
 	    break;
 	  }
     }
@@ -1930,7 +1931,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
       flip->root.u.undef.abfd = h->root.u.undef.abfd;
       h->root.type = bfd_link_hash_indirect;
       h->root.u.i.link = (struct bfd_link_hash_entry *) flip;
-      (*bed->elf_backend_copy_indirect_symbol) (info, flip, h);
+      obed->elf_backend_copy_indirect_symbol (info, flip, h);
       if (h->def_dynamic)
 	{
 	  h->def_dynamic = 0;
@@ -2006,7 +2007,7 @@ _bfd_elf_add_default_symbol (bfd *abfd,
 	return true;
     }
 
-  bed = get_elf_backend_data (abfd);
+  bed = get_elf_backend_data (info->output_bfd);
   collect = bed->collect;
   dynamic = (abfd->flags & DYNAMIC) != 0;
 
@@ -3167,7 +3168,7 @@ _bfd_elf_fix_symbol_flags (struct elf_link_hash_entry *h,
     }
 
   /* Backend specific symbol fixup.  */
-  bed = get_elf_backend_data (elf_hash_table (eif->info)->dynobj);
+  bed = get_elf_backend_data (eif->info->output_bfd);
   if (bed->elf_backend_fixup_symbol
       && !(*bed->elf_backend_fixup_symbol) (eif->info, h))
     return false;
@@ -4425,7 +4426,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
   Elf_Internal_Sym *isymbuf = NULL;
   Elf_Internal_Sym *isym;
   Elf_Internal_Sym *isymend;
-  elf_backend_data *bed;
+  elf_backend_data *bed, *obed;
   bool add_needed;
   struct elf_link_hash_table *htab;
   void *alloc_mark = NULL;
@@ -4443,6 +4444,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 
   htab = elf_hash_table (info);
   bed = get_elf_backend_data (abfd);
+  obed = get_elf_backend_data (info->output_bfd);
 
   if (elf_use_dt_symtab_p (abfd))
     {
@@ -5703,7 +5705,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 	      {
 	      case STV_INTERNAL:
 	      case STV_HIDDEN:
-		(*bed->elf_backend_hide_symbol) (info, h, true);
+		obed->elf_backend_hide_symbol (info, h, true);
 		dynsym = false;
 		break;
 	      }
@@ -5941,10 +5943,10 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 	      && hi->root.u.def.value == h->root.u.def.value
 	      && hi->root.u.def.section == h->root.u.def.section)
 	    {
-	      (*bed->elf_backend_hide_symbol) (info, hi, true);
+	      obed->elf_backend_hide_symbol (info, hi, true);
 	      hi->root.type = bfd_link_hash_indirect;
 	      hi->root.u.i.link = (struct bfd_link_hash_entry *) h;
-	      (*bed->elf_backend_copy_indirect_symbol) (info, h, hi);
+	      obed->elf_backend_copy_indirect_symbol (info, h, hi);
 	      sym_hash = elf_sym_hashes (abfd);
 	      if (sym_hash)
 		for (symidx = 0; symidx < extsymcount; ++symidx)

--- a/bfd/elflink.c
+++ b/bfd/elflink.c
@@ -1162,7 +1162,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
   bfd *oldbfd;
   bool newdyn, olddyn, olddef, newdef, newdyncommon, olddyncommon;
   bool newweak, oldweak, newfunc, oldfunc;
-  elf_backend_data *bed;
+  elf_backend_data *bed, *obed;
   const char *new_version;
   bool default_sym = *matched;
   struct elf_link_hash_table *htab;
@@ -1183,6 +1183,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
   *sym_hash = h;
 
   bed = get_elf_backend_data (abfd);
+  obed = get_elf_backend_data (info->output_bfd);
 
   htab = elf_hash_table (info);
 
@@ -1434,7 +1435,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	  && olddyn)
 	{
 	  h = hi;
-	  (*bed->elf_backend_hide_symbol) (info, h, true);
+	  obed->elf_backend_hide_symbol (info, h, true);
 	  h->forced_local = 0;
 	  h->ref_dynamic = 0;
 	  h->def_dynamic = 0;
@@ -1550,14 +1551,14 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	    {
 	      hi->root.type = h->root.type;
 	      h->root.type = bfd_link_hash_indirect;
-	      (*bed->elf_backend_copy_indirect_symbol) (info, hi, h);
+	      obed->elf_backend_copy_indirect_symbol (info, hi, h);
 
 	      h->root.u.i.link = (struct bfd_link_hash_entry *) hi;
 	      if (ELF_ST_VISIBILITY (sym->st_other) != STV_PROTECTED)
 		{
 		  /* If the new symbol is hidden or internal, completely undo
 		     any dynamic link state.  */
-		  (*bed->elf_backend_hide_symbol) (info, h, true);
+		  obed->elf_backend_hide_symbol (info, h, true);
 		  h->forced_local = 0;
 		  h->ref_dynamic = 0;
 		}
@@ -1597,7 +1598,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	{
 	  /* If the new symbol is hidden or internal, completely undo
 	     any dynamic link state.  */
-	  (*bed->elf_backend_hide_symbol) (info, h, true);
+	  obed->elf_backend_hide_symbol (info, h, true);
 	  h->forced_local = 0;
 	  h->ref_dynamic = 0;
 	}
@@ -1700,9 +1701,9 @@ _bfd_elf_merge_symbol (bfd *abfd,
 
   /* We now know everything about the old and new symbols.  We ask the
      backend to check if we can merge them.  */
-  if (bed->merge_symbol != NULL)
+  if (obed->merge_symbol != NULL)
     {
-      if (!bed->merge_symbol (h, sym, psec, newdef, olddef, oldbfd, oldsec))
+      if (!obed->merge_symbol (h, sym, psec, newdef, olddef, oldbfd, oldsec))
 	return false;
       sec = *psec;
     }
@@ -1819,7 +1820,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
 	  {
 	  case STV_INTERNAL:
 	  case STV_HIDDEN:
-	    (*bed->elf_backend_hide_symbol) (info, h, true);
+	    obed->elf_backend_hide_symbol (info, h, true);
 	    break;
 	  }
     }
@@ -1930,7 +1931,7 @@ _bfd_elf_merge_symbol (bfd *abfd,
       flip->root.u.undef.abfd = h->root.u.undef.abfd;
       h->root.type = bfd_link_hash_indirect;
       h->root.u.i.link = (struct bfd_link_hash_entry *) flip;
-      (*bed->elf_backend_copy_indirect_symbol) (info, flip, h);
+      obed->elf_backend_copy_indirect_symbol (info, flip, h);
       if (h->def_dynamic)
 	{
 	  h->def_dynamic = 0;
@@ -2006,7 +2007,7 @@ _bfd_elf_add_default_symbol (bfd *abfd,
 	return true;
     }
 
-  bed = get_elf_backend_data (abfd);
+  bed = get_elf_backend_data (info->output_bfd);
   collect = bed->collect;
   dynamic = (abfd->flags & DYNAMIC) != 0;
 
@@ -3167,7 +3168,7 @@ _bfd_elf_fix_symbol_flags (struct elf_link_hash_entry *h,
     }
 
   /* Backend specific symbol fixup.  */
-  bed = get_elf_backend_data (elf_hash_table (eif->info)->dynobj);
+  bed = get_elf_backend_data (eif->info->output_bfd);
   if (bed->elf_backend_fixup_symbol
       && !(*bed->elf_backend_fixup_symbol) (eif->info, h))
     return false;
@@ -4425,7 +4426,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
   Elf_Internal_Sym *isymbuf = NULL;
   Elf_Internal_Sym *isym;
   Elf_Internal_Sym *isymend;
-  elf_backend_data *bed;
+  elf_backend_data *bed, *obed;
   bool add_needed;
   struct elf_link_hash_table *htab;
   void *alloc_mark = NULL;
@@ -4443,6 +4444,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 
   htab = elf_hash_table (info);
   bed = get_elf_backend_data (abfd);
+  obed = get_elf_backend_data (info->output_bfd);
 
   if (elf_use_dt_symtab_p (abfd))
     {
@@ -5703,7 +5705,7 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 	      {
 	      case STV_INTERNAL:
 	      case STV_HIDDEN:
-		(*bed->elf_backend_hide_symbol) (info, h, true);
+		obed->elf_backend_hide_symbol (info, h, true);
 		dynsym = false;
 		break;
 	      }
@@ -5941,10 +5943,10 @@ elf_link_add_object_symbols (bfd *abfd, struct bfd_link_info *info)
 	      && hi->root.u.def.value == h->root.u.def.value
 	      && hi->root.u.def.section == h->root.u.def.section)
 	    {
-	      (*bed->elf_backend_hide_symbol) (info, hi, true);
+	      obed->elf_backend_hide_symbol (info, hi, true);
 	      hi->root.type = bfd_link_hash_indirect;
 	      hi->root.u.i.link = (struct bfd_link_hash_entry *) h;
-	      (*bed->elf_backend_copy_indirect_symbol) (info, h, hi);
+	      obed->elf_backend_copy_indirect_symbol (info, h, hi);
 	      sym_hash = elf_sym_hashes (abfd);
 	      if (sym_hash)
 		for (symidx = 0; symidx < extsymcount; ++symidx)
@@ -15582,34 +15584,6 @@ get_dynamic_reloc_section_name (bfd *       abfd,
   sprintf (name, "%s%s", prefix, old_name);
 
   return name;
-}
-
-/* Returns the dynamic reloc section associated with SEC.
-   If necessary compute the name of the dynamic reloc section based
-   on SEC's name (looked up in ABFD's string table) and the setting
-   of IS_RELA.  */
-
-asection *
-_bfd_elf_get_dynamic_reloc_section (bfd *abfd,
-				    asection *sec,
-				    bool is_rela)
-{
-  asection *reloc_sec = elf_section_data (sec)->sreloc;
-
-  if (reloc_sec == NULL)
-    {
-      const char *name = get_dynamic_reloc_section_name (abfd, sec, is_rela);
-
-      if (name != NULL)
-	{
-	  reloc_sec = bfd_get_linker_section (abfd, name);
-
-	  if (reloc_sec != NULL)
-	    elf_section_data (sec)->sreloc = reloc_sec;
-	}
-    }
-
-  return reloc_sec;
 }
 
 /* Returns the dynamic reloc section associated with SEC.  If the

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260429
+#define BFD_VERSION_DATE 20260430
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260502
+#define BFD_VERSION_DATE 20260503
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260430
+#define BFD_VERSION_DATE 20260501
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260428
+#define BFD_VERSION_DATE 20260429
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260501
+#define BFD_VERSION_DATE 20260502
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260428
+#define BFD_VERSION_DATE 20260503
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/binutils/bucomm.c
+++ b/binutils/bucomm.c
@@ -502,7 +502,7 @@ template_in_dir (const char *path)
 #ifdef HAVE_DOS_BASED_FILE_SYSTEM
   {
     /* We could have foo/bar\\baz, or foo\\bar, or d:bar.  */
-    char *bslash = strrchr (path, '\\');
+    const char *bslash = strrchr (path, '\\');
 
     if (slash == NULL || (bslash != NULL && bslash > slash))
       slash = bslash;

--- a/gas/gen-sframe.c
+++ b/gas/gen-sframe.c
@@ -2478,6 +2478,14 @@ create_sframe_all (void)
       /* Initialize the translation context with information anew.  */
       sframe_xlate_ctx_init (xlate_ctx);
 
+      /* Report and fix open CFI.  */
+      if (dw_fde->end_address == NULL)
+	{
+	  as_bad (_("open CFI at the end of file; "
+		    "missing .cfi_endproc directive"));
+	  dw_fde->end_address = dw_fde->start_address;
+	}
+
       /* Process and link SFrame FDEs if no error.  */
       int err = sframe_do_fde (xlate_ctx, dw_fde);
       if (err && get_dw_fde_signal_p (dw_fde))

--- a/gas/testsuite/gas/cfi-sframe/cfi-sframe-common-pr34026.d
+++ b/gas/testsuite/gas/cfi-sframe/cfi-sframe-common-pr34026.d
@@ -1,0 +1,3 @@
+#as: --gsframe
+#error: open CFI at the end of file; missing \.cfi_endproc directive
+#name: Open CFI at end of file (PR 34026)

--- a/gas/testsuite/gas/cfi-sframe/cfi-sframe-common-pr34026.s
+++ b/gas/testsuite/gas/cfi-sframe/cfi-sframe-common-pr34026.s
@@ -1,0 +1,1 @@
+	.cfi_startproc

--- a/gas/testsuite/gas/cfi-sframe/cfi-sframe.exp
+++ b/gas/testsuite/gas/cfi-sframe/cfi-sframe.exp
@@ -55,6 +55,7 @@ if  { ([istarget "x86_64-*-*"] || [istarget "aarch64*-*-*"]
     run_dump_test "common-empty-3"
 
     run_dump_test "cfi-sframe-common-pr33810"
+    run_dump_test "cfi-sframe-common-pr34026"
 }
 
 # x86-64 specific tests

--- a/gas/testsuite/gas/loongarch/insn_align_4.d
+++ b/gas/testsuite/gas/loongarch/insn_align_4.d
@@ -1,7 +1,6 @@
 #as:
-#readelf: -S
+#readelf: -W -S
 
 #...
-  \[ [0-9]+\] \.text             PROGBITS         [0-9a-f]{16}  [0-9a-f]{8}
-       [0-9a-f]{16}  [0-9a-f]{16}  AX       0     0     4
-#...
+.* \.text .* 4
+#pass

--- a/gdb/NEWS
+++ b/gdb/NEWS
@@ -75,6 +75,9 @@
 * The Windows native target now supports scheduler-locking.  E.g.,
   "set scheduler-locking on" now works.  Previously it gave an error.
 
+* The Windows native target now supports non-stop mode.  This feature
+  requires Windows 10 or later.
+
 * New targets
 
 GNU/Linux/MicroBlaze (gdbserver) microblazeel-*linux*

--- a/gdb/aarch64-windows-nat.c
+++ b/gdb/aarch64-windows-nat.c
@@ -44,7 +44,7 @@ struct aarch64_windows_nat_target final
   void cleanup_windows_arch () override;
 
   void thread_context_continue (windows_thread_info *th, int killed) override;
-  void thread_context_step (windows_thread_info *th) override;
+  void thread_context_step (windows_thread_info *th, bool step) override;
 
   void fetch_one_register (struct regcache *regcache,
 			   windows_thread_info *th, int r) override;
@@ -241,9 +241,13 @@ aarch64_windows_nat_target::thread_context_continue (windows_thread_info *th,
 /* See windows-nat.h.  */
 
 void
-aarch64_windows_nat_target::thread_context_step (windows_thread_info *th)
+aarch64_windows_nat_target::thread_context_step (windows_thread_info *th,
+						 bool enable)
 {
-  th->context.Cpsr |= 0x200000;
+  if (enable)
+    th->context.Cpsr |= 0x200000;
+  else
+    th->context.Cpsr &= ~0x200000;
 }
 
 /* See windows-nat.h.  */

--- a/gdb/aarch64-windows-nat.c
+++ b/gdb/aarch64-windows-nat.c
@@ -317,8 +317,7 @@ aarch64_notify_debug_reg_change (ptid_t ptid,
     = aarch64_get_debug_reg_state (inferior_ptid.pid ());
   aarch64_windows_process.dr_state = *state;
 
-  for (auto &th : aarch64_windows_process.thread_list)
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 INIT_GDB_FILE (aarch64_windows_nat)

--- a/gdb/aarch64-windows-nat.c
+++ b/gdb/aarch64-windows-nat.c
@@ -44,7 +44,7 @@ struct aarch64_windows_nat_target final
   void cleanup_windows_arch () override;
 
   void thread_context_continue (windows_thread_info *th, int killed) override;
-  void thread_context_step (windows_thread_info *th) override;
+  void thread_context_step (windows_thread_info *th, bool step) override;
 
   void fetch_one_register (struct regcache *regcache,
 			   windows_thread_info *th, int r) override;
@@ -241,9 +241,13 @@ aarch64_windows_nat_target::thread_context_continue (windows_thread_info *th,
 /* See windows-nat.h.  */
 
 void
-aarch64_windows_nat_target::thread_context_step (windows_thread_info *th)
+aarch64_windows_nat_target::thread_context_step (windows_thread_info *th,
+						 bool enable)
 {
-  th->context.Cpsr |= 0x200000;
+  if (enable)
+    th->context.Cpsr |= 0x200000;
+  else
+    th->context.Cpsr &= ~0x200000;
 }
 
 /* See windows-nat.h.  */
@@ -313,8 +317,7 @@ aarch64_notify_debug_reg_change (ptid_t ptid,
     = aarch64_get_debug_reg_state (inferior_ptid.pid ());
   aarch64_windows_process.dr_state = *state;
 
-  for (auto &th : aarch64_windows_process.thread_list)
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 INIT_GDB_FILE (aarch64_windows_nat)

--- a/gdb/ada-lang.c
+++ b/gdb/ada-lang.c
@@ -5429,25 +5429,9 @@ struct match_data
 
   void operator() (struct block_symbol *bsym);
 
-  void finish (const block *block);
-
   struct objfile *objfile = nullptr;
   std::vector<struct block_symbol> *resultp;
-  struct symbol *arg_sym = nullptr;
-  bool found_sym = false;
 };
-
-/* Finish iteration over one block.  If a symbol hasn't been found
-   already, add 'arg_sym' to the list of symbols.  */
-
-void
-match_data::finish (const block *block)
-{
-  if (!found_sym && arg_sym != nullptr)
-    add_defn_to_vec (*resultp, arg_sym, block);
-  found_sym = false;
-  arg_sym = nullptr;
-}
 
 /* A callback for add_nonlocal_symbols that adds symbol, found in
    BSYM, to a list of symbols.  */
@@ -5460,27 +5444,20 @@ match_data::operator() (struct block_symbol *bsym)
 
   if (sym->loc_class () == LOC_UNRESOLVED)
     return;
-  else if (sym->is_argument ())
-    arg_sym = sym;
   else
-    {
-      found_sym = true;
-      add_defn_to_vec (*resultp, sym, block);
-    }
+    add_defn_to_vec (*resultp, sym, block);
 }
 
 /* Helper for add_nonlocal_symbols.  Find symbols in DOMAIN which are
    targeted by renamings matching LOOKUP_NAME in BLOCK.  Add these
-   symbols to RESULT.  Return whether we found such symbols.  */
+   symbols to RESULT.  */
 
-static bool
+static void
 ada_add_block_renamings (std::vector<struct block_symbol> &result,
 			 const struct block *block,
 			 const lookup_name_info &lookup_name,
 			 domain_search_flags domain)
 {
-  int defns_mark = result.size ();
-
   symbol_name_matcher_ftype *name_match
     = ada_get_symbol_name_matcher (lookup_name);
 
@@ -5531,7 +5508,6 @@ ada_add_block_renamings (std::vector<struct block_symbol> &result,
 			       1, NULL);
 	}
     }
-  return result.size () != defns_mark;
 }
 
 /* Convenience function to get at the Ada encoded lookup name for
@@ -5562,7 +5538,6 @@ map_matching_symbols (struct objfile *objfile,
       const struct block *block
 	= symtab->blockvector ()->block (block_kind);
       for_each_symbol (block, lookup_name, domain, data);
-      data.finish (block);
       return iteration_status::keep_going;
     };
 
@@ -5594,9 +5569,7 @@ add_nonlocal_symbols (std::vector<struct block_symbol> &result,
 	  const struct block *global_block
 	    = cu.blockvector ()->global_block ();
 
-	  if (ada_add_block_renamings (result, global_block, lookup_name,
-				       domain))
-	    data.found_sym = true;
+	  ada_add_block_renamings (result, global_block, lookup_name, domain);
 	}
     }
 
@@ -6046,44 +6019,18 @@ ada_add_block_symbols (std::vector<struct block_symbol> &result,
 		       const lookup_name_info &lookup_name,
 		       domain_search_flags domain, struct objfile *objfile)
 {
-  /* A matching argument symbol, if any.  */
-  struct symbol *arg_sym;
-  /* Set true when we find a matching non-argument symbol.  */
-  bool found_sym;
-
-  arg_sym = NULL;
-  found_sym = false;
   for (struct symbol *sym : block_iterator_range (block, &lookup_name))
     {
-      if (sym->matches (domain))
-	{
-	  if (sym->loc_class () != LOC_UNRESOLVED)
-	    {
-	      if (sym->is_argument ())
-		arg_sym = sym;
-	      else
-		{
-		  found_sym = true;
-		  add_defn_to_vec (result, sym, block);
-		}
-	    }
-	}
+      if (sym->matches (domain) && sym->loc_class () != LOC_UNRESOLVED)
+	add_defn_to_vec (result, sym, block);
     }
 
   /* Handle renamings.  */
 
-  if (ada_add_block_renamings (result, block, lookup_name, domain))
-    found_sym = true;
-
-  if (!found_sym && arg_sym != NULL)
-    {
-      add_defn_to_vec (result, arg_sym, block);
-    }
+  ada_add_block_renamings (result, block, lookup_name, domain);
 
   if (!lookup_name.ada ().wild_match_p ())
     {
-      arg_sym = NULL;
-      found_sym = false;
       const std::string &ada_lookup_name = lookup_name.ada ().lookup_name ();
       const char *name = ada_lookup_name.c_str ();
       size_t name_len = ada_lookup_name.size ();
@@ -6107,25 +6054,10 @@ ada_add_block_symbols (std::vector<struct block_symbol> &result,
 		&& is_name_suffix (sym->linkage_name () + name_len + 5))
 	      {
 		if (sym->loc_class () != LOC_UNRESOLVED)
-		  {
-		    if (sym->is_argument ())
-		      arg_sym = sym;
-		    else
-		      {
-			found_sym = true;
-			add_defn_to_vec (result, sym, block);
-		      }
-		  }
+		  add_defn_to_vec (result, sym, block);
 	      }
 	  }
       }
-
-      /* NOTE: This really shouldn't be needed for _ada_ symbols.
-	 They aren't parameters, right?  */
-      if (!found_sym && arg_sym != NULL)
-	{
-	  add_defn_to_vec (result, arg_sym, block);
-	}
     }
 }
 

--- a/gdb/ada-lang.c
+++ b/gdb/ada-lang.c
@@ -5432,25 +5432,9 @@ struct match_data
 
   void operator() (struct block_symbol *bsym);
 
-  void finish (const block *block);
-
   struct objfile *objfile = nullptr;
   std::vector<struct block_symbol> *resultp;
-  struct symbol *arg_sym = nullptr;
-  bool found_sym = false;
 };
-
-/* Finish iteration over one block.  If a symbol hasn't been found
-   already, add 'arg_sym' to the list of symbols.  */
-
-void
-match_data::finish (const block *block)
-{
-  if (!found_sym && arg_sym != nullptr)
-    add_defn_to_vec (*resultp, arg_sym, block);
-  found_sym = false;
-  arg_sym = nullptr;
-}
 
 /* A callback for add_nonlocal_symbols that adds symbol, found in
    BSYM, to a list of symbols.  */
@@ -5463,27 +5447,20 @@ match_data::operator() (struct block_symbol *bsym)
 
   if (sym->loc_class () == LOC_UNRESOLVED)
     return;
-  else if (sym->is_argument ())
-    arg_sym = sym;
   else
-    {
-      found_sym = true;
-      add_defn_to_vec (*resultp, sym, block);
-    }
+    add_defn_to_vec (*resultp, sym, block);
 }
 
 /* Helper for add_nonlocal_symbols.  Find symbols in DOMAIN which are
    targeted by renamings matching LOOKUP_NAME in BLOCK.  Add these
-   symbols to RESULT.  Return whether we found such symbols.  */
+   symbols to RESULT.  */
 
-static bool
+static void
 ada_add_block_renamings (std::vector<struct block_symbol> &result,
 			 const struct block *block,
 			 const lookup_name_info &lookup_name,
 			 domain_search_flags domain)
 {
-  int defns_mark = result.size ();
-
   symbol_name_matcher_ftype *name_match
     = ada_get_symbol_name_matcher (lookup_name);
 
@@ -5534,7 +5511,6 @@ ada_add_block_renamings (std::vector<struct block_symbol> &result,
 			       1, NULL);
 	}
     }
-  return result.size () != defns_mark;
 }
 
 /* Convenience function to get at the Ada encoded lookup name for
@@ -5565,7 +5541,6 @@ map_matching_symbols (struct objfile *objfile,
       const struct block *block
 	= symtab->blockvector ()->block (block_kind);
       for_each_symbol (block, lookup_name, domain, data);
-      data.finish (block);
       return iteration_status::keep_going;
     };
 
@@ -5597,9 +5572,7 @@ add_nonlocal_symbols (std::vector<struct block_symbol> &result,
 	  const struct block *global_block
 	    = cu.blockvector ()->global_block ();
 
-	  if (ada_add_block_renamings (result, global_block, lookup_name,
-				       domain))
-	    data.found_sym = true;
+	  ada_add_block_renamings (result, global_block, lookup_name, domain);
 	}
     }
 
@@ -6049,44 +6022,18 @@ ada_add_block_symbols (std::vector<struct block_symbol> &result,
 		       const lookup_name_info &lookup_name,
 		       domain_search_flags domain, struct objfile *objfile)
 {
-  /* A matching argument symbol, if any.  */
-  struct symbol *arg_sym;
-  /* Set true when we find a matching non-argument symbol.  */
-  bool found_sym;
-
-  arg_sym = NULL;
-  found_sym = false;
   for (struct symbol *sym : block_iterator_range (block, &lookup_name))
     {
-      if (sym->matches (domain))
-	{
-	  if (sym->loc_class () != LOC_UNRESOLVED)
-	    {
-	      if (sym->is_argument ())
-		arg_sym = sym;
-	      else
-		{
-		  found_sym = true;
-		  add_defn_to_vec (result, sym, block);
-		}
-	    }
-	}
+      if (sym->matches (domain) && sym->loc_class () != LOC_UNRESOLVED)
+	add_defn_to_vec (result, sym, block);
     }
 
   /* Handle renamings.  */
 
-  if (ada_add_block_renamings (result, block, lookup_name, domain))
-    found_sym = true;
-
-  if (!found_sym && arg_sym != NULL)
-    {
-      add_defn_to_vec (result, arg_sym, block);
-    }
+  ada_add_block_renamings (result, block, lookup_name, domain);
 
   if (!lookup_name.ada ().wild_match_p ())
     {
-      arg_sym = NULL;
-      found_sym = false;
       const std::string &ada_lookup_name = lookup_name.ada ().lookup_name ();
       const char *name = ada_lookup_name.c_str ();
       size_t name_len = ada_lookup_name.size ();
@@ -6110,25 +6057,10 @@ ada_add_block_symbols (std::vector<struct block_symbol> &result,
 		&& is_name_suffix (sym->linkage_name () + name_len + 5))
 	      {
 		if (sym->loc_class () != LOC_UNRESOLVED)
-		  {
-		    if (sym->is_argument ())
-		      arg_sym = sym;
-		    else
-		      {
-			found_sym = true;
-			add_defn_to_vec (result, sym, block);
-		      }
-		  }
+		  add_defn_to_vec (result, sym, block);
 	      }
 	  }
       }
-
-      /* NOTE: This really shouldn't be needed for _ada_ symbols.
-	 They aren't parameters, right?  */
-      if (!found_sym && arg_sym != NULL)
-	{
-	  add_defn_to_vec (result, arg_sym, block);
-	}
     }
 }
 

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1080,7 +1080,6 @@ void
 default_read_core_file_mappings
   (struct gdbarch *gdbarch,
    struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
    read_core_file_mappings_loop_ftype loop_cb)
 {
 }

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -1081,7 +1081,6 @@ void
 default_read_core_file_mappings
   (struct gdbarch *gdbarch,
    struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
    read_core_file_mappings_loop_ftype loop_cb)
 {
 }

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -378,7 +378,6 @@ extern std::string default_get_pc_address_flags (const frame_info_ptr &frame,
 extern void default_read_core_file_mappings
   (struct gdbarch *gdbarch,
    struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
    read_core_file_mappings_loop_ftype loop_cb);
 
 /* Default implementation of gdbarch_core_parse_exec_context.  Returns

--- a/gdb/arch-utils.h
+++ b/gdb/arch-utils.h
@@ -379,7 +379,6 @@ extern std::string default_get_pc_address_flags (const frame_info_ptr &frame,
 extern void default_read_core_file_mappings
   (struct gdbarch *gdbarch,
    struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
    read_core_file_mappings_loop_ftype loop_cb);
 
 /* Default implementation of gdbarch_core_parse_exec_context.  Returns

--- a/gdb/block.c
+++ b/gdb/block.c
@@ -640,38 +640,9 @@ struct symbol *
 block_lookup_symbol (const struct block *block, const lookup_name_info &name,
 		     const domain_search_flags domain)
 {
-  if (!block->function ())
-    {
-      best_symbol_tracker tracker;
-      tracker.search (nullptr, block, name, domain);
-      return tracker.currently_best.symbol;
-    }
-  else
-    {
-      /* Note that parameter symbols do not always show up last in the
-	 list; this loop makes sure to take anything else other than
-	 parameter symbols first; it only uses parameter symbols as a
-	 last resort.  Note that this only takes up extra computation
-	 time on a match.
-	 It's hard to define types in the parameter list (at least in
-	 C/C++) so we don't do the same PR 16253 hack here that is done
-	 for the !BLOCK_FUNCTION case.  */
-
-      struct symbol *sym_found = NULL;
-
-      for (struct symbol *sym : block_iterator_range (block, &name))
-	{
-	  if (sym->matches (domain))
-	    {
-	      sym_found = sym;
-	      if (!sym->is_argument ())
-		{
-		  break;
-		}
-	    }
-	}
-      return (sym_found);	/* Will be NULL if not found.  */
-    }
+  best_symbol_tracker tracker;
+  tracker.search (nullptr, block, name, domain);
+  return tracker.currently_best.symbol;
 }
 
 /* See block.h.  */

--- a/gdb/block.c
+++ b/gdb/block.c
@@ -648,38 +648,9 @@ struct symbol *
 block_lookup_symbol (const struct block *block, const lookup_name_info &name,
 		     const domain_search_flags domain)
 {
-  if (!block->function ())
-    {
-      best_symbol_tracker tracker;
-      tracker.search (nullptr, block, name, domain);
-      return tracker.currently_best.symbol;
-    }
-  else
-    {
-      /* Note that parameter symbols do not always show up last in the
-	 list; this loop makes sure to take anything else other than
-	 parameter symbols first; it only uses parameter symbols as a
-	 last resort.  Note that this only takes up extra computation
-	 time on a match.
-	 It's hard to define types in the parameter list (at least in
-	 C/C++) so we don't do the same PR 16253 hack here that is done
-	 for the !BLOCK_FUNCTION case.  */
-
-      struct symbol *sym_found = NULL;
-
-      for (struct symbol *sym : block_iterator_range (block, &name))
-	{
-	  if (sym->matches (domain))
-	    {
-	      sym_found = sym;
-	      if (!sym->is_argument ())
-		{
-		  break;
-		}
-	    }
-	}
-      return (sym_found);	/* Will be NULL if not found.  */
-    }
+  best_symbol_tracker tracker;
+  tracker.search (nullptr, block, name, domain);
+  return tracker.currently_best.symbol;
 }
 
 /* See block.h.  */

--- a/gdb/bt-utils.c
+++ b/gdb/bt-utils.c
@@ -146,7 +146,6 @@ gdb_internal_backtrace_1 ()
 #endif
 
 static const char *str_backtrace = "----- Backtrace -----\n";
-static const char *str_backtrace_unavailable = "Backtrace unavailable\n";
 
 #endif /* GDB_PRINT_INTERNAL_BACKTRACE */
 
@@ -157,7 +156,6 @@ gdb_internal_backtrace_init_str ()
 {
 #ifdef GDB_PRINT_INTERNAL_BACKTRACE
   str_backtrace = _("----- Backtrace -----\n");
-  str_backtrace_unavailable = _("Backtrace unavailable\n");
 #endif
 }
 

--- a/gdb/compile/compile-loc2c.c
+++ b/gdb/compile/compile-loc2c.c
@@ -70,16 +70,18 @@ struct insn_info
    TO_DO is a list of bytecodes which must be examined; it may be
    added to by this function.
    BYTE_ORDER and ADDR_SIZE describe this bytecode in the obvious way.
-   OP_PTR and OP_END are the bounds of the DWARF expression.  */
+   EXPR is the DWARF expression.  */
 
 static void
 compute_stack_depth_worker (int start, int *need_tempvar,
 			    std::vector<struct insn_info> *info,
 			    std::vector<int> *to_do,
 			    enum bfd_endian byte_order, unsigned int addr_size,
-			    const gdb_byte *op_ptr, const gdb_byte *op_end)
+			    gdb::array_view<const gdb_byte> expr)
 {
-  const gdb_byte * const base = op_ptr;
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *const op_end = expr.data () + expr.size ();
   int stack_depth;
 
   op_ptr += start;
@@ -378,7 +380,7 @@ compute_stack_depth_worker (int start, int *need_tempvar,
    generator).
    IS_TLS is an out parameter which is set if this expression refers
    to a TLS variable.
-   OP_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
    INITIAL_DEPTH is the initial depth of the DWARF expression stack.
    INFO is an array of insn_info objects, indexed by offset from the
    start of the DWARF expression.
@@ -388,14 +390,14 @@ compute_stack_depth_worker (int start, int *need_tempvar,
 static int
 compute_stack_depth (enum bfd_endian byte_order, unsigned int addr_size,
 		     int *need_tempvar, int *is_tls,
-		     const gdb_byte *op_ptr, const gdb_byte *op_end,
+		     gdb::array_view<const gdb_byte> expr,
 		     int initial_depth,
 		     std::vector<struct insn_info> *info)
 {
   std::vector<int> to_do;
-  int stack_depth, i;
+  int stack_depth;
 
-  info->resize (op_end - op_ptr);
+  info->resize (expr.size ());
 
   to_do.push_back (0);
   (*info)[0].depth = initial_depth;
@@ -406,14 +408,13 @@ compute_stack_depth (enum bfd_endian byte_order, unsigned int addr_size,
       int ndx = to_do.back ();
       to_do.pop_back ();
 
-      compute_stack_depth_worker (ndx, need_tempvar, info, &to_do,
-				  byte_order, addr_size,
-				  op_ptr, op_end);
+      compute_stack_depth_worker (ndx, need_tempvar, info, &to_do, byte_order,
+				  addr_size, expr);
     }
 
   stack_depth = 0;
   *is_tls = 0;
-  for (i = 0; i < op_end - op_ptr; ++i)
+  for (int i = 0; i < expr.size (); ++i)
     {
       if ((*info)[i].depth > stack_depth)
 	stack_depth = (*info)[i].depth;
@@ -579,7 +580,7 @@ pushf_register (int indent, string_file *stream,
 
    ADDR_SIZE is the DWARF address size to use.
 
-   OPT_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
 
    If non-NULL, INITIAL points to an initial value to write to the
    stack.  If NULL, no initial value is written.
@@ -595,7 +596,7 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 			    struct gdbarch *arch,
 			    std::vector<bool> &registers_used,
 			    unsigned int addr_size,
-			    const gdb_byte *op_ptr, const gdb_byte *op_end,
+			    gdb::array_view<const gdb_byte> expr,
 			    CORE_ADDR *initial,
 			    dwarf2_per_cu *per_cu,
 			    dwarf2_per_objfile *per_objfile)
@@ -605,7 +606,6 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
   static unsigned int scope;
 
   enum bfd_endian byte_order = gdbarch_byte_order (arch);
-  const gdb_byte * const base = op_ptr;
   int need_tempvar = 0;
   int is_tls = 0;
   std::vector<struct insn_info> info;
@@ -620,7 +620,7 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 
   stack_depth = compute_stack_depth (byte_order, addr_size,
 				     &need_tempvar, &is_tls,
-				     op_ptr, op_end, initial != NULL,
+				     expr, initial != NULL,
 				     &info);
 
   /* This is a hack until we can add a feature to glibc to let us
@@ -667,6 +667,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 
   if (initial != NULL)
     pushf (indent, stream, "%s", core_addr_to_string (*initial));
+
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = base;
+  const gdb_byte *const op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -880,8 +884,6 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	  break;
 	case DW_OP_fbreg:
 	  {
-	    const gdb_byte *datastart;
-	    size_t datalen;
 	    const struct block *b;
 	    struct symbol *framefunc;
 	    char fb_name[50];
@@ -896,8 +898,8 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    if (!framefunc)
 	      error (_("No function found for block"));
 
-	    func_get_frame_base_dwarf_block (framefunc, pc,
-					     &datastart, &datalen);
+	    auto frame_base_expr
+	      = func_get_frame_base_dwarf_block (framefunc, pc);
 
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 
@@ -906,12 +908,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    xsnprintf (fb_name, sizeof (fb_name), "__frame_base_%ld",
 		       (long) (op_ptr - base));
 
-	    do_compile_dwarf_expr_to_c (indent, stream,
-					GCC_UINTPTR, fb_name,
-					sym, pc,
-					arch, registers_used, addr_size,
-					datastart, datastart + datalen,
-					NULL, per_cu, per_objfile);
+	    do_compile_dwarf_expr_to_c (indent, stream, GCC_UINTPTR, fb_name,
+					sym, pc, arch, registers_used,
+					addr_size, frame_base_expr, nullptr,
+					per_cu, per_objfile);
 
 	    pushf (indent, stream, "%s + %s", fb_name, hex_string (offset));
 	  }
@@ -1074,11 +1074,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    int regnum;
 	    CORE_ADDR text_offset;
 	    LONGEST off;
-	    const gdb_byte *cfa_start, *cfa_end;
+	    gdb::array_view<const gdb_byte> cfa_expr;
 
-	    if (dwarf2_fetch_cfa_info (arch, pc, per_cu,
-				       &regnum, &off,
-				       &text_offset, &cfa_start, &cfa_end))
+	    if (dwarf2_fetch_cfa_info (arch, pc, per_cu, &regnum, &off,
+				       &text_offset, cfa_expr))
 	      {
 		/* Register.  */
 		pushf_register (indent, stream, registers_used, arch, regnum,
@@ -1094,12 +1093,11 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 		xsnprintf (cfa_name, sizeof (cfa_name),
 			   "__cfa_%ld", (long) (op_ptr - base));
 
-		do_compile_dwarf_expr_to_c (indent, stream,
-					    GCC_UINTPTR, cfa_name,
-					    sym, pc, arch, registers_used,
-					    addr_size,
-					    cfa_start, cfa_end,
-					    &text_offset, per_cu, per_objfile);
+		do_compile_dwarf_expr_to_c (indent, stream, GCC_UINTPTR,
+					    cfa_name, sym, pc, arch,
+					    registers_used, addr_size,
+					    cfa_expr, &text_offset, per_cu,
+					    per_objfile);
 		pushf (indent, stream, "%s", cfa_name);
 	      }
 	  }
@@ -1146,13 +1144,13 @@ compile_dwarf_expr_to_c (string_file *stream, const char *result_name,
 			 struct gdbarch *arch,
 			 std::vector<bool> &registers_used,
 			 unsigned int addr_size,
-			 const gdb_byte *op_ptr, const gdb_byte *op_end,
+			 gdb::array_view<const gdb_byte> expr,
 			 dwarf2_per_cu *per_cu,
 			 dwarf2_per_objfile *per_objfile)
 {
   do_compile_dwarf_expr_to_c (2, stream, GCC_UINTPTR, result_name, sym, pc,
-			      arch, registers_used, addr_size, op_ptr, op_end,
-			      NULL, per_cu, per_objfile);
+			      arch, registers_used, addr_size, expr, nullptr,
+			      per_cu, per_objfile);
 }
 
 /* See compile.h.  */
@@ -1165,12 +1163,11 @@ compile_dwarf_bounds_to_c (string_file *stream,
 			   struct gdbarch *arch,
 			   std::vector<bool> &registers_used,
 			   unsigned int addr_size,
-			   const gdb_byte *op_ptr, const gdb_byte *op_end,
+			   gdb::array_view<const gdb_byte> expr,
 			   dwarf2_per_cu *per_cu,
 			   dwarf2_per_objfile *per_objfile)
 {
-  do_compile_dwarf_expr_to_c (2, stream, "unsigned long ", result_name,
-			      sym, pc, arch, registers_used,
-			      addr_size, op_ptr, op_end, NULL, per_cu,
-			      per_objfile);
+  do_compile_dwarf_expr_to_c (2, stream, "unsigned long ", result_name, sym,
+			      pc, arch, registers_used, addr_size, expr,
+			      nullptr, per_cu, per_objfile);
 }

--- a/gdb/compile/compile-loc2c.c
+++ b/gdb/compile/compile-loc2c.c
@@ -123,16 +123,18 @@ llvm_user_stack_depth (dwarf_llvm_user op, const gdb_byte *op_ptr,
    TO_DO is a list of bytecodes which must be examined; it may be
    added to by this function.
    BYTE_ORDER and ADDR_SIZE describe this bytecode in the obvious way.
-   OP_PTR and OP_END are the bounds of the DWARF expression.  */
+   EXPR is the DWARF expression.  */
 
 static void
 compute_stack_depth_worker (int start, int *need_tempvar,
 			    std::vector<struct insn_info> *info,
 			    std::vector<int> *to_do,
 			    enum bfd_endian byte_order, unsigned int addr_size,
-			    const gdb_byte *op_ptr, const gdb_byte *op_end)
+			    gdb::array_view<const gdb_byte> expr)
 {
-  const gdb_byte * const base = op_ptr;
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *const op_end = expr.data () + expr.size ();
   int stack_depth;
 
   op_ptr += start;
@@ -459,7 +461,7 @@ compute_stack_depth_worker (int start, int *need_tempvar,
    generator).
    IS_TLS is an out parameter which is set if this expression refers
    to a TLS variable.
-   OP_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
    INITIAL_DEPTH is the initial depth of the DWARF expression stack.
    INFO is an array of insn_info objects, indexed by offset from the
    start of the DWARF expression.
@@ -469,14 +471,14 @@ compute_stack_depth_worker (int start, int *need_tempvar,
 static int
 compute_stack_depth (enum bfd_endian byte_order, unsigned int addr_size,
 		     int *need_tempvar, int *is_tls,
-		     const gdb_byte *op_ptr, const gdb_byte *op_end,
+		     gdb::array_view<const gdb_byte> expr,
 		     int initial_depth,
 		     std::vector<struct insn_info> *info)
 {
   std::vector<int> to_do;
-  int stack_depth, i;
+  int stack_depth;
 
-  info->resize (op_end - op_ptr);
+  info->resize (expr.size ());
 
   to_do.push_back (0);
   (*info)[0].depth = initial_depth;
@@ -487,14 +489,13 @@ compute_stack_depth (enum bfd_endian byte_order, unsigned int addr_size,
       int ndx = to_do.back ();
       to_do.pop_back ();
 
-      compute_stack_depth_worker (ndx, need_tempvar, info, &to_do,
-				  byte_order, addr_size,
-				  op_ptr, op_end);
+      compute_stack_depth_worker (ndx, need_tempvar, info, &to_do, byte_order,
+				  addr_size, expr);
     }
 
   stack_depth = 0;
   *is_tls = 0;
-  for (i = 0; i < op_end - op_ptr; ++i)
+  for (int i = 0; i < expr.size (); ++i)
     {
       if ((*info)[i].depth > stack_depth)
 	stack_depth = (*info)[i].depth;
@@ -660,7 +661,7 @@ pushf_register (int indent, string_file *stream,
 
    ADDR_SIZE is the DWARF address size to use.
 
-   OPT_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
 
    If non-NULL, INITIAL points to an initial value to write to the
    stack.  If NULL, no initial value is written.
@@ -676,7 +677,7 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 			    struct gdbarch *arch,
 			    std::vector<bool> &registers_used,
 			    unsigned int addr_size,
-			    const gdb_byte *op_ptr, const gdb_byte *op_end,
+			    gdb::array_view<const gdb_byte> expr,
 			    CORE_ADDR *initial,
 			    dwarf2_per_cu *per_cu,
 			    dwarf2_per_objfile *per_objfile)
@@ -686,7 +687,6 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
   static unsigned int scope;
 
   enum bfd_endian byte_order = gdbarch_byte_order (arch);
-  const gdb_byte * const base = op_ptr;
   int need_tempvar = 0;
   int is_tls = 0;
   std::vector<struct insn_info> info;
@@ -701,7 +701,7 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 
   stack_depth = compute_stack_depth (byte_order, addr_size,
 				     &need_tempvar, &is_tls,
-				     op_ptr, op_end, initial != NULL,
+				     expr, initial != NULL,
 				     &info);
 
   /* This is a hack until we can add a feature to glibc to let us
@@ -748,6 +748,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 
   if (initial != NULL)
     pushf (indent, stream, "%s", core_addr_to_string (*initial));
+
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = base;
+  const gdb_byte *const op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -961,8 +965,6 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	  break;
 	case DW_OP_fbreg:
 	  {
-	    const gdb_byte *datastart;
-	    size_t datalen;
 	    const struct block *b;
 	    struct symbol *framefunc;
 	    char fb_name[50];
@@ -977,8 +979,8 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    if (!framefunc)
 	      error (_("No function found for block"));
 
-	    func_get_frame_base_dwarf_block (framefunc, pc,
-					     &datastart, &datalen);
+	    auto frame_base_expr
+	      = func_get_frame_base_dwarf_block (framefunc, pc);
 
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 
@@ -987,12 +989,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    xsnprintf (fb_name, sizeof (fb_name), "__frame_base_%ld",
 		       (long) (op_ptr - base));
 
-	    do_compile_dwarf_expr_to_c (indent, stream,
-					GCC_UINTPTR, fb_name,
-					sym, pc,
-					arch, registers_used, addr_size,
-					datastart, datastart + datalen,
-					NULL, per_cu, per_objfile);
+	    do_compile_dwarf_expr_to_c (indent, stream, GCC_UINTPTR, fb_name,
+					sym, pc, arch, registers_used,
+					addr_size, frame_base_expr, nullptr,
+					per_cu, per_objfile);
 
 	    pushf (indent, stream, "%s + %s", fb_name, hex_string (offset));
 	  }
@@ -1155,11 +1155,10 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 	    int regnum;
 	    CORE_ADDR text_offset;
 	    LONGEST off;
-	    const gdb_byte *cfa_start, *cfa_end;
+	    gdb::array_view<const gdb_byte> cfa_expr;
 
-	    if (dwarf2_fetch_cfa_info (arch, pc, per_cu,
-				       &regnum, &off,
-				       &text_offset, &cfa_start, &cfa_end))
+	    if (dwarf2_fetch_cfa_info (arch, pc, per_cu, &regnum, &off,
+				       &text_offset, cfa_expr))
 	      {
 		/* Register.  */
 		pushf_register (indent, stream, registers_used, arch, regnum,
@@ -1175,12 +1174,11 @@ do_compile_dwarf_expr_to_c (int indent, string_file *stream,
 		xsnprintf (cfa_name, sizeof (cfa_name),
 			   "__cfa_%ld", (long) (op_ptr - base));
 
-		do_compile_dwarf_expr_to_c (indent, stream,
-					    GCC_UINTPTR, cfa_name,
-					    sym, pc, arch, registers_used,
-					    addr_size,
-					    cfa_start, cfa_end,
-					    &text_offset, per_cu, per_objfile);
+		do_compile_dwarf_expr_to_c (indent, stream, GCC_UINTPTR,
+					    cfa_name, sym, pc, arch,
+					    registers_used, addr_size,
+					    cfa_expr, &text_offset, per_cu,
+					    per_objfile);
 		pushf (indent, stream, "%s", cfa_name);
 	      }
 	  }
@@ -1227,13 +1225,13 @@ compile_dwarf_expr_to_c (string_file *stream, const char *result_name,
 			 struct gdbarch *arch,
 			 std::vector<bool> &registers_used,
 			 unsigned int addr_size,
-			 const gdb_byte *op_ptr, const gdb_byte *op_end,
+			 gdb::array_view<const gdb_byte> expr,
 			 dwarf2_per_cu *per_cu,
 			 dwarf2_per_objfile *per_objfile)
 {
   do_compile_dwarf_expr_to_c (2, stream, GCC_UINTPTR, result_name, sym, pc,
-			      arch, registers_used, addr_size, op_ptr, op_end,
-			      NULL, per_cu, per_objfile);
+			      arch, registers_used, addr_size, expr, nullptr,
+			      per_cu, per_objfile);
 }
 
 /* See compile.h.  */
@@ -1246,12 +1244,11 @@ compile_dwarf_bounds_to_c (string_file *stream,
 			   struct gdbarch *arch,
 			   std::vector<bool> &registers_used,
 			   unsigned int addr_size,
-			   const gdb_byte *op_ptr, const gdb_byte *op_end,
+			   gdb::array_view<const gdb_byte> expr,
 			   dwarf2_per_cu *per_cu,
 			   dwarf2_per_objfile *per_objfile)
 {
-  do_compile_dwarf_expr_to_c (2, stream, "unsigned long ", result_name,
-			      sym, pc, arch, registers_used,
-			      addr_size, op_ptr, op_end, NULL, per_cu,
-			      per_objfile);
+  do_compile_dwarf_expr_to_c (2, stream, "unsigned long ", result_name, sym,
+			      pc, arch, registers_used, addr_size, expr,
+			      nullptr, per_cu, per_objfile);
 }

--- a/gdb/compile/compile.h
+++ b/gdb/compile/compile.h
@@ -198,7 +198,7 @@ extern void eval_compile_command (struct command_line *cmd,
 
    ADDR_SIZE is the DWARF address size to use.
 
-   OPT_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
 
    PER_CU is the per-CU object used for looking up various other
    things.
@@ -213,8 +213,7 @@ extern void compile_dwarf_expr_to_c (string_file *stream,
 				     struct gdbarch *arch,
 				     std::vector<bool> &registers_used,
 				     unsigned int addr_size,
-				     const gdb_byte *op_ptr,
-				     const gdb_byte *op_end,
+				     gdb::array_view<const gdb_byte> expr,
 				     dwarf2_per_cu *per_cu,
 				     dwarf2_per_objfile *per_objfile);
 
@@ -237,7 +236,7 @@ extern void compile_dwarf_expr_to_c (string_file *stream,
 
    ADDR_SIZE is the DWARF address size to use.
 
-   OPT_PTR and OP_END are the bounds of the DWARF expression.
+   EXPR is the DWARF expression.
 
    PER_CU is the per-CU object used for looking up various other
    things.
@@ -252,8 +251,7 @@ extern void compile_dwarf_bounds_to_c (string_file *stream,
 				       struct gdbarch *arch,
 				       std::vector<bool> &registers_used,
 				       unsigned int addr_size,
-				       const gdb_byte *op_ptr,
-				       const gdb_byte *op_end,
+				       gdb::array_view<const gdb_byte> expr,
 				       dwarf2_per_cu *per_cu,
 				       dwarf2_per_objfile *per_objfile);
 

--- a/gdb/corelow.c
+++ b/gdb/corelow.c
@@ -2176,7 +2176,7 @@ gdb_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd)
 
     /* read_core_file_mappings will invoke this lambda for each mapping
        that it finds.  */
-    [&] (int num, ULONGEST start, ULONGEST end, ULONGEST file_ofs,
+    [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
 	/* Architecture-specific read_core_mapping methods are expected to

--- a/gdb/corelow.c
+++ b/gdb/corelow.c
@@ -2168,14 +2168,8 @@ gdb_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd)
   /* See linux_read_core_file_mappings() in linux-tdep.c for an example
      read_core_file_mappings method.  */
   gdbarch_read_core_file_mappings (gdbarch, cbfd,
-    /* After determining the number of mappings, read_core_file_mappings
-       will invoke this lambda.  */
-    [&] (ULONGEST)
-      {
-      },
-
-    /* read_core_file_mappings will invoke this lambda for each mapping
-       that it finds.  */
+    /* gdbarch_read_core_file_mappings will invoke this lambda for each
+       mapping that it finds.  */
     [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {

--- a/gdb/corelow.c
+++ b/gdb/corelow.c
@@ -406,12 +406,25 @@ core_target::build_file_mappings ()
   gdb::unordered_string_map<struct bfd *> bfd_map;
   gdb::unordered_set<std::string> unavailable_paths;
 
-  /* All files mapped into the core file.  The key is the filename.  */
+  /* All files mapped into the core file.  */
   std::vector<core_mapped_file> mapped_files
     = gdb_read_core_file_mappings (m_core_gdbarch, this->core_bfd ());
 
   for (const core_mapped_file &file_data : mapped_files)
     {
+      /* A mapping without a filename can still have a build-id.  Tracking
+	 these mappings is useful as when the shared libraries are loaded,
+	 if the shared library is within this anonymous region, we can
+	 validate the build-id of the shared library being loaded.  */
+      if (file_data.filename.empty ())
+	{
+	  gdb_assert (file_data.build_id != nullptr);
+	  std::vector<mem_range> ranges = file_data.mem_ranges ();
+	  m_mapped_file_info.add (nullptr, nullptr, nullptr,
+				  std::move (ranges), file_data.build_id);
+	  continue;
+	}
+
       /* If this mapped file is marked as the main executable then record
 	 the filename as we can use this later.  */
       if (file_data.is_main_exec && m_expected_exec_filename.empty ())
@@ -476,10 +489,6 @@ core_target::build_file_mappings ()
 	      gdb_assert (abfd != nullptr);
 	    }
 	}
-
-      std::vector<mem_range> ranges;
-      for (const core_mapped_file::region &region : file_data.regions)
-	ranges.emplace_back (region.start, region.end - region.start);
 
       if (expanded_fname == nullptr
 	  || abfd == nullptr
@@ -593,7 +602,7 @@ core_target::build_file_mappings ()
 	 libraries.  */
       if (file_data.build_id != nullptr)
 	{
-	  normalize_mem_ranges (&ranges);
+	  std::vector<mem_range> ranges = file_data.mem_ranges ();
 
 	  const char *actual_filename = nullptr;
 	  gdb::unique_xmalloc_ptr<char> soname;
@@ -1977,7 +1986,10 @@ maintenance_print_core_file_backed_mappings (const char *args, int from_tty)
    DT_SONAME attribute.
 
    EXPECTED_FILENAME is the name of the file that was mapped into the
-   inferior as extracted from the core file, this should never be nullptr.
+   inferior as extracted from the core file, this can be nullptr if the
+   filename is unknown.  This can happen on Linux if there is no NT_FILE
+   note, and we are building the mapped_file_info using just the segment
+   table from the core file.
 
    ACTUAL_FILENAME is the name of the actual file GDB found to provide the
    mapped file information, this can be nullptr if GDB failed to find a
@@ -2001,7 +2013,6 @@ mapped_file_info::add (const char *soname,
 		       const bfd_build_id *build_id)
 {
   gdb_assert (build_id != nullptr);
-  gdb_assert (expected_filename != nullptr);
 
   if (soname != nullptr)
     {
@@ -2021,13 +2032,17 @@ mapped_file_info::add (const char *soname,
 	m_soname_to_build_id_map[soname] = build_id;
     }
 
-  /* When the core file is initially opened and the mapped files are
-     parsed, we group the build-id information based on the file name.  As
-     a consequence, we should see each EXPECTED_FILENAME value exactly
-     once.  This means that each insertion should always succeed.  */
-  const auto inserted
-    = m_filename_to_build_id_map.emplace (expected_filename, build_id).second;
-  gdb_assert (inserted);
+  /* Ignore empty filenames.  */
+  if (expected_filename != nullptr)
+    {
+      /* When the core file is initially opened and the mapped files are
+	 parsed, we group the build-id information based on the file name.  As
+	 a consequence, we should see each EXPECTED_FILENAME value exactly
+	 once.  This means that each insertion should always succeed.  */
+      const auto inserted
+	= m_filename_to_build_id_map.emplace (expected_filename, build_id).second;
+      gdb_assert (inserted);
+    }
 
   /* Setup the reverse build-id to file name map.  */
   if (actual_filename != nullptr)
@@ -2173,9 +2188,19 @@ gdb_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd)
     [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
-	/* Architecture-specific read_core_mapping methods are expected to
-	   weed out non-file-backed mappings.  */
-	gdb_assert (filename != nullptr);
+	if (filename == nullptr)
+	  {
+	    /* A mapping without a filename MUST have a build-id, and the
+	       file_ofs MUST be 0, but the file_ofs is actually meaningless
+	       in this case.  */
+	    gdb_assert (build_id != nullptr);
+	    gdb_assert (file_ofs == 0);
+
+	    results.emplace_back ();
+	    results.back ().build_id = build_id;
+	    results.back ().regions.emplace_back (start, end, file_ofs);
+	    return;
+	  }
 
 	/* Add this mapped region to the data for FILENAME.  */
 	auto iter = mapped_files.find (filename);

--- a/gdb/corelow.c
+++ b/gdb/corelow.c
@@ -408,12 +408,25 @@ core_target::build_file_mappings ()
   gdb::unordered_string_map<struct bfd *> bfd_map;
   gdb::unordered_set<std::string> unavailable_paths;
 
-  /* All files mapped into the core file.  The key is the filename.  */
+  /* All files mapped into the core file.  */
   std::vector<core_mapped_file> mapped_files
     = gdb_read_core_file_mappings (m_core_gdbarch, this->core_bfd ());
 
   for (const core_mapped_file &file_data : mapped_files)
     {
+      /* A mapping without a filename can still have a build-id.  Tracking
+	 these mappings is useful as when the shared libraries are loaded,
+	 if the shared library is within this anonymous region, we can
+	 validate the build-id of the shared library being loaded.  */
+      if (file_data.filename.empty ())
+	{
+	  gdb_assert (file_data.build_id != nullptr);
+	  std::vector<mem_range> ranges = file_data.mem_ranges ();
+	  m_mapped_file_info.add (nullptr, nullptr, nullptr,
+				  std::move (ranges), file_data.build_id);
+	  continue;
+	}
+
       /* If this mapped file is marked as the main executable then record
 	 the filename as we can use this later.  */
       if (file_data.is_main_exec && m_expected_exec_filename.empty ())
@@ -494,10 +507,6 @@ core_target::build_file_mappings ()
 	      gdb_assert (abfd != nullptr);
 	    }
 	}
-
-      std::vector<mem_range> ranges;
-      for (const core_mapped_file::region &region : file_data.regions)
-	ranges.emplace_back (region.start, region.end - region.start);
 
       if (expanded_fname == nullptr
 	  || abfd == nullptr
@@ -611,7 +620,7 @@ core_target::build_file_mappings ()
 	 libraries.  */
       if (file_data.build_id != nullptr)
 	{
-	  normalize_mem_ranges (&ranges);
+	  std::vector<mem_range> ranges = file_data.mem_ranges ();
 
 	  const char *actual_filename = nullptr;
 	  gdb::unique_xmalloc_ptr<char> soname;
@@ -2004,7 +2013,10 @@ maintenance_print_core_file_backed_mappings (const char *args, int from_tty)
    DT_SONAME attribute.
 
    EXPECTED_FILENAME is the name of the file that was mapped into the
-   inferior as extracted from the core file, this should never be nullptr.
+   inferior as extracted from the core file, this can be nullptr if the
+   filename is unknown.  This can happen on Linux if there is no NT_FILE
+   note, and we are building the mapped_file_info using just the segment
+   table from the core file.
 
    ACTUAL_FILENAME is the name of the actual file GDB found to provide the
    mapped file information, this can be nullptr if GDB failed to find a
@@ -2028,7 +2040,6 @@ mapped_file_info::add (const char *soname,
 		       const bfd_build_id *build_id)
 {
   gdb_assert (build_id != nullptr);
-  gdb_assert (expected_filename != nullptr);
 
   if (soname != nullptr)
     {
@@ -2048,13 +2059,17 @@ mapped_file_info::add (const char *soname,
 	m_soname_to_build_id_map[soname] = build_id;
     }
 
-  /* When the core file is initially opened and the mapped files are
-     parsed, we group the build-id information based on the file name.  As
-     a consequence, we should see each EXPECTED_FILENAME value exactly
-     once.  This means that each insertion should always succeed.  */
-  const auto inserted
-    = m_filename_to_build_id_map.emplace (expected_filename, build_id).second;
-  gdb_assert (inserted);
+  /* Ignore empty filenames.  */
+  if (expected_filename != nullptr)
+    {
+      /* When the core file is initially opened and the mapped files are
+	 parsed, we group the build-id information based on the file name.  As
+	 a consequence, we should see each EXPECTED_FILENAME value exactly
+	 once.  This means that each insertion should always succeed.  */
+      const auto inserted
+	= m_filename_to_build_id_map.emplace (expected_filename, build_id).second;
+      gdb_assert (inserted);
+    }
 
   /* Setup the reverse build-id to file name map.  */
   if (actual_filename != nullptr)
@@ -2195,20 +2210,24 @@ gdb_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd)
   /* See linux_read_core_file_mappings() in linux-tdep.c for an example
      read_core_file_mappings method.  */
   gdbarch_read_core_file_mappings (gdbarch, cbfd,
-    /* After determining the number of mappings, read_core_file_mappings
-       will invoke this lambda.  */
-    [&] (ULONGEST)
-      {
-      },
-
-    /* read_core_file_mappings will invoke this lambda for each mapping
-       that it finds.  */
-    [&] (int num, ULONGEST start, ULONGEST end, ULONGEST file_ofs,
+    /* gdbarch_read_core_file_mappings will invoke this lambda for each
+       mapping that it finds.  */
+    [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
-	/* Architecture-specific read_core_mapping methods are expected to
-	   weed out non-file-backed mappings.  */
-	gdb_assert (filename != nullptr);
+	if (filename == nullptr)
+	  {
+	    /* A mapping without a filename MUST have a build-id, and the
+	       file_ofs MUST be 0, but the file_ofs is actually meaningless
+	       in this case.  */
+	    gdb_assert (build_id != nullptr);
+	    gdb_assert (file_ofs == 0);
+
+	    results.emplace_back ();
+	    results.back ().build_id = build_id;
+	    results.back ().regions.emplace_back (start, end, file_ofs);
+	    return;
+	  }
 
 	/* Add this mapped region to the data for FILENAME.  */
 	auto iter = mapped_files.find (filename);

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -7528,6 +7528,10 @@ multiple processes.
 @c This section is really only a place-holder, and needs to be expanded
 @c with more details.
 
+By default, when a thread stops to report a debugging event,
+@value{GDBN} stops all other threads as well.  This is called
+@dfn{all-stop} mode.
+
 For some multi-threaded targets, @value{GDBN} supports an optional
 mode of operation in which you can examine stopped program threads in
 the debugger while other threads continue to execute freely.  This
@@ -7546,34 +7550,22 @@ one thread while allowing others to run freely, stepping
 one thread while holding all others stopped, or stepping several threads
 independently and simultaneously.
 
-To enter non-stop mode, use this sequence of commands before you run
-or attach to your program:
-
-@smallexample
-# If using the CLI, pagination breaks non-stop.
-set pagination off
-
-# Finally, turn it on!
-set non-stop on
-@end smallexample
-
 You can use these commands to manipulate the non-stop mode setting:
 
 @table @code
 @kindex set non-stop
 @item set non-stop on
-Enable selection of non-stop mode.
+Enable non-stop mode.
 @item set non-stop off
-Disable selection of non-stop mode.
+Disable non-stop mode.  Also known as enabling all-stop mode.  This is
+the default.
 @kindex show non-stop
 @item show non-stop
 Show the current non-stop enablement setting.
 @end table
 
-Note these commands only reflect whether non-stop mode is enabled,
-not whether the currently-executing program is being run in non-stop mode.
-In particular, the @code{set non-stop} preference is only consulted when
-@value{GDBN} starts or connects to the target program, and it is generally
+Note the @code{set non-stop} preference is only consulted when
+@value{GDBN} starts or connects to the target program, and it is
 not possible to switch modes once debugging has started.  Furthermore,
 since not all targets support non-stop mode, even when you have enabled
 non-stop mode, @value{GDBN} may still fall back to all-stop operation by
@@ -42907,15 +42899,22 @@ to more easily debug problems occurring only in synchronous mode.
 @item maint set target-non-stop
 @itemx maint show target-non-stop
 
-This controls whether @value{GDBN} targets always operate in non-stop
-mode even if @code{set non-stop} is @code{off} (@pxref{Non-Stop
-Mode}).  The default is @code{auto}, meaning non-stop mode is enabled
-if supported by the target.
+This controls whether @value{GDBN} targets (e.g., the native target,
+or a remote target) operate in non-stop mode even if @code{set
+non-stop} is @code{off} (@pxref{Non-Stop Mode}).  The default is
+@code{auto}.
+
+This affects @value{GDBN} internal operation and is largely invisible
+to users.  Normally users should not need to change this setting, but
+it can be changed to more easily debug problems occurring only in a
+specific mode.
 
 @table @code
 @item maint set target-non-stop auto
 This is the default mode.  @value{GDBN} controls the target in
-non-stop mode if the target supports it.
+non-stop mode if @code{set non-stop} is @code{on}, or the target tells
+infrun that it wants to operate in non-stop mode even with @code{set
+non-stop} is set to @code{off}.
 
 @item maint set target-non-stop on
 @value{GDBN} controls the target in non-stop mode even if the target
@@ -42924,6 +42923,34 @@ does not indicate support.
 @item maint set target-non-stop off
 @value{GDBN} does not control the target in non-stop mode even if the
 target supports it.
+@end table
+
+Here is how @code{set non-stop} and @code{maint set target-non-stop}
+settings combine:
+
+@table @code
+@item @code{set non-stop off}, target operating in all-stop mode
+When a thread hits a breakpoint, finishes a step, etc., the target
+stops all threads, and reports the event to the infrun module in the
+core of @value{GDBN}.  If infrun decides the stop is not to be seen by
+the user, infrun re-resumes all threads again.  In other words, all
+threads stop and are re-resumed for every debug event, even for debug
+events that are internal and do not cause a user-visible stop.
+
+@item @code{set non-stop off}, target operating in non-stop mode
+When a thread hits a breakpoint, finishes a step, etc., the target
+does not immediately stop all other threads.  If, while processing the
+event, infrun decides the stop should be reported to the user, it then
+explicitly stops all threads, just before presenting the stop to the
+user; otherwise, infrun re-resumes the stopped thread.  This scenario
+is also called ``all-stop on top of non-stop''.
+
+@item @code{set non-stop on}, target operating in all-stop mode
+This combination is invalid.
+
+@item @code{set non-stop on}, target operating in non-stop mode
+When a thread hits a breakpoint, finishes a step, etc., neither the
+target, nor infrun stop any other thread.
 @end table
 
 @kindex maint set tui-resize-message

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -7608,6 +7608,10 @@ multiple processes.
 @c This section is really only a place-holder, and needs to be expanded
 @c with more details.
 
+By default, when a thread stops to report a debugging event,
+@value{GDBN} stops all other threads as well.  This is called
+@dfn{all-stop} mode.
+
 For some multi-threaded targets, @value{GDBN} supports an optional
 mode of operation in which you can examine stopped program threads in
 the debugger while other threads continue to execute freely.  This
@@ -7626,34 +7630,22 @@ one thread while allowing others to run freely, stepping
 one thread while holding all others stopped, or stepping several threads
 independently and simultaneously.
 
-To enter non-stop mode, use this sequence of commands before you run
-or attach to your program:
-
-@smallexample
-# If using the CLI, pagination breaks non-stop.
-set pagination off
-
-# Finally, turn it on!
-set non-stop on
-@end smallexample
-
 You can use these commands to manipulate the non-stop mode setting:
 
 @table @code
 @kindex set non-stop
 @item set non-stop on
-Enable selection of non-stop mode.
+Enable non-stop mode.
 @item set non-stop off
-Disable selection of non-stop mode.
+Disable non-stop mode.  Also known as enabling all-stop mode.  This is
+the default.
 @kindex show non-stop
 @item show non-stop
 Show the current non-stop enablement setting.
 @end table
 
-Note these commands only reflect whether non-stop mode is enabled,
-not whether the currently-executing program is being run in non-stop mode.
-In particular, the @code{set non-stop} preference is only consulted when
-@value{GDBN} starts or connects to the target program, and it is generally
+Note the @code{set non-stop} preference is only consulted when
+@value{GDBN} starts or connects to the target program, and it is
 not possible to switch modes once debugging has started.  Furthermore,
 since not all targets support non-stop mode, even when you have enabled
 non-stop mode, @value{GDBN} may still fall back to all-stop operation by
@@ -46155,15 +46147,22 @@ to more easily debug problems occurring only in synchronous mode.
 @item maint set target-non-stop
 @itemx maint show target-non-stop
 
-This controls whether @value{GDBN} targets always operate in non-stop
-mode even if @code{set non-stop} is @code{off} (@pxref{Non-Stop
-Mode}).  The default is @code{auto}, meaning non-stop mode is enabled
-if supported by the target.
+This controls whether @value{GDBN} targets (e.g., the native target,
+or a remote target) operate in non-stop mode even if @code{set
+non-stop} is @code{off} (@pxref{Non-Stop Mode}).  The default is
+@code{auto}.
+
+This affects @value{GDBN} internal operation and is largely invisible
+to users.  Normally users should not need to change this setting, but
+it can be changed to more easily debug problems occurring only in a
+specific mode.
 
 @table @code
 @item maint set target-non-stop auto
 This is the default mode.  @value{GDBN} controls the target in
-non-stop mode if the target supports it.
+non-stop mode if @code{set non-stop} is @code{on}, or the target tells
+infrun that it wants to operate in non-stop mode even with @code{set
+non-stop} is set to @code{off}.
 
 @item maint set target-non-stop on
 @value{GDBN} controls the target in non-stop mode even if the target
@@ -46172,6 +46171,34 @@ does not indicate support.
 @item maint set target-non-stop off
 @value{GDBN} does not control the target in non-stop mode even if the
 target supports it.
+@end table
+
+Here is how @code{set non-stop} and @code{maint set target-non-stop}
+settings combine:
+
+@table @code
+@item @code{set non-stop off}, target operating in all-stop mode
+When a thread hits a breakpoint, finishes a step, etc., the target
+stops all threads, and reports the event to the infrun module in the
+core of @value{GDBN}.  If infrun decides the stop is not to be seen by
+the user, infrun re-resumes all threads again.  In other words, all
+threads stop and are re-resumed for every debug event, even for debug
+events that are internal and do not cause a user-visible stop.
+
+@item @code{set non-stop off}, target operating in non-stop mode
+When a thread hits a breakpoint, finishes a step, etc., the target
+does not immediately stop all other threads.  If, while processing the
+event, infrun decides the stop should be reported to the user, it then
+explicitly stops all threads, just before presenting the stop to the
+user; otherwise, infrun re-resumes the stopped thread.  This scenario
+is also called ``all-stop on top of non-stop''.
+
+@item @code{set non-stop on}, target operating in all-stop mode
+This combination is invalid.
+
+@item @code{set non-stop on}, target operating in non-stop mode
+When a thread hits a breakpoint, finishes a step, etc., neither the
+target, nor infrun stop any other thread.
 @end table
 
 @kindex maint set tui-resize-message

--- a/gdb/doc/python.texi
+++ b/gdb/doc/python.texi
@@ -9040,8 +9040,10 @@ processes address space when the core file was created.
 A @code{gdb.CorefileMappedFile} object has the following attributes:
 
 @defvar CorefileMappedFile.filename
-This read only attribute contains a non-empty string, the file name of
-the mapped file.
+This read only attribute contains a string, the file name of the
+mapped file.  This string can be empty if @value{GDBN} was unable to
+find the name of the mapped file.  If this string is empty then
+@code{CorefileMappedFile.build_id} will not be @code{None}.
 @end defvar
 
 @defvar CorefileMappedFile.build_id
@@ -9081,7 +9083,9 @@ the inferior.
 
 @defvar CorefileMappedFileRegion.file_offset
 This read only attribute contains the offset within the mapped file
-for this mapping.
+for this mapping.  This attribute will be @code{0} if the containing
+@code{CorefileMappedFile.filename} is empty, in which case this
+attribute has no meaning.
 @end defvar
 
 @node Python Auto-loading

--- a/gdb/dwarf2/attribute.h
+++ b/gdb/dwarf2/attribute.h
@@ -33,6 +33,10 @@
 /* Blocks are a bunch of untyped bytes.  */
 struct dwarf_block
 {
+  /* Return the contents of this block.  */
+  gdb::array_view<const gdb_byte> view () const
+  { return gdb::make_array_view (data, size); }
+
   size_t size;
 
   /* Valid only if SIZE is not zero.  */

--- a/gdb/dwarf2/call-site.h
+++ b/gdb/dwarf2/call-site.h
@@ -143,6 +143,15 @@ union call_site_parameter_u
 
 struct call_site_parameter
 {
+  /* Return the DW_AT_call_value DWARF expression.  */
+  gdb::array_view<const gdb_byte> value_expr () const
+  { return gdb::make_array_view (value, value_size); }
+
+  /* Return the DW_AT_call_data_value DWARF expression.  Returns an empty
+     view if not provided by DWARF.  */
+  gdb::array_view<const gdb_byte> data_value_expr () const
+  { return gdb::make_array_view (data_value, data_value_size); }
+
   ENUM_BITFIELD (call_site_parameter_kind) kind : 2;
 
   union call_site_parameter_u u;

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -783,9 +783,8 @@ dwarf_expr_context::fetch (int n)
 
 /* See expr.h.  */
 
-void
-dwarf_expr_context::get_frame_base (const gdb_byte **start,
-				    size_t * length)
+gdb::array_view<const gdb_byte>
+dwarf_expr_context::get_frame_base ()
 {
   ensure_have_frame (this->m_frame, "DW_OP_fbreg");
 
@@ -804,9 +803,8 @@ dwarf_expr_context::get_frame_base (const gdb_byte **start,
      something has gone wrong.  */
   gdb_assert (framefunc != NULL);
 
-  func_get_frame_base_dwarf_block (framefunc,
-				   get_frame_address_in_block (this->m_frame),
-				   start, length);
+  return func_get_frame_base_dwarf_block
+    (framefunc, get_frame_address_in_block (this->m_frame));
 }
 
 /* See expr.h.  */
@@ -848,7 +846,7 @@ dwarf_expr_context::dwarf_call (cu_offset die_cu_off)
   /* DW_OP_call_ref is currently not supported.  */
   gdb_assert (block.per_cu == this->m_per_cu);
 
-  this->eval (block.data, block.size);
+  this->eval (block.expr ());
 }
 
 /* See expr.h.  */
@@ -921,13 +919,12 @@ dwarf_expr_context::push_dwarf_reg_entry_value (call_site_parameter_kind kind,
     = dwarf_expr_reg_to_entry_parameter (this->m_frame, kind, kind_u,
 					 &caller_per_cu,
 					 &caller_per_objfile);
-  const gdb_byte *data_src
-    = deref_size == -1 ? parameter->value : parameter->data_value;
-  size_t size
-    = deref_size == -1 ? parameter->value_size : parameter->data_value_size;
+  auto expr = (deref_size == -1
+	       ? parameter->value_expr ()
+	       : parameter->data_value_expr ());
 
   /* DEREF_SIZE size is not verified here.  */
-  if (data_src == nullptr)
+  if (expr.empty ())
     throw_error (NO_ENTRY_VALUE_ERROR,
 		 _("Cannot resolve DW_AT_call_data_value"));
 
@@ -949,7 +946,7 @@ dwarf_expr_context::push_dwarf_reg_entry_value (call_site_parameter_kind kind,
   scoped_restore save_addr_size = make_scoped_restore (&this->m_addr_size);
   this->m_addr_size = this->m_per_cu->addr_size ();
 
-  this->eval (data_src, size);
+  this->eval (expr);
 }
 
 /* See expr.h.  */
@@ -1119,8 +1116,8 @@ dwarf_expr_context::fetch_result (struct type *type, struct type *subobj_type,
 /* See expr.h.  */
 
 value *
-dwarf_expr_context::evaluate (const gdb_byte *addr, size_t len, bool as_lval,
-			      dwarf2_per_cu *per_cu,
+dwarf_expr_context::evaluate (gdb::array_view<const gdb_byte> expr,
+			      bool as_lval, dwarf2_per_cu *per_cu,
 			      const frame_info_ptr &frame,
 			      const struct property_addr_info *addr_info,
 			      struct type *type, struct type *subobj_type,
@@ -1130,7 +1127,7 @@ dwarf_expr_context::evaluate (const gdb_byte *addr, size_t len, bool as_lval,
   this->m_frame = frame;
   this->m_addr_info = addr_info;
 
-  eval (addr, len);
+  eval (expr);
   return fetch_result (type, subobj_type, subobj_offset, as_lval);
 }
 
@@ -1285,14 +1282,14 @@ dwarf_expr_context::add_piece (ULONGEST size, ULONGEST offset,
     }
 }
 
-/* Evaluate the expression at ADDR (LEN bytes long).  */
+/* Evaluate the expression EXPR.  */
 
 void
-dwarf_expr_context::eval (const gdb_byte *addr, size_t len)
+dwarf_expr_context::eval (gdb::array_view<const gdb_byte> expr)
 {
   int old_recursion_depth = this->m_recursion_depth;
 
-  execute_stack_op (addr, addr + len);
+  execute_stack_op (expr);
 
   /* RECURSION_DEPTH becomes invalid if an exception was thrown here.  */
 
@@ -1365,13 +1362,15 @@ base_types_equal_p (struct type *t1, struct type *t2)
   return t1->length () == t2->length ();
 }
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_reg* return the
+/* If BLOCK contains DW_FORM_block* with single DW_OP_reg* return the
    DWARF register number.  Otherwise return -1.  */
 
 int
-dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end)
+dwarf_block_to_dwarf_reg (gdb::array_view<const gdb_byte> block)
 {
   uint64_t dwarf_reg;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return -1;
@@ -1406,17 +1405,19 @@ dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end)
   return dwarf_reg;
 }
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with just DW_OP_breg*(0) and
-   DW_OP_deref* return the DWARF register number.  Otherwise return -1.
-   DEREF_SIZE_RETURN contains -1 for DW_OP_deref; otherwise it contains the
-   size from DW_OP_deref_size.  */
+/* If BLOCK contains DW_FORM_block* with just DW_OP_breg*(0) and DW_OP_deref*
+   return the DWARF register number.  Otherwise return -1.  DEREF_SIZE_RETURN
+   contains -1 for DW_OP_deref; otherwise it contains the size from
+   DW_OP_deref_size.  */
 
 int
-dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf, const gdb_byte *buf_end,
+dwarf_block_to_dwarf_reg_deref (gdb::array_view<const gdb_byte> block,
 				CORE_ADDR *deref_size_return)
 {
   uint64_t dwarf_reg;
   int64_t offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return -1;
@@ -1470,10 +1471,12 @@ dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf, const gdb_byte *buf_end,
 /* See expr.h.  */
 
 bool
-dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
+dwarf_block_to_fb_offset (gdb::array_view<const gdb_byte> block,
 			  CORE_ADDR *fb_offset_return)
 {
   int64_t fb_offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return false;
@@ -1495,11 +1498,14 @@ dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
 /* See expr.h.  */
 
 bool
-dwarf_block_to_sp_offset (struct gdbarch *gdbarch, const gdb_byte *buf,
-			  const gdb_byte *buf_end, CORE_ADDR *sp_offset_return)
+dwarf_block_to_sp_offset (struct gdbarch *gdbarch,
+			  gdb::array_view<const gdb_byte> block,
+			  CORE_ADDR *sp_offset_return)
 {
   uint64_t dwarf_reg;
   int64_t sp_offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return false;
@@ -1555,11 +1561,10 @@ trivial_entry_value (frame_info_ptr frame)
 }
 
 /* The engine for the expression evaluator.  Using the context in this
-   object, evaluate the expression between OP_PTR and OP_END.  */
+   object, evaluate the expression EXPR.  */
 
 void
-dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
-				      const gdb_byte *op_end)
+dwarf_expr_context::execute_stack_op (gdb::array_view<const gdb_byte> expr)
 {
   gdbarch *arch = this->m_per_objfile->objfile->arch ();
   bfd_endian byte_order = gdbarch_byte_order (arch);
@@ -1579,6 +1584,9 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
     error (_("DWARF-2 expression error: Loop detected (%d)."),
 	   this->m_recursion_depth);
   this->m_recursion_depth++;
+
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -1880,9 +1888,6 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 	  break;
 	case DW_OP_fbreg:
 	  {
-	    const gdb_byte *datastart;
-	    size_t datalen;
-
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 
 	    /* Rather than create a whole new context, we simply
@@ -1895,8 +1900,7 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 	    /* FIXME: cagney/2003-03-26: This code should be using
 	       get_frame_base_address(), and then implement a dwarf2
 	       specific this_base method.  */
-	    this->get_frame_base (&datastart, &datalen);
-	    eval (datastart, datalen);
+	    eval (this->get_frame_base ());
 	    if (this->m_location == DWARF_VALUE_MEMORY)
 	      result = fetch_address (0);
 	    else if (this->m_location == DWARF_VALUE_REGISTER)
@@ -2310,7 +2314,8 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 	    if (op_ptr + len > op_end)
 	      error (_("DW_OP_entry_value: too few bytes available."));
 
-	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (op_ptr, op_ptr + len);
+	    auto entry_value_expr = gdb::make_array_view (op_ptr, len);
+	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (entry_value_expr);
 	    if (kind_u.dwarf_reg != -1)
 	      {
 		op_ptr += len;
@@ -2331,8 +2336,7 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 		goto no_push;
 	      }
 
-	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg_deref (op_ptr,
-							       op_ptr + len,
+	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg_deref (entry_value_expr,
 							       &deref_size);
 	    if (kind_u.dwarf_reg != -1)
 	      {

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -4829,7 +4829,7 @@ dwarf_expr_context::execute_stack_op (gdb::array_view<const gdb_byte> expr)
 /* See expr.h.  */
 
 value *
-dwarf2_evaluate (const gdb_byte *addr, size_t len, bool as_lval,
+dwarf2_evaluate (gdb::array_view<const gdb_byte> expr, bool as_lval,
 		 dwarf2_per_objfile *per_objfile, dwarf2_per_cu *per_cu,
 		 const frame_info_ptr &frame, int addr_size,
 		 std::vector<value *> *init_values,
@@ -4839,8 +4839,7 @@ dwarf2_evaluate (const gdb_byte *addr, size_t len, bool as_lval,
 {
   dwarf_expr_context ctx (per_objfile, addr_size);
 
-  return ctx.evaluate ({addr, len}, as_lval, per_cu,
-		       frame, init_values, addr_info,
+  return ctx.evaluate (expr, as_lval, per_cu, frame, init_values, addr_info,
 		       type, subobj_type, subobj_offset);
 }
 

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -2773,16 +2773,15 @@ struct dwarf_expr_context
   dwarf_expr_context (struct dwarf2_per_objfile *per_objfile,
 		      int addr_size);
 
-  /* Evaluate the expression at ADDR (LEN bytes long) in a given PER_CU
-     FRAME context.  INIT_VALUES vector contains values that are
-     expected to be pushed on a DWARF expression stack before the
-     evaluation.  AS_LVAL defines if the returned struct value is
-     expected to be a value or a location description.  Where TYPE,
-     SUBOBJ_TYPE and SUBOBJ_OFFSET describe expected struct value
-     representation of the evaluation result.  The ADDR_INFO property
-     can be specified to override the range of memory addresses with
-     the passed in buffer.  */
-  struct value *evaluate (const gdb_byte *addr, size_t len, bool as_lval,
+  /* Evaluate the expression EXPR in a given PER_CU FRAME context.
+     INIT_VALUES vector contains values that are expected to be pushed
+     on a DWARF expression stack before the evaluation.  AS_LVAL defines
+     if the returned struct value is expected to be a value or a location
+     description.  Where TYPE, SUBOBJ_TYPE and SUBOBJ_OFFSET describe
+     expected struct value representation of the evaluation result.
+     The ADDR_INFO property can be specified to override the range
+     of memory addresses with the passed in buffer.  */
+  struct value *evaluate (gdb::array_view<const gdb_byte> expr, bool as_lval,
 			  dwarf2_per_cu *per_cu,
 			  const frame_info_ptr &frame,
 			  std::vector<value *> *init_values,
@@ -2822,8 +2821,8 @@ private:
      struct value object.  */
   location_scope m_scope = LOCATION_SCOPE_INFERIOR;
 
-  /* Evaluate the expression at ADDR (LEN bytes long).  */
-  void eval (const gdb_byte *addr, size_t len);
+  /* Evaluate the expression EXPR.  */
+  void eval (gdb::array_view<const gdb_byte> expr);
 
   /* Return the type used for DWARF operations where the type is
      unspecified in the DWARF spec.  Only certain sizes are
@@ -2898,8 +2897,8 @@ private:
 					 const gdb_byte *op_end);
 
   /* The engine for the expression evaluator.  Using the context in this
-     object, evaluate the expression between OP_PTR and OP_END.  */
-  void execute_stack_op (const gdb_byte *op_ptr, const gdb_byte *op_end);
+     object, evaluate the expression EXPR.  */
+  void execute_stack_op (gdb::array_view<const gdb_byte> expr);
 
   /* Pop the top item off of the stack.  */
   void pop ();
@@ -2915,10 +2914,10 @@ private:
   value *fetch_result (struct type *type, struct type *subobj_type,
 		       LONGEST subobj_offset, bool as_lval);
 
-  /* Return the location expression for the frame base attribute, in
-     START and LENGTH.  The result must be live until the current
-     expression evaluation is complete.  */
-  void get_frame_base (const gdb_byte **start, size_t *length);
+  /* Return the location expression for the frame base attribute.
+     The result must be live until the current expression evaluation
+     is complete.  */
+  gdb::array_view<const gdb_byte> get_frame_base ();
 
   /* Return the base type given by the indicated DIE at DIE_CU_OFF.
      This can throw an exception if the DIE is invalid or does not
@@ -2985,9 +2984,10 @@ dwarf_expr_context::fetch (int n)
   return this->m_stack[this->m_stack.size () - (1 + n)];
 }
 
-void
-dwarf_expr_context::get_frame_base (const gdb_byte **start,
-				    size_t * length)
+/* See expr.h.  */
+
+gdb::array_view<const gdb_byte>
+dwarf_expr_context::get_frame_base ()
 {
   ensure_have_frame (this->m_frame, "DW_OP_fbreg");
 
@@ -3006,9 +3006,8 @@ dwarf_expr_context::get_frame_base (const gdb_byte **start,
      something has gone wrong.  */
   gdb_assert (framefunc != NULL);
 
-  func_get_frame_base_dwarf_block (framefunc,
-				   get_frame_address_in_block (this->m_frame),
-				   start, length);
+  return func_get_frame_base_dwarf_block
+    (framefunc, get_frame_address_in_block (this->m_frame));
 }
 
 type *
@@ -3045,7 +3044,7 @@ dwarf_expr_context::dwarf_call (cu_offset die_cu_off)
   /* DW_OP_call_ref is currently not supported.  */
   gdb_assert (block.per_cu == this->m_per_cu);
 
-  this->eval (block.data, block.size);
+  this->eval (block.expr ());
 }
 
 void
@@ -3062,13 +3061,12 @@ dwarf_expr_context::push_dwarf_reg_entry_value
     = dwarf_expr_reg_to_entry_parameter (this->m_frame, kind, kind_u,
 					 &caller_per_cu,
 					 &caller_per_objfile);
-  const gdb_byte *data_src
-    = deref_size == -1 ? parameter->value : parameter->data_value;
-  size_t size
-    = deref_size == -1 ? parameter->value_size : parameter->data_value_size;
+  auto expr = (deref_size == -1
+	       ? parameter->value_expr ()
+	       : parameter->data_value_expr ());
 
   /* DEREF_SIZE size is not verified here.  */
-  if (data_src == nullptr)
+  if (expr.empty ())
     throw_error (NO_ENTRY_VALUE_ERROR,
 		 _("Cannot resolve DW_AT_call_data_value"));
 
@@ -3089,7 +3087,7 @@ dwarf_expr_context::push_dwarf_reg_entry_value
   scoped_restore save_addr_size = make_scoped_restore (&this->m_addr_size);
   this->m_addr_size = this->m_per_cu->addr_size ();
 
-  this->eval (data_src, size);
+  this->eval (expr);
 }
 
 value *
@@ -3122,8 +3120,8 @@ dwarf_expr_context::fetch_result (struct type *type, struct type *subobj_type,
 }
 
 value *
-dwarf_expr_context::evaluate (const gdb_byte *addr, size_t len, bool as_lval,
-			      dwarf2_per_cu *per_cu,
+dwarf_expr_context::evaluate (gdb::array_view<const gdb_byte> expr,
+			      bool as_lval, dwarf2_per_cu *per_cu,
 			      const frame_info_ptr &frame,
 			      std::vector<value *> *init_values,
 			      const property_addr_info *addr_info,
@@ -3139,7 +3137,7 @@ dwarf_expr_context::evaluate (const gdb_byte *addr, size_t len, bool as_lval,
     for (unsigned int i = 0; i < init_values->size (); i++)
       push (gdb_value_to_dwarf_entry (arch, (*init_values)[i]));
 
-  eval (addr, len);
+  eval (expr);
   return fetch_result (type, subobj_type, subobj_offset, as_lval);
 }
 
@@ -3338,12 +3336,14 @@ dwarf_expr_context::create_extend_composite (ULONGEST piece_bit_size,
   return composite;
 }
 
+/* Evaluate the expression EXPR.  */
+
 void
-dwarf_expr_context::eval (const gdb_byte *addr, size_t len)
+dwarf_expr_context::eval (gdb::array_view<const gdb_byte> expr)
 {
   int old_recursion_depth = this->m_recursion_depth;
 
-  execute_stack_op (addr, addr + len);
+  execute_stack_op (expr);
 
   /* RECURSION_DEPTH becomes invalid if an exception was thrown here.  */
 
@@ -3418,9 +3418,11 @@ base_types_equal_p (struct type *t1, struct type *t2)
 /* See expr.h.  */
 
 int
-dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end)
+dwarf_block_to_dwarf_reg (gdb::array_view<const gdb_byte> block)
 {
   uint64_t dwarf_reg;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return -1;
@@ -3458,11 +3460,13 @@ dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end)
 /* See expr.h.  */
 
 int
-dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf, const gdb_byte *buf_end,
+dwarf_block_to_dwarf_reg_deref (gdb::array_view<const gdb_byte> block,
 				CORE_ADDR *deref_size_return)
 {
   uint64_t dwarf_reg;
   int64_t offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return -1;
@@ -3516,10 +3520,12 @@ dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf, const gdb_byte *buf_end,
 /* See expr.h.  */
 
 bool
-dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
+dwarf_block_to_fb_offset (gdb::array_view<const gdb_byte> block,
 			  CORE_ADDR *fb_offset_return)
 {
   int64_t fb_offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return false;
@@ -3541,11 +3547,14 @@ dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
 /* See expr.h.  */
 
 bool
-dwarf_block_to_sp_offset (struct gdbarch *gdbarch, const gdb_byte *buf,
-			  const gdb_byte *buf_end, CORE_ADDR *sp_offset_return)
+dwarf_block_to_sp_offset (struct gdbarch *gdbarch,
+			  gdb::array_view<const gdb_byte> block,
+			  CORE_ADDR *sp_offset_return)
 {
   uint64_t dwarf_reg;
   int64_t sp_offset;
+  const gdb_byte *buf = block.data ();
+  const gdb_byte *const buf_end = block.data () + block.size ();
 
   if (buf_end <= buf)
     return false;
@@ -3823,8 +3832,7 @@ trivial_entry_value (frame_info_ptr frame)
 }
 
 void
-dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
-				      const gdb_byte *op_end)
+dwarf_expr_context::execute_stack_op (gdb::array_view<const gdb_byte> expr)
 {
   gdbarch *arch = this->m_per_objfile->objfile->arch ();
   bfd_endian byte_order = gdbarch_byte_order (arch);
@@ -3841,6 +3849,9 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
     error (_("DWARF-2 expression error: Loop detected (%d)."),
 	   this->m_recursion_depth);
   this->m_recursion_depth++;
+
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -4170,11 +4181,7 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 	      = std::move (this->m_stack);
 	    this->m_stack.clear ();
 
-	    const gdb_byte *datastart;
-	    size_t datalen;
-
-	    this->get_frame_base (&datastart, &datalen);
-	    eval (datastart, datalen);
+	    eval (this->get_frame_base ());
 	    result_entry = fetch (0);
 
 	    auto reg_loc
@@ -4624,7 +4631,8 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 	    if (op_ptr + len > op_end)
 	      error (_("DW_OP_entry_value: too few bytes available."));
 
-	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (op_ptr, op_ptr + len);
+	    auto entry_value_expr = gdb::make_array_view (op_ptr, len);
+	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (entry_value_expr);
 	    if (kind_u.dwarf_reg != -1)
 	      {
 		op_ptr += len;
@@ -4644,8 +4652,7 @@ dwarf_expr_context::execute_stack_op (const gdb_byte *op_ptr,
 		goto no_push;
 	      }
 
-	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg_deref (op_ptr,
-							       op_ptr + len,
+	    kind_u.dwarf_reg = dwarf_block_to_dwarf_reg_deref (entry_value_expr,
 							       &deref_size);
 	    if (kind_u.dwarf_reg != -1)
 	      {
@@ -4832,7 +4839,7 @@ dwarf2_evaluate (const gdb_byte *addr, size_t len, bool as_lval,
 {
   dwarf_expr_context ctx (per_objfile, addr_size);
 
-  return ctx.evaluate (addr, len, as_lval, per_cu,
+  return ctx.evaluate ({addr, len}, as_lval, per_cu,
 		       frame, init_values, addr_info,
 		       type, subobj_type, subobj_offset);
 }

--- a/gdb/dwarf2/expr.h
+++ b/gdb/dwarf2/expr.h
@@ -129,8 +129,7 @@ struct dwarf_expr_context
 
   void push_address (CORE_ADDR value, bool in_stack_memory);
 
-  /* Evaluate the expression at ADDR (LEN bytes long) in a given PER_CU
-     and FRAME context.
+  /* Evaluate expression EXPR in a given PER_CU and FRAME context.
 
      AS_LVAL defines if the returned struct value is expected to be a
      value (false) or a location description (true).
@@ -140,7 +139,7 @@ struct dwarf_expr_context
 
      The ADDR_INFO property can be specified to override the range of
      memory addresses with the passed in buffer.  */
-  value *evaluate (const gdb_byte *addr, size_t len, bool as_lval,
+  value *evaluate (gdb::array_view<const gdb_byte> expr, bool as_lval,
 		   dwarf2_per_cu *per_cu, const frame_info_ptr &frame,
 		   const struct property_addr_info *addr_info = nullptr,
 		   struct type *type = nullptr,
@@ -208,12 +207,12 @@ private:
   /* Property address info used for the evaluation.  */
   const struct property_addr_info *m_addr_info = nullptr;
 
-  void eval (const gdb_byte *addr, size_t len);
+  void eval (gdb::array_view<const gdb_byte> expr);
   struct type *address_type () const;
   void push (struct value *value, bool in_stack_memory);
   bool stack_empty_p () const;
   void add_piece (ULONGEST size, ULONGEST offset, enum dwarf_location_atom op);
-  void execute_stack_op (const gdb_byte *op_ptr, const gdb_byte *op_end);
+  void execute_stack_op (gdb::array_view<const gdb_byte> expr);
   void pop ();
   struct value *fetch (int n);
   CORE_ADDR fetch_address (int n);
@@ -227,10 +226,10 @@ private:
   value *fetch_result (struct type *type, struct type *subobj_type,
 		       LONGEST subobj_offset, bool as_lval);
 
-  /* Return the location expression for the frame base attribute, in
-     START and LENGTH.  The result must be live until the current
-     expression evaluation is complete.  */
-  void get_frame_base (const gdb_byte **start, size_t *length);
+  /* Return the location expression for the frame base attribute.  The
+     result must be live until the current expression evaluation is
+     complete.  */
+  gdb::array_view<const gdb_byte> get_frame_base ();
 
   /* Return the base type given by the indicated DIE at DIE_CU_OFF.
      This can throw an exception if the DIE is invalid or does not
@@ -269,25 +268,24 @@ CORE_ADDR read_addr_from_reg (const frame_info_ptr &frame, int reg);
 void dwarf_expr_require_composition (const gdb_byte *, const gdb_byte *,
 				     const char *);
 
-int dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end);
+int dwarf_block_to_dwarf_reg (gdb::array_view<const gdb_byte> block);
 
-int dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf,
-				    const gdb_byte *buf_end,
+int dwarf_block_to_dwarf_reg_deref (gdb::array_view<const gdb_byte> block,
 				    CORE_ADDR *deref_size_return);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_fbreg(X) fill
-   in FB_OFFSET_RETURN with the X offset and return true.  Otherwise return
+/* If BLOCK contains DW_FORM_block* with single DW_OP_fbreg(X) fill in
+   FB_OFFSET_RETURN with the X offset and return true.  Otherwise return
    false.  */
 
-bool dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
+bool dwarf_block_to_fb_offset (gdb::array_view<const gdb_byte> block,
 			       CORE_ADDR *fb_offset_return);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_bregSP(X) fill
-   in SP_OFFSET_RETURN with the X offset and return true.  Otherwise return
+/* If BLOCK contains DW_FORM_block* with single DW_OP_bregSP(X) fill in
+   SP_OFFSET_RETURN with the X offset and return true.  Otherwise return
    false.  The matched SP register number depends on GDBARCH.  */
 
-bool dwarf_block_to_sp_offset (struct gdbarch *gdbarch, const gdb_byte *buf,
-			       const gdb_byte *buf_end,
+bool dwarf_block_to_sp_offset (struct gdbarch *gdbarch,
+			       gdb::array_view<const gdb_byte> block,
 			       CORE_ADDR *sp_offset_return);
 
 /* Wrappers around the leb128 reader routines to simplify them for our

--- a/gdb/dwarf2/expr.h
+++ b/gdb/dwarf2/expr.h
@@ -39,7 +39,7 @@ struct dwarf2_per_objfile;
    expected struct value representation of the evaluation result.  The
    ADDR_INFO property can be specified to override the range of memory
    addresses with the passed in buffer.  */
-value *dwarf2_evaluate (const gdb_byte *addr, size_t len, bool as_lval,
+value *dwarf2_evaluate (gdb::array_view<const gdb_byte> expr, bool as_lval,
 			dwarf2_per_objfile *per_objfile,
 			dwarf2_per_cu *per_cu,
 			const frame_info_ptr &frame, int addr_size,

--- a/gdb/dwarf2/expr.h
+++ b/gdb/dwarf2/expr.h
@@ -29,9 +29,9 @@
 
 struct dwarf2_per_objfile;
 
-/* Evaluate the expression at ADDR (LEN bytes long) in a given PER_CU
-   FRAME context.  The PER_OBJFILE contains a pointer to the PER_BFD
-   information.  ADDR_SIZE defines a size of the DWARF generic type.
+/* Evaluate the expression EXPR in a given PER_CU FRAME context.  The
+   PER_OBJFILE contains a pointer to the PER_BFD information.
+   ADDR_SIZE defines a size of the DWARF generic type.
    INIT_VALUES vector contains values that are expected to be pushed
    on a DWARF expression stack before the evaluation.  AS_LVAL defines
    if the returned struct value is expected to be a value or a location
@@ -59,29 +59,28 @@ type *address_type (gdbarch *arch, int addr_size);
 void dwarf_expr_require_composition (const gdb_byte *, const gdb_byte *,
 				     const char *);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_reg* return the
+/* If BLOCK contains DW_FORM_block* with single DW_OP_reg* return the
    DWARF register number.  Otherwise return -1.  */
-int dwarf_block_to_dwarf_reg (const gdb_byte *buf, const gdb_byte *buf_end);
+int dwarf_block_to_dwarf_reg (gdb::array_view<const gdb_byte> block);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with just DW_OP_breg*(0) and
+/* If BLOCK contains DW_FORM_block* with just DW_OP_breg*(0) and
    DW_OP_deref* return the DWARF register number.  Otherwise return -1.
    DEREF_SIZE_RETURN contains -1 for DW_OP_deref; otherwise it contains the
    size from DW_OP_deref_size.  */
-int dwarf_block_to_dwarf_reg_deref (const gdb_byte *buf,
-				    const gdb_byte *buf_end,
+int dwarf_block_to_dwarf_reg_deref (gdb::array_view<const gdb_byte> block,
 				    CORE_ADDR *deref_size_return);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_fbreg(X) fill
-   in FB_OFFSET_RETURN with the X offset and return true.  Otherwise return
+/* If BLOCK contains DW_FORM_block* with single DW_OP_fbreg(X) fill in
+   FB_OFFSET_RETURN with the X offset and return true.  Otherwise return
    false.  */
-bool dwarf_block_to_fb_offset (const gdb_byte *buf, const gdb_byte *buf_end,
+bool dwarf_block_to_fb_offset (gdb::array_view<const gdb_byte> block,
 			       CORE_ADDR *fb_offset_return);
 
-/* If <BUF..BUF_END] contains DW_FORM_block* with single DW_OP_bregSP(X) fill
-   in SP_OFFSET_RETURN with the X offset and return true.  Otherwise return
+/* If BLOCK contains DW_FORM_block* with single DW_OP_bregSP(X) fill in
+   SP_OFFSET_RETURN with the X offset and return true.  Otherwise return
    false.  The matched SP register number depends on GDBARCH.  */
-bool dwarf_block_to_sp_offset (struct gdbarch *gdbarch, const gdb_byte *buf,
-			       const gdb_byte *buf_end,
+bool dwarf_block_to_sp_offset (struct gdbarch *gdbarch,
+			       gdb::array_view<const gdb_byte> block,
 			       CORE_ADDR *sp_offset_return);
 
 /* Wrappers around the leb128 reader routines to simplify them for our

--- a/gdb/dwarf2/frame.c
+++ b/gdb/dwarf2/frame.c
@@ -183,11 +183,6 @@ static ULONGEST read_encoded_value (struct comp_unit *unit, gdb_byte encoding,
 				    int ptr_len, const gdb_byte *buf,
 				    unsigned int *bytes_read_ptr,
 				    unrelocated_addr func_base);
-
-
-/* Store the length the expression for the CFA in the `cfa_reg' field,
-   which is unused in that case.  */
-#define cfa_exp_len cfa_reg
 
 dwarf2_frame_state::dwarf2_frame_state (CORE_ADDR pc_, struct dwarf2_cie *cie)
   : pc (pc_), data_align (cie->data_alignment_factor),
@@ -228,7 +223,7 @@ register %s (#%d) at %s"),
 }
 
 static CORE_ADDR
-execute_stack_op (const gdb_byte *exp, ULONGEST len, int addr_size,
+execute_stack_op (gdb::array_view<const gdb_byte> expr, int addr_size,
 		  const frame_info_ptr &this_frame, CORE_ADDR initial,
 		  int initial_in_stack_memory, dwarf2_per_objfile *per_objfile)
 {
@@ -236,7 +231,7 @@ execute_stack_op (const gdb_byte *exp, ULONGEST len, int addr_size,
   scoped_value_mark free_values;
 
   ctx.push_address (initial, initial_in_stack_memory);
-  value *result_val = ctx.evaluate (exp, len, true, nullptr, this_frame);
+  value *result_val = ctx.evaluate (expr, true, nullptr, this_frame);
 
   if (result_val->lval () == lval_memory)
     return result_val->address ();
@@ -408,10 +403,9 @@ bad CFI data; mismatched DW_CFA_restore_state at %s"),
 
 	    case DW_CFA_def_cfa_expression:
 	      insn_ptr = safe_read_uleb128 (insn_ptr, insn_end, &utmp);
-	      fs->regs.cfa_exp_len = utmp;
-	      fs->regs.cfa_exp = insn_ptr;
+	      fs->regs.cfa_exp = gdb::make_array_view (insn_ptr, utmp);
 	      fs->regs.cfa_how = CFA_EXP;
-	      insn_ptr += fs->regs.cfa_exp_len;
+	      insn_ptr += utmp;
 	      break;
 
 	    case DW_CFA_expression:
@@ -571,7 +565,7 @@ execute_cfa_program_test (struct gdbarch *gdbarch)
   SELF_CHECK (fs.regs.cfa_reg == 1);
   SELF_CHECK (fs.regs.cfa_offset == 4);
   SELF_CHECK (fs.regs.cfa_how == CFA_REG_OFFSET);
-  SELF_CHECK (fs.regs.cfa_exp == NULL);
+  SELF_CHECK (fs.regs.cfa_exp.empty ());
   SELF_CHECK (fs.regs.prev == NULL);
 }
 
@@ -759,8 +753,7 @@ bool
 dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
 		       dwarf2_per_cu *data, int *regnum_out,
 		       LONGEST *offset_out, CORE_ADDR *text_offset_out,
-		       const gdb_byte **cfa_start_out,
-		       const gdb_byte **cfa_end_out)
+		       gdb::array_view<const gdb_byte> &cfa_expr_out)
 {
   struct dwarf2_fde *fde;
   dwarf2_per_objfile *per_objfile;
@@ -811,8 +804,7 @@ dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
 
     case CFA_EXP:
       *text_offset_out = per_objfile->objfile->text_section_offset ();
-      *cfa_start_out = fs.regs.cfa_exp;
-      *cfa_end_out = fs.regs.cfa_exp + fs.regs.cfa_exp_len;
+      cfa_expr_out = fs.regs.cfa_exp;
       return false;
 
     default:
@@ -978,10 +970,8 @@ dwarf2_frame_cache (const frame_info_ptr &this_frame, void **this_cache)
 	  break;
 
 	case CFA_EXP:
-	  cache->cfa =
-	    execute_stack_op (fs.regs.cfa_exp, fs.regs.cfa_exp_len,
-			      cache->addr_size, this_frame, 0, 0,
-			      cache->per_objfile);
+	  cache->cfa = execute_stack_op (fs.regs.cfa_exp, cache->addr_size,
+					 this_frame, 0, 0, cache->per_objfile);
 	  break;
 
 	default:
@@ -1166,10 +1156,8 @@ dwarf2_frame_prev_register (const frame_info_ptr &this_frame, void **this_cache,
       return frame_unwind_got_register (this_frame, regnum, realnum);
 
     case DWARF2_FRAME_REG_SAVED_EXP:
-      addr = execute_stack_op (cache->reg[regnum].loc.exp.start,
-			       cache->reg[regnum].loc.exp.len,
-			       cache->addr_size,
-			       this_frame, cache->cfa, 1,
+      addr = execute_stack_op (cache->reg[regnum].loc.exp.view (),
+			       cache->addr_size, this_frame, cache->cfa, 1,
 			       cache->per_objfile);
       return frame_unwind_got_memory (this_frame, regnum, addr);
 
@@ -1178,10 +1166,8 @@ dwarf2_frame_prev_register (const frame_info_ptr &this_frame, void **this_cache,
       return frame_unwind_got_constant (this_frame, regnum, addr);
 
     case DWARF2_FRAME_REG_SAVED_VAL_EXP:
-      addr = execute_stack_op (cache->reg[regnum].loc.exp.start,
-			       cache->reg[regnum].loc.exp.len,
-			       cache->addr_size,
-			       this_frame, cache->cfa, 1,
+      addr = execute_stack_op (cache->reg[regnum].loc.exp.view (),
+			       cache->addr_size, this_frame, cache->cfa, 1,
 			       cache->per_objfile);
       return frame_unwind_got_constant (this_frame, regnum, addr);
 

--- a/gdb/dwarf2/frame.c
+++ b/gdb/dwarf2/frame.c
@@ -252,9 +252,8 @@ execute_stack_op (gdb::array_view<const gdb_byte> expr, int addr_size,
   init_values.push_back (init_value);
 
   value *result_val
-    = dwarf2_evaluate (expr.data (), expr.size (), as_lval, per_objfile,
-		       nullptr, this_frame, addr_size, &init_values, nullptr,
-		       type);
+    = dwarf2_evaluate (expr, as_lval, per_objfile, nullptr, this_frame,
+		       addr_size, &init_values, nullptr, type);
 
   /* We need to clean up all the values that are not needed any more.
      The problem with a value_ref_ptr class is that it disconnects the

--- a/gdb/dwarf2/frame.c
+++ b/gdb/dwarf2/frame.c
@@ -184,11 +184,6 @@ static ULONGEST read_encoded_value (struct comp_unit *unit, gdb_byte encoding,
 				    int ptr_len, const gdb_byte *buf,
 				    unsigned int *bytes_read_ptr,
 				    unrelocated_addr func_base);
-
-
-/* Store the length the expression for the CFA in the `cfa_reg' field,
-   which is unused in that case.  */
-#define cfa_exp_len cfa_reg
 
 dwarf2_frame_state::dwarf2_frame_state (CORE_ADDR pc_, struct dwarf2_cie *cie)
   : pc (pc_), data_align (cie->data_alignment_factor),
@@ -241,7 +236,7 @@ register %s (#%d) at %s"),
 }
 
 static value *
-execute_stack_op (const gdb_byte *exp, ULONGEST len, int addr_size,
+execute_stack_op (gdb::array_view<const gdb_byte> expr, int addr_size,
 		  const frame_info_ptr &this_frame, CORE_ADDR initial,
 		  int initial_in_stack_memory, dwarf2_per_objfile *per_objfile,
 		  struct type* type = nullptr, bool as_lval = true)
@@ -257,8 +252,9 @@ execute_stack_op (const gdb_byte *exp, ULONGEST len, int addr_size,
   init_values.push_back (init_value);
 
   value *result_val
-    = dwarf2_evaluate (exp, len, as_lval, per_objfile, nullptr,
-		       this_frame, addr_size, &init_values, nullptr, type);
+    = dwarf2_evaluate (expr.data (), expr.size (), as_lval, per_objfile,
+		       nullptr, this_frame, addr_size, &init_values, nullptr,
+		       type);
 
   /* We need to clean up all the values that are not needed any more.
      The problem with a value_ref_ptr class is that it disconnects the
@@ -435,10 +431,9 @@ bad CFI data; mismatched DW_CFA_restore_state at %s"),
 
 	    case DW_CFA_def_cfa_expression:
 	      insn_ptr = safe_read_uleb128 (insn_ptr, insn_end, &utmp);
-	      fs->regs.cfa_exp_len = utmp;
-	      fs->regs.cfa_exp = insn_ptr;
+	      fs->regs.cfa_exp = gdb::make_array_view (insn_ptr, utmp);
 	      fs->regs.cfa_how = CFA_EXP;
-	      insn_ptr += fs->regs.cfa_exp_len;
+	      insn_ptr += utmp;
 	      break;
 
 	    case DW_CFA_def_aspace_cfa:
@@ -614,7 +609,7 @@ execute_cfa_program_test (struct gdbarch *gdbarch)
   SELF_CHECK (fs.regs.cfa_reg == 1);
   SELF_CHECK (fs.regs.cfa_offset == 4);
   SELF_CHECK (fs.regs.cfa_how == CFA_REG_OFFSET);
-  SELF_CHECK (fs.regs.cfa_exp == NULL);
+  SELF_CHECK (fs.regs.cfa_exp.empty ());
   SELF_CHECK (fs.regs.prev == NULL);
 }
 
@@ -803,8 +798,7 @@ bool
 dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
 		       dwarf2_per_cu *data, int *regnum_out,
 		       LONGEST *offset_out, CORE_ADDR *text_offset_out,
-		       const gdb_byte **cfa_start_out,
-		       const gdb_byte **cfa_end_out)
+		       gdb::array_view<const gdb_byte> &cfa_expr_out)
 {
   struct dwarf2_fde *fde;
   dwarf2_per_objfile *per_objfile;
@@ -855,8 +849,7 @@ dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
 
     case CFA_EXP:
       *text_offset_out = per_objfile->objfile->text_section_offset ();
-      *cfa_start_out = fs.regs.cfa_exp;
-      *cfa_end_out = fs.regs.cfa_exp + fs.regs.cfa_exp_len;
+      cfa_expr_out = fs.regs.cfa_exp;
       return false;
 
     default:
@@ -1029,9 +1022,8 @@ dwarf2_frame_cache (const frame_info_ptr &this_frame, void **this_cache)
 	case CFA_EXP:
 	  {
 	    struct value *value
-	      = execute_stack_op (fs.regs.cfa_exp, fs.regs.cfa_exp_len,
-				  cache->addr_size, this_frame, 0, 0,
-				  cache->per_objfile);
+	      = execute_stack_op (fs.regs.cfa_exp, cache->addr_size,
+				  this_frame, 0, 0, cache->per_objfile);
 	    cache->cfa = value->address ();
 	  }
 
@@ -1224,8 +1216,7 @@ dwarf2_frame_prev_register (const frame_info_ptr &this_frame, void **this_cache,
       {
 	struct value *value;
 	cache->reg[regnum].evaluated = true;
-	value = execute_stack_op (cache->reg[regnum].loc.exp.start,
-				  cache->reg[regnum].loc.exp.len,
+	value = execute_stack_op (cache->reg[regnum].loc.exp.view (),
 				  cache->addr_size, this_frame,
 				  cache->cfa, 1, cache->per_objfile,
 				  register_type (gdbarch, regnum));
@@ -1241,8 +1232,7 @@ dwarf2_frame_prev_register (const frame_info_ptr &this_frame, void **this_cache,
       {
 	struct value *value;
 	cache->reg[regnum].evaluated = true;
-	value = execute_stack_op (cache->reg[regnum].loc.exp.start,
-				  cache->reg[regnum].loc.exp.len,
+	value = execute_stack_op (cache->reg[regnum].loc.exp.view (),
 				  cache->addr_size, this_frame,
 				  cache->cfa, 1, cache->per_objfile,
 				  register_type (gdbarch, regnum), false);

--- a/gdb/dwarf2/frame.h
+++ b/gdb/dwarf2/frame.h
@@ -78,6 +78,10 @@ struct dwarf2_frame_state_reg
     ULONGEST reg;
     struct
     {
+      /* Return this expression.  */
+      gdb::array_view<const gdb_byte> view () const
+      { return gdb::make_array_view (start, len); }
+
       const gdb_byte *start;
       ULONGEST len;
     } exp;
@@ -143,7 +147,7 @@ struct dwarf2_frame_state_reg_info
   LONGEST cfa_offset = 0;
   ULONGEST cfa_reg = 0;
   enum cfa_how_kind cfa_how = CFA_UNSET;
-  const gdb_byte *cfa_exp = NULL;
+  gdb::array_view<const gdb_byte> cfa_exp;
 
   /* Used to implement DW_CFA_remember_state.  */
   struct dwarf2_frame_state_reg_info *prev = NULL;
@@ -255,15 +259,13 @@ CORE_ADDR dwarf2_frame_cfa (const frame_info_ptr &this_frame);
    OFFSET_OUT is the offset to use from this register.
    These are only filled in when true is returned.
 
-   TEXT_OFFSET_OUT, CFA_START_OUT, and CFA_END_OUT describe the CFA
-   in other cases.  These are only used when false is returned.  */
+   TEXT_OFFSET_OUT and CFA_EXPR describe the CFA in other cases.  These are
+   only filled in when false is returned.  */
 
-extern bool dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
-				   dwarf2_per_cu *data, int *regnum_out,
-				   LONGEST *offset_out,
-				   CORE_ADDR *text_offset_out,
-				   const gdb_byte **cfa_start_out,
-				   const gdb_byte **cfa_end_out);
+extern bool dwarf2_fetch_cfa_info
+  (struct gdbarch *gdbarch, CORE_ADDR pc, dwarf2_per_cu *data, int *regnum_out,
+   LONGEST *offset_out, CORE_ADDR *text_offset_out,
+   gdb::array_view<const gdb_byte> &cfa_expr_out);
 
 /* Allocate a new instance of the function unique data.
 

--- a/gdb/dwarf2/frame.h
+++ b/gdb/dwarf2/frame.h
@@ -79,6 +79,10 @@ struct dwarf2_frame_state_reg
     ULONGEST reg;
     struct
     {
+      /* Return this expression.  */
+      gdb::array_view<const gdb_byte> view () const
+      { return gdb::make_array_view (start, len); }
+
       const gdb_byte *start;
       ULONGEST len;
     } exp;
@@ -146,7 +150,7 @@ struct dwarf2_frame_state_reg_info
   ULONGEST cfa_reg = 0;
   ULONGEST cfa_aspace = 0;
   enum cfa_how_kind cfa_how = CFA_UNSET;
-  const gdb_byte *cfa_exp = NULL;
+  gdb::array_view<const gdb_byte> cfa_exp;
 
   /* Used to implement DW_CFA_remember_state.  */
   struct dwarf2_frame_state_reg_info *prev = NULL;
@@ -259,15 +263,13 @@ CORE_ADDR dwarf2_frame_cfa (const frame_info_ptr &this_frame);
    OFFSET_OUT is the offset to use from this register.
    These are only filled in when true is returned.
 
-   TEXT_OFFSET_OUT, CFA_START_OUT, and CFA_END_OUT describe the CFA
-   in other cases.  These are only used when false is returned.  */
+   TEXT_OFFSET_OUT and CFA_EXPR describe the CFA in other cases.  These are
+   only filled in when false is returned.  */
 
-extern bool dwarf2_fetch_cfa_info (struct gdbarch *gdbarch, CORE_ADDR pc,
-				   dwarf2_per_cu *data, int *regnum_out,
-				   LONGEST *offset_out,
-				   CORE_ADDR *text_offset_out,
-				   const gdb_byte **cfa_start_out,
-				   const gdb_byte **cfa_end_out);
+extern bool dwarf2_fetch_cfa_info
+  (struct gdbarch *gdbarch, CORE_ADDR pc, dwarf2_per_cu *data, int *regnum_out,
+   LONGEST *offset_out, CORE_ADDR *text_offset_out,
+   gdb::array_view<const gdb_byte> &cfa_expr_out);
 
 /* Allocate a new instance of the function unique data.
 

--- a/gdb/dwarf2/loc.c
+++ b/gdb/dwarf2/loc.c
@@ -49,9 +49,10 @@
 #include "extract-store-integer.h"
 
 static struct value *dwarf2_evaluate_loc_desc_full
-  (struct type *type, const frame_info_ptr &frame, const gdb_byte *data,
-   size_t size, dwarf2_per_cu *per_cu, dwarf2_per_objfile *per_objfile,
-   struct type *subobj_type, LONGEST subobj_byte_offset, bool as_lval = true);
+  (struct type *type, const frame_info_ptr &frame,
+   gdb::array_view<const gdb_byte> loc_desc, dwarf2_per_cu *per_cu,
+   dwarf2_per_objfile *per_objfile, struct type *subobj_type,
+   LONGEST subobj_byte_offset, bool as_lval = true);
 
 /* Until these have formal names, we define these here.
    ref: http://gcc.gnu.org/wiki/DebugFission
@@ -354,18 +355,16 @@ decode_debug_loc_dwo_addresses (dwarf2_per_cu *per_cu,
     }
 }
 
-/* A function for dealing with location lists.  Given a
-   symbol baton (BATON) and a pc value (PC), find the appropriate
-   location expression, set *LOCEXPR_LENGTH, and return a pointer
-   to the beginning of the expression.  Returns NULL on failure.
+/* A function for dealing with location lists.  Given a symbol baton
+   (BATON) and a pc value (PC), find and return the appropriate location
+   expression.  Returns an empty view on failure.
 
    For now, only return the first matching location expression; there
    can be more than one in the list.  */
 
-const gdb_byte *
+gdb::array_view<const gdb_byte>
 dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
-				 size_t *locexpr_length, const CORE_ADDR pc,
-				 bool at_entry)
+				 const CORE_ADDR pc, bool at_entry)
 {
   dwarf2_per_objfile *per_objfile = baton->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
@@ -410,8 +409,7 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
       switch (kind)
 	{
 	case DEBUG_LOC_END_OF_LIST:
-	  *locexpr_length = 0;
-	  return NULL;
+	  return {};
 
 	case DEBUG_LOC_BASE_ADDRESS:
 	  base_address = high;
@@ -470,17 +468,11 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
 	    pc_func = pc_block->linkage_function ();
 
 	  if (pc_func && pc == pc_func->value_block ()->entry_pc ())
-	    {
-	      *locexpr_length = length;
-	      return loc_ptr;
-	    }
+	    return gdb::make_array_view (loc_ptr, length);
 	}
 
       if (unrel_pc >= low && unrel_pc < high)
-	{
-	  *locexpr_length = length;
-	  return loc_ptr;
-	}
+	return gdb::make_array_view (loc_ptr, length);
 
       loc_ptr += length;
     }
@@ -489,15 +481,13 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
 /* Implement find_frame_base_location method for LOC_BLOCK functions using
    DWARF expression for its DW_AT_frame_base.  */
 
-static void
-locexpr_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc,
-				  const gdb_byte **start, size_t *length)
+static gdb::array_view<const gdb_byte>
+locexpr_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc)
 {
   struct dwarf2_locexpr_baton *symbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  *length = symbaton->size;
-  *start = symbaton->data;
+  return symbaton->expr ();
 }
 
 /* Implement the struct symbol_block_ops::get_frame_base method for
@@ -509,8 +499,6 @@ locexpr_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   struct gdbarch *gdbarch;
   struct type *type;
   struct dwarf2_locexpr_baton *dlbaton;
-  const gdb_byte *start;
-  size_t length;
   struct value *result;
 
   /* If this method is called, then FRAMEFUNC is supposed to be a DWARF block.
@@ -522,11 +510,11 @@ locexpr_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   type = builtin_type (gdbarch)->builtin_data_ptr;
   dlbaton = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  framefunc->block_ops ()->find_frame_base_location (framefunc,
-						     get_frame_pc (frame),
-						     &start, &length);
-  result = dwarf2_evaluate_loc_desc (type, frame, start, length,
-				     dlbaton->per_cu, dlbaton->per_objfile);
+  auto expr
+    = framefunc->block_ops ()->find_frame_base_location (framefunc,
+							 get_frame_pc (frame));
+  result = dwarf2_evaluate_loc_desc (type, frame, expr, dlbaton->per_cu,
+				     dlbaton->per_objfile);
 
   /* The DW_AT_frame_base attribute contains a location description which
      computes the base address itself.  However, the call to
@@ -548,14 +536,13 @@ const struct symbol_block_ops dwarf2_block_frame_base_locexpr_funcs =
 /* Implement find_frame_base_location method for LOC_BLOCK functions using
    DWARF location list for its DW_AT_frame_base.  */
 
-static void
-loclist_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc,
-				  const gdb_byte **start, size_t *length)
+static gdb::array_view<const gdb_byte>
+loclist_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc)
 {
   struct dwarf2_loclist_baton *symbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  *start = dwarf2_find_location_expression (symbaton, length, pc);
+  return dwarf2_find_location_expression (symbaton, pc);
 }
 
 /* Implement the struct symbol_block_ops::get_frame_base method for
@@ -567,8 +554,6 @@ loclist_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   struct gdbarch *gdbarch;
   struct type *type;
   struct dwarf2_loclist_baton *dlbaton;
-  const gdb_byte *start;
-  size_t length;
   struct value *result;
 
   /* If this method is called, then FRAMEFUNC is supposed to be a DWARF block.
@@ -580,11 +565,11 @@ loclist_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   type = builtin_type (gdbarch)->builtin_data_ptr;
   dlbaton = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  framefunc->block_ops ()->find_frame_base_location (framefunc,
-						     get_frame_pc (frame),
-						     &start, &length);
-  result = dwarf2_evaluate_loc_desc (type, frame, start, length,
-				     dlbaton->per_cu, dlbaton->per_objfile);
+  auto expr
+    = framefunc->block_ops ()->find_frame_base_location (framefunc,
+							 get_frame_pc (frame));
+  result = dwarf2_evaluate_loc_desc (type, frame, expr, dlbaton->per_cu,
+				     dlbaton->per_objfile);
 
   /* The DW_AT_frame_base attribute contains a location description which
      computes the base address itself.  However, the call to
@@ -605,19 +590,20 @@ const struct symbol_block_ops dwarf2_block_frame_base_loclist_funcs =
 
 /* See dwarf2/loc.h.  */
 
-void
-func_get_frame_base_dwarf_block (struct symbol *framefunc, CORE_ADDR pc,
-				 const gdb_byte **start, size_t *length)
+gdb::array_view<const gdb_byte>
+func_get_frame_base_dwarf_block (struct symbol *framefunc, CORE_ADDR pc)
 {
+  gdb::array_view<const gdb_byte> block;
+
   if (const symbol_block_ops *block_ops = framefunc->block_ops ();
       block_ops != nullptr)
-    block_ops->find_frame_base_location (framefunc, pc, start, length);
-  else
-    *length = 0;
+    block = block_ops->find_frame_base_location (framefunc, pc);
 
-  if (*length == 0)
+  if (block.empty ())
     error (_("Could not find the frame base for \"%s\"."),
 	   framefunc->natural_name ());
+
+  return block;
 }
 
 /* See loc.h.  */
@@ -692,7 +678,7 @@ call_site_target::iterate_over_addresses (gdbarch *call_site_gdbarch,
 	caller_arch = get_frame_arch (caller_frame);
 	caller_core_addr_type = builtin_type (caller_arch)->builtin_func_ptr;
 	val = dwarf2_evaluate_loc_desc (caller_core_addr_type, caller_frame,
-					dwarf_block->data, dwarf_block->size,
+					dwarf_block->expr (),
 					dwarf_block->per_cu,
 					dwarf_block->per_objfile);
 	/* DW_AT_call_target is a DWARF expression, not a DWARF location.  */
@@ -1275,8 +1261,9 @@ dwarf_entry_parameter_to_value (struct call_site_parameter *parameter,
     throw_error (NO_ENTRY_VALUE_ERROR,
 		 _("Cannot resolve DW_AT_call_data_value"));
 
-  return dwarf2_evaluate_loc_desc (type, caller_frame, data_src, size, per_cu,
-				   per_objfile, false);
+  return dwarf2_evaluate_loc_desc (type, caller_frame,
+				   gdb::make_array_view (data_src, size),
+				   per_cu, per_objfile, false);
 }
 
 /* VALUE must be of type lval_computed with entry_data_value_funcs.  Perform
@@ -1384,8 +1371,8 @@ value_of_dwarf_reg_entry (struct type *type, const frame_info_ptr &frame,
   return val;
 }
 
-/* Read parameter of TYPE at (callee) FRAME's function entry.  DATA and
-   SIZE are DWARF block used to match DW_AT_location at the caller's
+/* Read parameter of TYPE at (callee) FRAME's function entry.  BLOCK is the
+   DWARF block used to match DW_AT_location at the caller's
    DW_TAG_call_site_parameter.
 
    Function always returns non-NULL value.  It throws NO_ENTRY_VALUE_ERROR if it
@@ -1393,16 +1380,16 @@ value_of_dwarf_reg_entry (struct type *type, const frame_info_ptr &frame,
 
 static struct value *
 value_of_dwarf_block_entry (struct type *type, const frame_info_ptr &frame,
-			    const gdb_byte *block, size_t block_len)
+			    gdb::array_view<const gdb_byte> block)
 {
   union call_site_parameter_u kind_u;
 
-  kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (block, block + block_len);
+  kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (block);
   if (kind_u.dwarf_reg != -1)
     return value_of_dwarf_reg_entry (type, frame, CALL_SITE_PARAMETER_DWARF_REG,
 				     kind_u);
 
-  if (dwarf_block_to_fb_offset (block, block + block_len, &kind_u.fb_offset))
+  if (dwarf_block_to_fb_offset (block, &kind_u.fb_offset))
     return value_of_dwarf_reg_entry (type, frame, CALL_SITE_PARAMETER_FB_OFFSET,
 				     kind_u);
 
@@ -1475,26 +1462,24 @@ indirect_synthetic_pointer (sect_offset die, LONGEST byte_offset,
   /* If pointed-to DIE has a DW_AT_location, evaluate it and return the
      resulting value.  Otherwise, it may have a DW_AT_const_value instead,
      or it may've been optimized out.  */
-  if (baton.data != NULL)
-    return dwarf2_evaluate_loc_desc_full (orig_type, frame, baton.data,
-					  baton.size, baton.per_cu,
+  auto expr = baton.expr ();
+  if (!expr.empty ())
+    return dwarf2_evaluate_loc_desc_full (orig_type, frame, expr, baton.per_cu,
 					  baton.per_objfile,
-					  type->target_type (),
-					  byte_offset);
+					  type->target_type (), byte_offset);
   else
     return fetch_const_value_from_synthetic_pointer (die, byte_offset, per_cu,
 						     per_objfile, type);
 }
 
-/* Evaluate a location description, starting at DATA and with length
-   SIZE, to find the current location of variable of TYPE in the
-   context of FRAME.  If SUBOBJ_TYPE is non-NULL, return instead the
-   location of the subobject of type SUBOBJ_TYPE at byte offset
-   SUBOBJ_BYTE_OFFSET within the variable of type TYPE.  */
+/* Evaluate the location description LOC_DESC to find the current location
+   of variable of TYPE in the context of FRAME.  If SUBOBJ_TYPE is non-NULL,
+   return instead the location of the subobject of type SUBOBJ_TYPE at byte
+   offset SUBOBJ_BYTE_OFFSET within the variable of type TYPE.  */
 
 static struct value *
 dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
-			       const gdb_byte *data, size_t size,
+			       gdb::array_view<const gdb_byte> loc_desc,
 			       dwarf2_per_cu *per_cu,
 			       dwarf2_per_objfile *per_objfile,
 			       struct type *subobj_type,
@@ -1509,7 +1494,7 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
   else if (subobj_byte_offset < 0)
     invalid_synthetic_pointer ();
 
-  if (size == 0)
+  if (loc_desc.empty ())
     return value::allocate_optimized_out (subobj_type);
 
   dwarf_expr_context ctx (per_objfile, per_cu->addr_size ());
@@ -1519,7 +1504,7 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
 
   try
     {
-      retval = ctx.evaluate (data, size, as_lval, per_cu, frame, nullptr,
+      retval = ctx.evaluate (loc_desc, as_lval, per_cu, frame, nullptr,
 			     type, subobj_type, subobj_byte_offset);
     }
   catch (const gdb_exception_error &ex)
@@ -1559,11 +1544,11 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
 
 struct value *
 dwarf2_evaluate_loc_desc (struct type *type, const frame_info_ptr &frame,
-			  const gdb_byte *data, size_t size,
+			  gdb::array_view<const gdb_byte> loc_desc,
 			  dwarf2_per_cu *per_cu,
 			  dwarf2_per_objfile *per_objfile, bool as_lval)
 {
-  return dwarf2_evaluate_loc_desc_full (type, frame, data, size, per_cu,
+  return dwarf2_evaluate_loc_desc_full (type, frame, loc_desc, per_cu,
 					per_objfile, NULL, 0, as_lval);
 }
 
@@ -1603,8 +1588,8 @@ dwarf2_locexpr_baton_eval (const struct dwarf2_locexpr_baton *dlbaton,
 
   try
     {
-      result = ctx.evaluate (dlbaton->data, dlbaton->size,
-			     true, per_cu, frame, addr_stack);
+      result = ctx.evaluate (dlbaton->expr (), true, per_cu, frame,
+			     addr_stack);
     }
   catch (const gdb_exception_error &ex)
     {
@@ -1704,19 +1689,17 @@ dwarf2_evaluate_property (const dynamic_prop *prop,
       {
 	const dwarf2_property_baton *baton = prop->baton ();
 	CORE_ADDR pc;
-	const gdb_byte *data;
 	struct value *val;
-	size_t size;
 
 	if (frame == NULL
 	    || !get_frame_address_in_block_if_available (frame, &pc))
 	  return false;
 
-	data = dwarf2_find_location_expression (&baton->loclist, &size, pc);
-	if (data != NULL)
+	auto data = dwarf2_find_location_expression (&baton->loclist, pc);
+	if (!data.empty ())
 	  {
 	    val = dwarf2_evaluate_loc_desc (baton->property_type, frame, data,
-					    size, baton->loclist.per_cu,
+					    baton->loclist.per_cu,
 					    baton->loclist.per_objfile);
 	    if (!val->optimized_out ())
 	      {
@@ -1809,15 +1792,13 @@ dwarf2_compile_property_to_c (string_file *stream,
 {
 #if defined (HAVE_COMPILE)
   const dwarf2_property_baton *baton = prop->baton ();
-  const gdb_byte *data;
-  size_t size;
+  gdb::array_view<const gdb_byte> expr;
   dwarf2_per_cu *per_cu;
   dwarf2_per_objfile *per_objfile;
 
   if (prop->kind () == PROP_LOCEXPR)
     {
-      data = baton->locexpr.data;
-      size = baton->locexpr.size;
+      expr = baton->locexpr.expr ();
       per_cu = baton->locexpr.per_cu;
       per_objfile = baton->locexpr.per_objfile;
     }
@@ -1825,15 +1806,14 @@ dwarf2_compile_property_to_c (string_file *stream,
     {
       gdb_assert (prop->kind () == PROP_LOCLIST);
 
-      data = dwarf2_find_location_expression (&baton->loclist, &size, pc);
+      expr = dwarf2_find_location_expression (&baton->loclist, pc);
       per_cu = baton->loclist.per_cu;
       per_objfile = baton->loclist.per_objfile;
     }
 
-  compile_dwarf_bounds_to_c (stream, result_name, prop, sym, pc,
-			     gdbarch, registers_used,
-			     per_cu->addr_size (),
-			     data, data + size, per_cu, per_objfile);
+  compile_dwarf_bounds_to_c (stream, result_name, prop, sym, pc, gdbarch,
+			     registers_used, per_cu->addr_size (), expr,
+			     per_cu, per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");
 #endif
@@ -2185,10 +2165,8 @@ dwarf2_get_symbol_read_needs (gdb::array_view<const gdb_byte> expr,
 	    if (symbol_needs != SYMBOL_NEEDS_FRAME)
 	      {
 		gdbarch *arch = baton.per_objfile->objfile->arch ();
-		gdb::array_view<const gdb_byte> sub_expr (baton.data,
-							  baton.size);
 		symbol_needs
-		  = dwarf2_get_symbol_read_needs (sub_expr,
+		  = dwarf2_get_symbol_read_needs (baton.expr (),
 						  baton.per_cu,
 						  baton.per_objfile,
 						  gdbarch_byte_order (arch),
@@ -2238,10 +2216,8 @@ dwarf2_get_symbol_read_needs (gdb::array_view<const gdb_byte> expr,
 	    if (symbol_needs != SYMBOL_NEEDS_FRAME)
 	      {
 		gdbarch *arch = baton.per_objfile->objfile->arch ();
-		gdb::array_view<const gdb_byte> sub_expr (baton.data,
-							  baton.size);
 		symbol_needs
-		  = dwarf2_get_symbol_read_needs (sub_expr,
+		  = dwarf2_get_symbol_read_needs (baton.expr (),
 						  baton.per_cu,
 						  baton.per_objfile,
 						  gdbarch_byte_order (arch),
@@ -2391,36 +2367,38 @@ access_memory (struct gdbarch *arch, struct agent_expr *expr, ULONGEST nbits)
 
 /* Compile a DWARF location expression to an agent expression.
 
-   EXPR is the agent expression we are building.
+   AX is the agent expression we are building.
    LOC is the agent value we modify.
-   ARCH is the architecture.
    ADDR_SIZE is the size of addresses, in bytes.
-   OP_PTR is the start of the location expression.
-   OP_END is one past the last byte of the location expression.
+   EXPR is the location expression.
 
    This will throw an exception for various kinds of errors -- for
    example, if the expression cannot be compiled, or if the expression
    is invalid.  */
 
 static void
-dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
-			   unsigned int addr_size, const gdb_byte *op_ptr,
-			   const gdb_byte *op_end, dwarf2_per_cu *per_cu,
+dwarf2_compile_expr_to_ax (struct agent_expr *ax, struct axs_value *loc,
+			   unsigned int addr_size,
+			   gdb::array_view<const gdb_byte> expr,
+			   dwarf2_per_cu *per_cu,
 			   dwarf2_per_objfile *per_objfile)
 {
-  gdbarch *arch = expr->gdbarch;
+  gdbarch *arch = ax->gdbarch;
   std::vector<int> dw_labels, patches;
-  const gdb_byte * const base = op_ptr;
-  const gdb_byte *previous_piece = op_ptr;
+  const gdb_byte *previous_piece = expr.data ();
   enum bfd_endian byte_order = gdbarch_byte_order (arch);
   ULONGEST bits_collected = 0;
   unsigned int addr_size_bits = 8 * addr_size;
   bool bits_big_endian = byte_order == BFD_ENDIAN_BIG;
 
-  std::vector<int> offsets (op_end - op_ptr, -1);
+  std::vector<int> offsets (expr.size (), -1);
 
   /* By default we are making an address.  */
   loc->kind = axs_lvalue_memory;
+
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *const op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -2429,7 +2407,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
       int64_t offset;
       int i;
 
-      offsets[op_ptr - base] = expr->buf.size ();
+      offsets[op_ptr - base] = ax->buf.size ();
       ++op_ptr;
 
       /* Our basic approach to code generation is to map DWARF
@@ -2482,7 +2460,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_lit29:
 	case DW_OP_lit30:
 	case DW_OP_lit31:
-	  ax_const_l (expr, op - DW_OP_lit0);
+	  ax_const_l (ax, op - DW_OP_lit0);
 	  break;
 
 	case DW_OP_addr:
@@ -2494,57 +2472,57 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	     branching between the address and the TLS op.  */
 	  if (op_ptr >= op_end || *op_ptr != DW_OP_GNU_push_tls_address)
 	    uoffset += per_objfile->objfile->text_section_offset ();
-	  ax_const_l (expr, uoffset);
+	  ax_const_l (ax, uoffset);
 	  break;
 
 	case DW_OP_const1u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 1, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 1, byte_order));
 	  op_ptr += 1;
 	  break;
 
 	case DW_OP_const1s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 1, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 1, byte_order));
 	  op_ptr += 1;
 	  break;
 
 	case DW_OP_const2u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 2, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 2, byte_order));
 	  op_ptr += 2;
 	  break;
 
 	case DW_OP_const2s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 2, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 2, byte_order));
 	  op_ptr += 2;
 	  break;
 
 	case DW_OP_const4u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 4, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 4, byte_order));
 	  op_ptr += 4;
 	  break;
 
 	case DW_OP_const4s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 4, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 4, byte_order));
 	  op_ptr += 4;
 	  break;
 
 	case DW_OP_const8u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 8, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 8, byte_order));
 	  op_ptr += 8;
 	  break;
 
 	case DW_OP_const8s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 8, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 8, byte_order));
 	  op_ptr += 8;
 	  break;
 
 	case DW_OP_constu:
 	  op_ptr = safe_read_uleb128 (op_ptr, op_end, &uoffset);
-	  ax_const_l (expr, uoffset);
+	  ax_const_l (ax, uoffset);
 	  break;
 
 	case DW_OP_consts:
 	  op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
-	  ax_const_l (expr, offset);
+	  ax_const_l (ax, offset);
 	  break;
 
 	case DW_OP_reg0:
@@ -2602,7 +2580,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	      error (_("Cannot translate DW_OP_implicit_value of %d bytes"),
 		     (int) len);
 
-	    ax_const_l (expr, extract_unsigned_integer (op_ptr, len,
+	    ax_const_l (ax, extract_unsigned_integer (op_ptr, len,
 							byte_order));
 	    op_ptr += len;
 	    dwarf_expr_require_composition (op_ptr, op_end,
@@ -2651,11 +2629,11 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_breg31:
 	  op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 	  i = dwarf_reg_to_regnum_or_error (arch, op - DW_OP_breg0);
-	  ax_reg (expr, i);
+	  ax_reg (ax, i);
 	  if (offset != 0)
 	    {
-	      ax_const_l (expr, offset);
-	      ax_simple (expr, aop_add);
+	      ax_const_l (ax, offset);
+	      ax_simple (ax, aop_add);
 	    }
 	  break;
 
@@ -2664,23 +2642,21 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    op_ptr = safe_read_uleb128 (op_ptr, op_end, &reg);
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 	    i = dwarf_reg_to_regnum_or_error (arch, reg);
-	    ax_reg (expr, i);
+	    ax_reg (ax, i);
 	    if (offset != 0)
 	      {
-		ax_const_l (expr, offset);
-		ax_simple (expr, aop_add);
+		ax_const_l (ax, offset);
+		ax_simple (ax, aop_add);
 	      }
 	  }
 	  break;
 
 	case DW_OP_fbreg:
 	  {
-	    const gdb_byte *datastart;
-	    size_t datalen;
 	    const struct block *b;
 	    struct symbol *framefunc;
 
-	    b = block_for_pc (expr->scope);
+	    b = block_for_pc (ax->scope);
 
 	    if (!b)
 	      error (_("No block found for address"));
@@ -2690,20 +2666,19 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    if (!framefunc)
 	      error (_("No function found for block"));
 
-	    func_get_frame_base_dwarf_block (framefunc, expr->scope,
-					     &datastart, &datalen);
+	    auto frame_base_expr = func_get_frame_base_dwarf_block (framefunc,
+								    ax->scope);
 
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
-	    dwarf2_compile_expr_to_ax (expr, loc, addr_size, datastart,
-				       datastart + datalen, per_cu,
-				       per_objfile);
+	    dwarf2_compile_expr_to_ax (ax, loc, addr_size, frame_base_expr,
+				       per_cu, per_objfile);
 	    if (loc->kind == axs_lvalue_register)
-	      require_rvalue (expr, loc);
+	      require_rvalue (ax, loc);
 
 	    if (offset != 0)
 	      {
-		ax_const_l (expr, offset);
-		ax_simple (expr, aop_add);
+		ax_const_l (ax, offset);
+		ax_simple (ax, aop_add);
 	      }
 
 	    loc->kind = axs_lvalue_memory;
@@ -2711,28 +2686,28 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	  break;
 
 	case DW_OP_dup:
-	  ax_simple (expr, aop_dup);
+	  ax_simple (ax, aop_dup);
 	  break;
 
 	case DW_OP_drop:
-	  ax_simple (expr, aop_pop);
+	  ax_simple (ax, aop_pop);
 	  break;
 
 	case DW_OP_pick:
 	  offset = *op_ptr++;
-	  ax_pick (expr, offset);
+	  ax_pick (ax, offset);
 	  break;
 
 	case DW_OP_swap:
-	  ax_simple (expr, aop_swap);
+	  ax_simple (ax, aop_swap);
 	  break;
 
 	case DW_OP_over:
-	  ax_pick (expr, 1);
+	  ax_pick (ax, 1);
 	  break;
 
 	case DW_OP_rot:
-	  ax_simple (expr, aop_rot);
+	  ax_simple (ax, aop_rot);
 	  break;
 
 	case DW_OP_deref:
@@ -2748,36 +2723,36 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    if (size != 1 && size != 2 && size != 4 && size != 8)
 	      error (_("Unsupported size %d in %s"),
 		     size, get_DW_OP_name (op));
-	    access_memory (arch, expr, size * TARGET_CHAR_BIT);
+	    access_memory (arch, ax, size * TARGET_CHAR_BIT);
 	  }
 	  break;
 
 	case DW_OP_abs:
 	  /* Sign extend the operand.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_dup);
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
-	  i = ax_goto (expr, aop_if_goto);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_dup);
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
+	  i = ax_goto (ax, aop_if_goto);
 	  /* We have to emit 0 - X.  */
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_sub);
-	  ax_label (expr, i, expr->buf.size ());
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_sub);
+	  ax_label (ax, i, ax->buf.size ());
 	  break;
 
 	case DW_OP_neg:
 	  /* No need to sign extend here.  */
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_sub);
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_sub);
 	  break;
 
 	case DW_OP_not:
 	  /* Sign extend the operand.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_bit_not);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_bit_not);
 	  break;
 
 	case DW_OP_plus_uconst:
@@ -2786,116 +2761,116 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	     but we micro-optimize anyhow.  */
 	  if (reg != 0)
 	    {
-	      ax_const_l (expr, reg);
-	      ax_simple (expr, aop_add);
+	      ax_const_l (ax, reg);
+	      ax_simple (ax, aop_add);
 	    }
 	  break;
 
 	case DW_OP_and:
-	  ax_simple (expr, aop_bit_and);
+	  ax_simple (ax, aop_bit_and);
 	  break;
 
 	case DW_OP_div:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_div_signed);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_div_signed);
 	  break;
 
 	case DW_OP_minus:
-	  ax_simple (expr, aop_sub);
+	  ax_simple (ax, aop_sub);
 	  break;
 
 	case DW_OP_mod:
-	  ax_simple (expr, aop_rem_unsigned);
+	  ax_simple (ax, aop_rem_unsigned);
 	  break;
 
 	case DW_OP_mul:
-	  ax_simple (expr, aop_mul);
+	  ax_simple (ax, aop_mul);
 	  break;
 
 	case DW_OP_or:
-	  ax_simple (expr, aop_bit_or);
+	  ax_simple (ax, aop_bit_or);
 	  break;
 
 	case DW_OP_plus:
-	  ax_simple (expr, aop_add);
+	  ax_simple (ax, aop_add);
 	  break;
 
 	case DW_OP_shl:
-	  ax_simple (expr, aop_lsh);
+	  ax_simple (ax, aop_lsh);
 	  break;
 
 	case DW_OP_shr:
-	  ax_simple (expr, aop_rsh_unsigned);
+	  ax_simple (ax, aop_rsh_unsigned);
 	  break;
 
 	case DW_OP_shra:
-	  ax_simple (expr, aop_rsh_signed);
+	  ax_simple (ax, aop_rsh_signed);
 	  break;
 
 	case DW_OP_xor:
-	  ax_simple (expr, aop_bit_xor);
+	  ax_simple (ax, aop_bit_xor);
 	  break;
 
 	case DW_OP_le:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* Note no swap here: A <= B is !(B < A).  */
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_ge:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
 	  /* A >= B is !(A < B).  */
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_eq:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* No need for a second swap here.  */
-	  ax_simple (expr, aop_equal);
+	  ax_simple (ax, aop_equal);
 	  break;
 
 	case DW_OP_lt:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_less_signed);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_less_signed);
 	  break;
 
 	case DW_OP_gt:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* Note no swap here: A > B is B < A.  */
-	  ax_simple (expr, aop_less_signed);
+	  ax_simple (ax, aop_less_signed);
 	  break;
 
 	case DW_OP_ne:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* No need for a swap here.  */
-	  ax_simple (expr, aop_equal);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_equal);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_call_frame_cfa:
@@ -2903,26 +2878,25 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    int regnum;
 	    CORE_ADDR text_offset;
 	    LONGEST off;
-	    const gdb_byte *cfa_start, *cfa_end;
+	    gdb::array_view<const gdb_byte> cfa_expr;
 
-	    if (dwarf2_fetch_cfa_info (arch, expr->scope, per_cu,
-				       &regnum, &off,
-				       &text_offset, &cfa_start, &cfa_end))
+	    if (dwarf2_fetch_cfa_info (arch, ax->scope, per_cu, &regnum,
+				       &off, &text_offset, cfa_expr))
 	      {
 		/* Register.  */
-		ax_reg (expr, regnum);
+		ax_reg (ax, regnum);
 		if (off != 0)
 		  {
-		    ax_const_l (expr, off);
-		    ax_simple (expr, aop_add);
+		    ax_const_l (ax, off);
+		    ax_simple (ax, aop_add);
 		  }
 	      }
 	    else
 	      {
 		/* Another expression.  */
-		ax_const_l (expr, text_offset);
-		dwarf2_compile_expr_to_ax (expr, loc, addr_size, cfa_start,
-					   cfa_end, per_cu, per_objfile);
+		ax_const_l (ax, text_offset);
+		dwarf2_compile_expr_to_ax (ax, loc, addr_size, cfa_expr,
+					   per_cu, per_objfile);
 	      }
 
 	    loc->kind = axs_lvalue_memory;
@@ -2941,7 +2915,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_skip:
 	  offset = extract_signed_integer (op_ptr, 2, byte_order);
 	  op_ptr += 2;
-	  i = ax_goto (expr, aop_goto);
+	  i = ax_goto (ax, aop_goto);
 	  dw_labels.push_back (op_ptr + offset - base);
 	  patches.push_back (i);
 	  break;
@@ -2950,8 +2924,8 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	  offset = extract_signed_integer (op_ptr, 2, byte_order);
 	  op_ptr += 2;
 	  /* Zero extend the operand.  */
-	  ax_zero_ext (expr, addr_size_bits);
-	  i = ax_goto (expr, aop_if_goto);
+	  ax_zero_ext (ax, addr_size_bits);
+	  i = ax_goto (ax, aop_if_goto);
 	  dw_labels.push_back (op_ptr + offset - base);
 	  patches.push_back (i);
 	  break;
@@ -2984,18 +2958,18 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    switch (loc->kind)
 	      {
 	      case axs_lvalue_register:
-		ax_reg (expr, loc->u.reg);
+		ax_reg (ax, loc->u.reg);
 		break;
 
 	      case axs_lvalue_memory:
 		/* Offset the pointer, if needed.  */
 		if (uoffset > 8)
 		  {
-		    ax_const_l (expr, uoffset / 8);
-		    ax_simple (expr, aop_add);
+		    ax_const_l (ax, uoffset / 8);
+		    ax_simple (ax, aop_add);
 		    uoffset %= 8;
 		  }
-		access_memory (arch, expr, size);
+		access_memory (arch, ax, size);
 		break;
 	      }
 
@@ -3008,18 +2982,18 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	      {
 		if (bits_big_endian)
 		  {
-		    ax_simple (expr, aop_swap);
-		    ax_const_l (expr, size);
-		    ax_simple (expr, aop_lsh);
+		    ax_simple (ax, aop_swap);
+		    ax_const_l (ax, size);
+		    ax_simple (ax, aop_lsh);
 		    /* We don't need a second swap here, because
 		       aop_bit_or is symmetric.  */
 		  }
 		else
 		  {
-		    ax_const_l (expr, size);
-		    ax_simple (expr, aop_lsh);
+		    ax_const_l (ax, size);
+		    ax_simple (ax, aop_lsh);
 		  }
-		ax_simple (expr, aop_bit_or);
+		ax_simple (ax, aop_bit_or);
 	      }
 
 	    bits_collected += size;
@@ -3039,9 +3013,9 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    uoffset = extract_unsigned_integer (op_ptr, size, byte_order);
 	    op_ptr += size;
 
-	    auto get_frame_pc_from_expr = [expr] ()
+	    auto get_frame_pc_from_expr = [ax] ()
 	      {
-		return expr->scope;
+		return ax->scope;
 	      };
 	    cu_offset cuoffset = (cu_offset) uoffset;
 	    block = dwarf2_fetch_die_loc_cu_off (cuoffset, per_cu, per_objfile,
@@ -3050,9 +3024,8 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    /* DW_OP_call_ref is currently not supported.  */
 	    gdb_assert (block.per_cu == per_cu);
 
-	    dwarf2_compile_expr_to_ax (expr, loc, addr_size, block.data,
-				       block.data + block.size, per_cu,
-				       per_objfile);
+	    dwarf2_compile_expr_to_ax (ax, loc, addr_size, block.expr (),
+				       per_cu, per_objfile);
 	  }
 	  break;
 
@@ -3073,7 +3046,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
       int targ = offsets[dw_labels[i]];
       if (targ == -1)
 	internal_error (_("invalid label"));
-      ax_label (expr, patches[i], targ);
+      ax_label (ax, patches[i], targ);
     }
 }
 
@@ -3087,9 +3060,8 @@ locexpr_read_variable (struct symbol *symbol, const frame_info_ptr &frame)
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (symbol);
   struct value *val;
 
-  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, dlbaton->data,
-				  dlbaton->size, dlbaton->per_cu,
-				  dlbaton->per_objfile);
+  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, dlbaton->expr (),
+				  dlbaton->per_cu, dlbaton->per_objfile);
 
   return val;
 }
@@ -3104,8 +3076,7 @@ locexpr_read_variable_at_entry (struct symbol *symbol, const frame_info_ptr &fra
   struct dwarf2_locexpr_baton *dlbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (symbol);
 
-  return value_of_dwarf_block_entry (symbol->type (), frame, dlbaton->data,
-				     dlbaton->size);
+  return value_of_dwarf_block_entry (symbol->type (), frame, dlbaton->expr ());
 }
 
 /* Implementation of get_symbol_read_needs from
@@ -3118,10 +3089,8 @@ locexpr_get_symbol_read_needs (struct symbol *symbol)
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (symbol);
 
   gdbarch *arch = dlbaton->per_objfile->objfile->arch ();
-  gdb::array_view<const gdb_byte> expr (dlbaton->data, dlbaton->size);
 
-  return dwarf2_get_symbol_read_needs (expr,
-				       dlbaton->per_cu,
+  return dwarf2_get_symbol_read_needs (dlbaton->expr (), dlbaton->per_cu,
 				       dlbaton->per_objfile,
 				       gdbarch_byte_order (arch),
 				       dlbaton->per_cu->addr_size (),
@@ -3196,8 +3165,7 @@ locexpr_describe_location_piece (struct symbol *symbol, struct ui_file *stream,
       struct symbol *framefunc;
       int frame_reg = 0;
       int64_t frame_offset;
-      const gdb_byte *base_data, *new_data, *save_data = data;
-      size_t base_size;
+      const gdb_byte *new_data, *save_data = data;
       int64_t base_offset = 0;
 
       new_data = safe_read_sleb128 (data + 1, end, &frame_offset);
@@ -3217,24 +3185,27 @@ locexpr_describe_location_piece (struct symbol *symbol, struct ui_file *stream,
 	error (_("No function found for block for symbol \"%s\"."),
 	       symbol->print_name ());
 
-      func_get_frame_base_dwarf_block (framefunc, addr, &base_data, &base_size);
+      auto frame_base_expr = func_get_frame_base_dwarf_block (framefunc, addr);
+      gdb_byte op0 = frame_base_expr[0];
 
-      if (base_data[0] >= DW_OP_breg0 && base_data[0] <= DW_OP_breg31)
+      if (op0 >= DW_OP_breg0 && op0 <= DW_OP_breg31)
 	{
 	  const gdb_byte *buf_end;
 
-	  frame_reg = base_data[0] - DW_OP_breg0;
-	  buf_end = safe_read_sleb128 (base_data + 1, base_data + base_size,
+	  frame_reg = op0 - DW_OP_breg0;
+	  buf_end = safe_read_sleb128 (frame_base_expr.data () + 1,
+				       (frame_base_expr.data ()
+					+ frame_base_expr.size ()),
 				       &base_offset);
-	  if (buf_end != base_data + base_size)
+	  if (buf_end != frame_base_expr.data () + frame_base_expr.size ())
 	    error (_("Unexpected opcode after "
 		     "DW_OP_breg%u for symbol \"%s\"."),
 		   frame_reg, symbol->print_name ());
 	}
-      else if (base_data[0] >= DW_OP_reg0 && base_data[0] <= DW_OP_reg31)
+      else if (op0 >= DW_OP_reg0 && op0 <= DW_OP_reg31)
 	{
 	  /* The frame base is just the register, with no offset.  */
-	  frame_reg = base_data[0] - DW_OP_reg0;
+	  frame_reg = op0 - DW_OP_reg0;
 	  base_offset = 0;
 	}
       else
@@ -3751,12 +3722,13 @@ show_dwarf_always_disassemble (struct ui_file *file, int from_tty,
 static void
 locexpr_describe_location_1 (struct symbol *symbol, CORE_ADDR addr,
 			     struct ui_file *stream,
-			     const gdb_byte *data, size_t size,
+			     gdb::array_view<const gdb_byte> expr,
 			     unsigned int addr_size,
 			     int offset_size, dwarf2_per_cu *per_cu,
 			     dwarf2_per_objfile *per_objfile)
 {
-  const gdb_byte *end = data + size;
+  const gdb_byte *data = expr.data ();
+  const gdb_byte *const end = expr.data () + expr.size ();
   int first_piece = 1, bad = 0;
   objfile *objfile = per_objfile->objfile;
 
@@ -3854,7 +3826,7 @@ locexpr_describe_location (struct symbol *symbol, CORE_ADDR addr,
   int offset_size = dlbaton->per_cu->offset_size ();
 
   locexpr_describe_location_1 (symbol, addr, stream,
-			       dlbaton->data, dlbaton->size,
+			       dlbaton->expr (),
 			       addr_size, offset_size,
 			       dlbaton->per_cu, dlbaton->per_objfile);
 }
@@ -3873,9 +3845,8 @@ locexpr_tracepoint_var_ref (struct symbol *symbol, struct agent_expr *ax,
   if (dlbaton->size == 0)
     value->optimized_out = 1;
   else
-    dwarf2_compile_expr_to_ax (ax, value, addr_size, dlbaton->data,
-			       dlbaton->data + dlbaton->size, dlbaton->per_cu,
-			       dlbaton->per_objfile);
+    dwarf2_compile_expr_to_ax (ax, value, addr_size, dlbaton->expr (),
+			       dlbaton->per_cu, dlbaton->per_objfile);
 }
 
 /* symbol_computed_ops 'generate_c_location' method.  */
@@ -3890,14 +3861,14 @@ locexpr_generate_c_location (struct symbol *sym, string_file *stream,
   struct dwarf2_locexpr_baton *dlbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (sym);
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
+  auto expr = dlbaton->expr ();
 
-  if (dlbaton->size == 0)
+  if (expr.empty ())
     error (_("symbol \"%s\" is optimized out"), sym->natural_name ());
 
-  compile_dwarf_expr_to_c (stream, result_name,
-			   sym, pc, gdbarch, registers_used, addr_size,
-			   dlbaton->data, dlbaton->data + dlbaton->size,
-			   dlbaton->per_cu, dlbaton->per_objfile);
+  compile_dwarf_expr_to_c (stream, result_name, sym, pc, gdbarch,
+			   registers_used, addr_size, expr, dlbaton->per_cu,
+			   dlbaton->per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");
 #endif
@@ -3926,16 +3897,11 @@ loclist_read_variable (struct symbol *symbol, const frame_info_ptr &frame)
 {
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
-  struct value *val;
-  const gdb_byte *data;
-  size_t size;
   CORE_ADDR pc = frame ? get_frame_address_in_block (frame) : 0;
+  auto expr = dwarf2_find_location_expression (dlbaton, pc);
 
-  data = dwarf2_find_location_expression (dlbaton, &size, pc);
-  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, data, size,
-				  dlbaton->per_cu, dlbaton->per_objfile);
-
-  return val;
+  return dwarf2_evaluate_loc_desc (symbol->type (), frame, expr,
+				   dlbaton->per_cu, dlbaton->per_objfile);
 }
 
 /* Read variable SYMBOL like loclist_read_variable at (callee) FRAME's function
@@ -3951,18 +3917,16 @@ loclist_read_variable_at_entry (struct symbol *symbol, const frame_info_ptr &fra
 {
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
-  const gdb_byte *data;
-  size_t size;
   CORE_ADDR pc;
 
   if (frame == NULL || !get_frame_func_if_available (frame, &pc))
     return value::allocate_optimized_out (symbol->type ());
 
-  data = dwarf2_find_location_expression (dlbaton, &size, pc, true);
-  if (data == NULL)
+  auto expr = dwarf2_find_location_expression (dlbaton, pc, true);
+  if (expr.empty ())
     return value::allocate_optimized_out (symbol->type ());
 
-  return value_of_dwarf_block_entry (symbol->type (), frame, data, size);
+  return value_of_dwarf_block_entry (symbol->type (), frame, expr);
 }
 
 /* Implementation of get_symbol_read_needs from
@@ -4088,9 +4052,10 @@ loclist_describe_location (struct symbol *symbol, CORE_ADDR addr,
 		  paddress (gdbarch, high_reloc));
 
       /* Now describe this particular location.  */
-      locexpr_describe_location_1 (symbol, low_reloc, stream, loc_ptr, length,
-				   addr_size, offset_size,
-				   dlbaton->per_cu, per_objfile);
+      locexpr_describe_location_1 (symbol, low_reloc, stream,
+				   gdb::make_array_view (loc_ptr, length),
+				   addr_size, offset_size, dlbaton->per_cu,
+				   per_objfile);
 
       gdb_printf (stream, "\n");
 
@@ -4106,16 +4071,14 @@ loclist_tracepoint_var_ref (struct symbol *symbol, struct agent_expr *ax,
 {
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
-  const gdb_byte *data;
-  size_t size;
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
 
-  data = dwarf2_find_location_expression (dlbaton, &size, ax->scope);
-  if (size == 0)
+  auto expr = dwarf2_find_location_expression (dlbaton, ax->scope);
+  if (expr.empty ())
     value->optimized_out = 1;
   else
-    dwarf2_compile_expr_to_ax (ax, value, addr_size, data, data + size,
-			       dlbaton->per_cu, dlbaton->per_objfile);
+    dwarf2_compile_expr_to_ax (ax, value, addr_size, expr, dlbaton->per_cu,
+			       dlbaton->per_objfile);
 }
 
 /* symbol_computed_ops 'generate_c_location' method.  */
@@ -4130,17 +4093,13 @@ loclist_generate_c_location (struct symbol *sym, string_file *stream,
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (sym);
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
-  const gdb_byte *data;
-  size_t size;
+  auto expr = dwarf2_find_location_expression (dlbaton, pc);
 
-  data = dwarf2_find_location_expression (dlbaton, &size, pc);
-  if (size == 0)
+  if (expr.empty ())
     error (_("symbol \"%s\" is optimized out"), sym->natural_name ());
 
-  compile_dwarf_expr_to_c (stream, result_name,
-			   sym, pc, gdbarch, registers_used, addr_size,
-			   data, data + size,
-			   dlbaton->per_cu,
+  compile_dwarf_expr_to_c (stream, result_name, sym, pc, gdbarch,
+			   registers_used, addr_size, expr, dlbaton->per_cu,
 			   dlbaton->per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");

--- a/gdb/dwarf2/loc.c
+++ b/gdb/dwarf2/loc.c
@@ -1505,10 +1505,9 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
   try
     {
       retval
-	= dwarf2_evaluate (loc_desc.data (), loc_desc.size (), as_lval,
-			   per_objfile, per_cu, frame, per_cu->addr_size (),
-			   nullptr, nullptr, type, subobj_type,
-			   subobj_byte_offset);
+	= dwarf2_evaluate (loc_desc, as_lval, per_objfile, per_cu, frame,
+			   per_cu->addr_size (), nullptr, nullptr, type,
+			   subobj_type, subobj_byte_offset);
     }
   catch (const gdb_exception_error &ex)
     {
@@ -1598,8 +1597,7 @@ dwarf2_locexpr_baton_eval (const struct dwarf2_locexpr_baton *dlbaton,
   try
     {
       result
-	= dwarf2_evaluate (dlbaton->expr ().data (), dlbaton->expr ().size (),
-			   true, per_objfile, per_cu, frame,
+	= dwarf2_evaluate (dlbaton->expr (), true, per_objfile, per_cu, frame,
 			   per_cu->addr_size (), &init_values, addr_stack);
     }
   catch (const gdb_exception_error &ex)

--- a/gdb/dwarf2/loc.c
+++ b/gdb/dwarf2/loc.c
@@ -50,9 +50,10 @@
 #include "extract-store-integer.h"
 
 static struct value *dwarf2_evaluate_loc_desc_full
-  (struct type *type, const frame_info_ptr &frame, const gdb_byte *data,
-   size_t size, dwarf2_per_cu *per_cu, dwarf2_per_objfile *per_objfile,
-   struct type *subobj_type, LONGEST subobj_byte_offset, bool as_lval = true);
+  (struct type *type, const frame_info_ptr &frame,
+   gdb::array_view<const gdb_byte> loc_desc, dwarf2_per_cu *per_cu,
+   dwarf2_per_objfile *per_objfile, struct type *subobj_type,
+   LONGEST subobj_byte_offset, bool as_lval = true);
 
 /* Until these have formal names, we define these here.
    ref: http://gcc.gnu.org/wiki/DebugFission
@@ -355,18 +356,16 @@ decode_debug_loc_dwo_addresses (dwarf2_per_cu *per_cu,
     }
 }
 
-/* A function for dealing with location lists.  Given a
-   symbol baton (BATON) and a pc value (PC), find the appropriate
-   location expression, set *LOCEXPR_LENGTH, and return a pointer
-   to the beginning of the expression.  Returns NULL on failure.
+/* A function for dealing with location lists.  Given a symbol baton
+   (BATON) and a pc value (PC), find and return the appropriate location
+   expression.  Returns an empty view on failure.
 
    For now, only return the first matching location expression; there
    can be more than one in the list.  */
 
-const gdb_byte *
+gdb::array_view<const gdb_byte>
 dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
-				 size_t *locexpr_length, const CORE_ADDR pc,
-				 bool at_entry)
+				 const CORE_ADDR pc, bool at_entry)
 {
   dwarf2_per_objfile *per_objfile = baton->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
@@ -411,8 +410,7 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
       switch (kind)
 	{
 	case DEBUG_LOC_END_OF_LIST:
-	  *locexpr_length = 0;
-	  return NULL;
+	  return {};
 
 	case DEBUG_LOC_BASE_ADDRESS:
 	  base_address = high;
@@ -471,17 +469,11 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
 	    pc_func = pc_block->linkage_function ();
 
 	  if (pc_func && pc == pc_func->value_block ()->entry_pc ())
-	    {
-	      *locexpr_length = length;
-	      return loc_ptr;
-	    }
+	    return gdb::make_array_view (loc_ptr, length);
 	}
 
       if (unrel_pc >= low && unrel_pc < high)
-	{
-	  *locexpr_length = length;
-	  return loc_ptr;
-	}
+	return gdb::make_array_view (loc_ptr, length);
 
       loc_ptr += length;
     }
@@ -490,15 +482,13 @@ dwarf2_find_location_expression (const dwarf2_loclist_baton *baton,
 /* Implement find_frame_base_location method for LOC_BLOCK functions using
    DWARF expression for its DW_AT_frame_base.  */
 
-static void
-locexpr_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc,
-				  const gdb_byte **start, size_t *length)
+static gdb::array_view<const gdb_byte>
+locexpr_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc)
 {
   struct dwarf2_locexpr_baton *symbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  *length = symbaton->size;
-  *start = symbaton->data;
+  return symbaton->expr ();
 }
 
 /* Implement the struct symbol_block_ops::get_frame_base method for
@@ -510,8 +500,6 @@ locexpr_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   struct gdbarch *gdbarch;
   struct type *type;
   struct dwarf2_locexpr_baton *dlbaton;
-  const gdb_byte *start;
-  size_t length;
   struct value *result;
 
   /* If this method is called, then FRAMEFUNC is supposed to be a DWARF block.
@@ -523,11 +511,11 @@ locexpr_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   type = builtin_type (gdbarch)->builtin_data_ptr;
   dlbaton = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  framefunc->block_ops ()->find_frame_base_location (framefunc,
-						     get_frame_pc (frame),
-						     &start, &length);
-  result = dwarf2_evaluate_loc_desc (type, frame, start, length,
-				     dlbaton->per_cu, dlbaton->per_objfile);
+  auto expr
+    = framefunc->block_ops ()->find_frame_base_location (framefunc,
+							 get_frame_pc (frame));
+  result = dwarf2_evaluate_loc_desc (type, frame, expr, dlbaton->per_cu,
+				     dlbaton->per_objfile);
 
   /* The DW_AT_frame_base attribute contains a location description which
      computes the base address itself.  However, the call to
@@ -549,14 +537,13 @@ const struct symbol_block_ops dwarf2_block_frame_base_locexpr_funcs =
 /* Implement find_frame_base_location method for LOC_BLOCK functions using
    DWARF location list for its DW_AT_frame_base.  */
 
-static void
-loclist_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc,
-				  const gdb_byte **start, size_t *length)
+static gdb::array_view<const gdb_byte>
+loclist_find_frame_base_location (struct symbol *framefunc, CORE_ADDR pc)
 {
   struct dwarf2_loclist_baton *symbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  *start = dwarf2_find_location_expression (symbaton, length, pc);
+  return dwarf2_find_location_expression (symbaton, pc);
 }
 
 /* Implement the struct symbol_block_ops::get_frame_base method for
@@ -568,8 +555,6 @@ loclist_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   struct gdbarch *gdbarch;
   struct type *type;
   struct dwarf2_loclist_baton *dlbaton;
-  const gdb_byte *start;
-  size_t length;
   struct value *result;
 
   /* If this method is called, then FRAMEFUNC is supposed to be a DWARF block.
@@ -581,11 +566,11 @@ loclist_get_frame_base (struct symbol *framefunc, const frame_info_ptr &frame)
   type = builtin_type (gdbarch)->builtin_data_ptr;
   dlbaton = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (framefunc);
 
-  framefunc->block_ops ()->find_frame_base_location (framefunc,
-						     get_frame_pc (frame),
-						     &start, &length);
-  result = dwarf2_evaluate_loc_desc (type, frame, start, length,
-				     dlbaton->per_cu, dlbaton->per_objfile);
+  auto expr
+    = framefunc->block_ops ()->find_frame_base_location (framefunc,
+							 get_frame_pc (frame));
+  result = dwarf2_evaluate_loc_desc (type, frame, expr, dlbaton->per_cu,
+				     dlbaton->per_objfile);
 
   /* The DW_AT_frame_base attribute contains a location description which
      computes the base address itself.  However, the call to
@@ -606,19 +591,20 @@ const struct symbol_block_ops dwarf2_block_frame_base_loclist_funcs =
 
 /* See dwarf2/loc.h.  */
 
-void
-func_get_frame_base_dwarf_block (struct symbol *framefunc, CORE_ADDR pc,
-				 const gdb_byte **start, size_t *length)
+gdb::array_view<const gdb_byte>
+func_get_frame_base_dwarf_block (struct symbol *framefunc, CORE_ADDR pc)
 {
+  gdb::array_view<const gdb_byte> block;
+
   if (const symbol_block_ops *block_ops = framefunc->block_ops ();
       block_ops != nullptr)
-    block_ops->find_frame_base_location (framefunc, pc, start, length);
-  else
-    *length = 0;
+    block = block_ops->find_frame_base_location (framefunc, pc);
 
-  if (*length == 0)
+  if (block.empty ())
     error (_("Could not find the frame base for \"%s\"."),
 	   framefunc->natural_name ());
+
+  return block;
 }
 
 /* See loc.h.  */
@@ -693,7 +679,7 @@ call_site_target::iterate_over_addresses (gdbarch *call_site_gdbarch,
 	caller_arch = get_frame_arch (caller_frame);
 	caller_core_addr_type = builtin_type (caller_arch)->builtin_func_ptr;
 	val = dwarf2_evaluate_loc_desc (caller_core_addr_type, caller_frame,
-					dwarf_block->data, dwarf_block->size,
+					dwarf_block->expr (),
 					dwarf_block->per_cu,
 					dwarf_block->per_objfile);
 	/* DW_AT_call_target is a DWARF expression, not a DWARF location.  */
@@ -1276,8 +1262,9 @@ dwarf_entry_parameter_to_value (struct call_site_parameter *parameter,
     throw_error (NO_ENTRY_VALUE_ERROR,
 		 _("Cannot resolve DW_AT_call_data_value"));
 
-  return dwarf2_evaluate_loc_desc (type, caller_frame, data_src, size, per_cu,
-				   per_objfile, false);
+  return dwarf2_evaluate_loc_desc (type, caller_frame,
+				   gdb::make_array_view (data_src, size),
+				   per_cu, per_objfile, false);
 }
 
 /* VALUE must be of type lval_computed with entry_data_value_funcs.  Perform
@@ -1386,8 +1373,8 @@ value_of_dwarf_reg_entry (struct type *type, const frame_info_ptr &frame,
   return val;
 }
 
-/* Read parameter of TYPE at (callee) FRAME's function entry.  DATA and
-   SIZE are DWARF block used to match DW_AT_location at the caller's
+/* Read parameter of TYPE at (callee) FRAME's function entry.  BLOCK is the
+   DWARF block used to match DW_AT_location at the caller's
    DW_TAG_call_site_parameter.
 
    Function always returns non-NULL value.  It throws NO_ENTRY_VALUE_ERROR if it
@@ -1395,16 +1382,16 @@ value_of_dwarf_reg_entry (struct type *type, const frame_info_ptr &frame,
 
 static struct value *
 value_of_dwarf_block_entry (struct type *type, const frame_info_ptr &frame,
-			    const gdb_byte *block, size_t block_len)
+			    gdb::array_view<const gdb_byte> block)
 {
   union call_site_parameter_u kind_u;
 
-  kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (block, block + block_len);
+  kind_u.dwarf_reg = dwarf_block_to_dwarf_reg (block);
   if (kind_u.dwarf_reg != -1)
     return value_of_dwarf_reg_entry (type, frame, CALL_SITE_PARAMETER_DWARF_REG,
 				     kind_u);
 
-  if (dwarf_block_to_fb_offset (block, block + block_len, &kind_u.fb_offset))
+  if (dwarf_block_to_fb_offset (block, &kind_u.fb_offset))
     return value_of_dwarf_reg_entry (type, frame, CALL_SITE_PARAMETER_FB_OFFSET,
 				     kind_u);
 
@@ -1477,26 +1464,24 @@ indirect_synthetic_pointer (sect_offset die, LONGEST byte_offset,
   /* If pointed-to DIE has a DW_AT_location, evaluate it and return the
      resulting value.  Otherwise, it may have a DW_AT_const_value instead,
      or it may've been optimized out.  */
-  if (baton.data != NULL)
-    return dwarf2_evaluate_loc_desc_full (orig_type, frame, baton.data,
-					  baton.size, baton.per_cu,
+  auto expr = baton.expr ();
+  if (!expr.empty ())
+    return dwarf2_evaluate_loc_desc_full (orig_type, frame, expr, baton.per_cu,
 					  baton.per_objfile,
-					  type->target_type (),
-					  byte_offset);
+					  type->target_type (), byte_offset);
   else
     return fetch_const_value_from_synthetic_pointer (die, byte_offset, per_cu,
 						     per_objfile, type);
 }
 
-/* Evaluate a location description, starting at DATA and with length
-   SIZE, to find the current location of variable of TYPE in the
-   context of FRAME.  If SUBOBJ_TYPE is non-NULL, return instead the
-   location of the subobject of type SUBOBJ_TYPE at byte offset
-   SUBOBJ_BYTE_OFFSET within the variable of type TYPE.  */
+/* Evaluate the location description LOC_DESC to find the current location
+   of variable of TYPE in the context of FRAME.  If SUBOBJ_TYPE is non-NULL,
+   return instead the location of the subobject of type SUBOBJ_TYPE at byte
+   offset SUBOBJ_BYTE_OFFSET within the variable of type TYPE.  */
 
 static struct value *
 dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
-			       const gdb_byte *data, size_t size,
+			       gdb::array_view<const gdb_byte> loc_desc,
 			       dwarf2_per_cu *per_cu,
 			       dwarf2_per_objfile *per_objfile,
 			       struct type *subobj_type,
@@ -1511,7 +1496,7 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
   else if (subobj_byte_offset < 0)
     invalid_synthetic_pointer ();
 
-  if (size == 0)
+  if (loc_desc.empty ())
     return value::allocate_optimized_out (subobj_type);
 
   value *retval;
@@ -1520,9 +1505,10 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
   try
     {
       retval
-	= dwarf2_evaluate (data, size, as_lval, per_objfile, per_cu,
-			   frame, per_cu->addr_size (), nullptr, nullptr,
-			   type, subobj_type, subobj_byte_offset);
+	= dwarf2_evaluate (loc_desc.data (), loc_desc.size (), as_lval,
+			   per_objfile, per_cu, frame, per_cu->addr_size (),
+			   nullptr, nullptr, type, subobj_type,
+			   subobj_byte_offset);
     }
   catch (const gdb_exception_error &ex)
     {
@@ -1561,11 +1547,11 @@ dwarf2_evaluate_loc_desc_full (struct type *type, const frame_info_ptr &frame,
 
 struct value *
 dwarf2_evaluate_loc_desc (struct type *type, const frame_info_ptr &frame,
-			  const gdb_byte *data, size_t size,
+			  gdb::array_view<const gdb_byte> loc_desc,
 			  dwarf2_per_cu *per_cu,
 			  dwarf2_per_objfile *per_objfile, bool as_lval)
 {
-  return dwarf2_evaluate_loc_desc_full (type, frame, data, size, per_cu,
+  return dwarf2_evaluate_loc_desc_full (type, frame, loc_desc, per_cu,
 					per_objfile, NULL, 0, as_lval);
 }
 
@@ -1612,9 +1598,9 @@ dwarf2_locexpr_baton_eval (const struct dwarf2_locexpr_baton *dlbaton,
   try
     {
       result
-	= dwarf2_evaluate (dlbaton->data, dlbaton->size, true, per_objfile,
-			   per_cu, frame, per_cu->addr_size (), &init_values,
-			   addr_stack);
+	= dwarf2_evaluate (dlbaton->expr ().data (), dlbaton->expr ().size (),
+			   true, per_objfile, per_cu, frame,
+			   per_cu->addr_size (), &init_values, addr_stack);
     }
   catch (const gdb_exception_error &ex)
     {
@@ -1711,19 +1697,17 @@ dwarf2_evaluate_property (const dynamic_prop *prop,
       {
 	const dwarf2_property_baton *baton = prop->baton ();
 	CORE_ADDR pc;
-	const gdb_byte *data;
 	struct value *val;
-	size_t size;
 
 	if (frame == NULL
 	    || !get_frame_address_in_block_if_available (frame, &pc))
 	  return false;
 
-	data = dwarf2_find_location_expression (&baton->loclist, &size, pc);
-	if (data != NULL)
+	auto data = dwarf2_find_location_expression (&baton->loclist, pc);
+	if (!data.empty ())
 	  {
 	    val = dwarf2_evaluate_loc_desc (baton->property_type, frame, data,
-					    size, baton->loclist.per_cu,
+					    baton->loclist.per_cu,
 					    baton->loclist.per_objfile);
 	    if (!val->optimized_out ())
 	      {
@@ -1816,15 +1800,13 @@ dwarf2_compile_property_to_c (string_file *stream,
 {
 #if defined (HAVE_COMPILE)
   const dwarf2_property_baton *baton = prop->baton ();
-  const gdb_byte *data;
-  size_t size;
+  gdb::array_view<const gdb_byte> expr;
   dwarf2_per_cu *per_cu;
   dwarf2_per_objfile *per_objfile;
 
   if (prop->kind () == PROP_LOCEXPR)
     {
-      data = baton->locexpr.data;
-      size = baton->locexpr.size;
+      expr = baton->locexpr.expr ();
       per_cu = baton->locexpr.per_cu;
       per_objfile = baton->locexpr.per_objfile;
     }
@@ -1832,15 +1814,14 @@ dwarf2_compile_property_to_c (string_file *stream,
     {
       gdb_assert (prop->kind () == PROP_LOCLIST);
 
-      data = dwarf2_find_location_expression (&baton->loclist, &size, pc);
+      expr = dwarf2_find_location_expression (&baton->loclist, pc);
       per_cu = baton->loclist.per_cu;
       per_objfile = baton->loclist.per_objfile;
     }
 
-  compile_dwarf_bounds_to_c (stream, result_name, prop, sym, pc,
-			     gdbarch, registers_used,
-			     per_cu->addr_size (),
-			     data, data + size, per_cu, per_objfile);
+  compile_dwarf_bounds_to_c (stream, result_name, prop, sym, pc, gdbarch,
+			     registers_used, per_cu->addr_size (), expr,
+			     per_cu, per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");
 #endif
@@ -1958,36 +1939,38 @@ access_memory (struct gdbarch *arch, struct agent_expr *expr, ULONGEST nbits)
 
 /* Compile a DWARF location expression to an agent expression.
 
-   EXPR is the agent expression we are building.
+   AX is the agent expression we are building.
    LOC is the agent value we modify.
-   ARCH is the architecture.
    ADDR_SIZE is the size of addresses, in bytes.
-   OP_PTR is the start of the location expression.
-   OP_END is one past the last byte of the location expression.
+   EXPR is the location expression.
 
    This will throw an exception for various kinds of errors -- for
    example, if the expression cannot be compiled, or if the expression
    is invalid.  */
 
 static void
-dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
-			   unsigned int addr_size, const gdb_byte *op_ptr,
-			   const gdb_byte *op_end, dwarf2_per_cu *per_cu,
+dwarf2_compile_expr_to_ax (struct agent_expr *ax, struct axs_value *loc,
+			   unsigned int addr_size,
+			   gdb::array_view<const gdb_byte> expr,
+			   dwarf2_per_cu *per_cu,
 			   dwarf2_per_objfile *per_objfile)
 {
-  gdbarch *arch = expr->gdbarch;
+  gdbarch *arch = ax->gdbarch;
   std::vector<int> dw_labels, patches;
-  const gdb_byte * const base = op_ptr;
-  const gdb_byte *previous_piece = op_ptr;
+  const gdb_byte *previous_piece = expr.data ();
   enum bfd_endian byte_order = gdbarch_byte_order (arch);
   ULONGEST bits_collected = 0;
   unsigned int addr_size_bits = 8 * addr_size;
   bool bits_big_endian = byte_order == BFD_ENDIAN_BIG;
 
-  std::vector<int> offsets (op_end - op_ptr, -1);
+  std::vector<int> offsets (expr.size (), -1);
 
   /* By default we are making an address.  */
   loc->kind = axs_lvalue_memory;
+
+  const gdb_byte *const base = expr.data ();
+  const gdb_byte *op_ptr = expr.data ();
+  const gdb_byte *const op_end = expr.data () + expr.size ();
 
   while (op_ptr < op_end)
     {
@@ -1996,7 +1979,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
       int64_t offset;
       int i;
 
-      offsets[op_ptr - base] = expr->buf.size ();
+      offsets[op_ptr - base] = ax->buf.size ();
       ++op_ptr;
 
       /* Our basic approach to code generation is to map DWARF
@@ -2049,7 +2032,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_lit29:
 	case DW_OP_lit30:
 	case DW_OP_lit31:
-	  ax_const_l (expr, op - DW_OP_lit0);
+	  ax_const_l (ax, op - DW_OP_lit0);
 	  break;
 
 	case DW_OP_addr:
@@ -2061,57 +2044,57 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	     branching between the address and the TLS op.  */
 	  if (op_ptr >= op_end || *op_ptr != DW_OP_GNU_push_tls_address)
 	    uoffset += per_objfile->objfile->text_section_offset ();
-	  ax_const_l (expr, uoffset);
+	  ax_const_l (ax, uoffset);
 	  break;
 
 	case DW_OP_const1u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 1, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 1, byte_order));
 	  op_ptr += 1;
 	  break;
 
 	case DW_OP_const1s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 1, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 1, byte_order));
 	  op_ptr += 1;
 	  break;
 
 	case DW_OP_const2u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 2, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 2, byte_order));
 	  op_ptr += 2;
 	  break;
 
 	case DW_OP_const2s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 2, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 2, byte_order));
 	  op_ptr += 2;
 	  break;
 
 	case DW_OP_const4u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 4, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 4, byte_order));
 	  op_ptr += 4;
 	  break;
 
 	case DW_OP_const4s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 4, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 4, byte_order));
 	  op_ptr += 4;
 	  break;
 
 	case DW_OP_const8u:
-	  ax_const_l (expr, extract_unsigned_integer (op_ptr, 8, byte_order));
+	  ax_const_l (ax, extract_unsigned_integer (op_ptr, 8, byte_order));
 	  op_ptr += 8;
 	  break;
 
 	case DW_OP_const8s:
-	  ax_const_l (expr, extract_signed_integer (op_ptr, 8, byte_order));
+	  ax_const_l (ax, extract_signed_integer (op_ptr, 8, byte_order));
 	  op_ptr += 8;
 	  break;
 
 	case DW_OP_constu:
 	  op_ptr = safe_read_uleb128 (op_ptr, op_end, &uoffset);
-	  ax_const_l (expr, uoffset);
+	  ax_const_l (ax, uoffset);
 	  break;
 
 	case DW_OP_consts:
 	  op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
-	  ax_const_l (expr, offset);
+	  ax_const_l (ax, offset);
 	  break;
 
 	case DW_OP_reg0:
@@ -2169,7 +2152,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	      error (_("Cannot translate DW_OP_implicit_value of %d bytes"),
 		     (int) len);
 
-	    ax_const_l (expr, extract_unsigned_integer (op_ptr, len,
+	    ax_const_l (ax, extract_unsigned_integer (op_ptr, len,
 							byte_order));
 	    op_ptr += len;
 	    dwarf_expr_require_composition (op_ptr, op_end,
@@ -2218,11 +2201,11 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_breg31:
 	  op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 	  i = dwarf_reg_to_regnum_or_error (arch, op - DW_OP_breg0);
-	  ax_reg (expr, i);
+	  ax_reg (ax, i);
 	  if (offset != 0)
 	    {
-	      ax_const_l (expr, offset);
-	      ax_simple (expr, aop_add);
+	      ax_const_l (ax, offset);
+	      ax_simple (ax, aop_add);
 	    }
 	  break;
 
@@ -2231,23 +2214,21 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    op_ptr = safe_read_uleb128 (op_ptr, op_end, &reg);
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
 	    i = dwarf_reg_to_regnum_or_error (arch, reg);
-	    ax_reg (expr, i);
+	    ax_reg (ax, i);
 	    if (offset != 0)
 	      {
-		ax_const_l (expr, offset);
-		ax_simple (expr, aop_add);
+		ax_const_l (ax, offset);
+		ax_simple (ax, aop_add);
 	      }
 	  }
 	  break;
 
 	case DW_OP_fbreg:
 	  {
-	    const gdb_byte *datastart;
-	    size_t datalen;
 	    const struct block *b;
 	    struct symbol *framefunc;
 
-	    b = block_for_pc (expr->scope);
+	    b = block_for_pc (ax->scope);
 
 	    if (!b)
 	      error (_("No block found for address"));
@@ -2257,20 +2238,19 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    if (!framefunc)
 	      error (_("No function found for block"));
 
-	    func_get_frame_base_dwarf_block (framefunc, expr->scope,
-					     &datastart, &datalen);
+	    auto frame_base_expr = func_get_frame_base_dwarf_block (framefunc,
+								    ax->scope);
 
 	    op_ptr = safe_read_sleb128 (op_ptr, op_end, &offset);
-	    dwarf2_compile_expr_to_ax (expr, loc, addr_size, datastart,
-				       datastart + datalen, per_cu,
-				       per_objfile);
+	    dwarf2_compile_expr_to_ax (ax, loc, addr_size, frame_base_expr,
+				       per_cu, per_objfile);
 	    if (loc->kind == axs_lvalue_register)
-	      require_rvalue (expr, loc);
+	      require_rvalue (ax, loc);
 
 	    if (offset != 0)
 	      {
-		ax_const_l (expr, offset);
-		ax_simple (expr, aop_add);
+		ax_const_l (ax, offset);
+		ax_simple (ax, aop_add);
 	      }
 
 	    loc->kind = axs_lvalue_memory;
@@ -2278,28 +2258,28 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	  break;
 
 	case DW_OP_dup:
-	  ax_simple (expr, aop_dup);
+	  ax_simple (ax, aop_dup);
 	  break;
 
 	case DW_OP_drop:
-	  ax_simple (expr, aop_pop);
+	  ax_simple (ax, aop_pop);
 	  break;
 
 	case DW_OP_pick:
 	  offset = *op_ptr++;
-	  ax_pick (expr, offset);
+	  ax_pick (ax, offset);
 	  break;
 
 	case DW_OP_swap:
-	  ax_simple (expr, aop_swap);
+	  ax_simple (ax, aop_swap);
 	  break;
 
 	case DW_OP_over:
-	  ax_pick (expr, 1);
+	  ax_pick (ax, 1);
 	  break;
 
 	case DW_OP_rot:
-	  ax_simple (expr, aop_rot);
+	  ax_simple (ax, aop_rot);
 	  break;
 
 	case DW_OP_deref:
@@ -2315,36 +2295,36 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    if (size != 1 && size != 2 && size != 4 && size != 8)
 	      error (_("Unsupported size %d in %s"),
 		     size, get_DW_OP_name (op));
-	    access_memory (arch, expr, size * TARGET_CHAR_BIT);
+	    access_memory (arch, ax, size * TARGET_CHAR_BIT);
 	  }
 	  break;
 
 	case DW_OP_abs:
 	  /* Sign extend the operand.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_dup);
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
-	  i = ax_goto (expr, aop_if_goto);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_dup);
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
+	  i = ax_goto (ax, aop_if_goto);
 	  /* We have to emit 0 - X.  */
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_sub);
-	  ax_label (expr, i, expr->buf.size ());
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_sub);
+	  ax_label (ax, i, ax->buf.size ());
 	  break;
 
 	case DW_OP_neg:
 	  /* No need to sign extend here.  */
-	  ax_const_l (expr, 0);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_sub);
+	  ax_const_l (ax, 0);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_sub);
 	  break;
 
 	case DW_OP_not:
 	  /* Sign extend the operand.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_bit_not);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_bit_not);
 	  break;
 
 	case DW_OP_plus_uconst:
@@ -2353,116 +2333,116 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	     but we micro-optimize anyhow.  */
 	  if (reg != 0)
 	    {
-	      ax_const_l (expr, reg);
-	      ax_simple (expr, aop_add);
+	      ax_const_l (ax, reg);
+	      ax_simple (ax, aop_add);
 	    }
 	  break;
 
 	case DW_OP_and:
-	  ax_simple (expr, aop_bit_and);
+	  ax_simple (ax, aop_bit_and);
 	  break;
 
 	case DW_OP_div:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_div_signed);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_div_signed);
 	  break;
 
 	case DW_OP_minus:
-	  ax_simple (expr, aop_sub);
+	  ax_simple (ax, aop_sub);
 	  break;
 
 	case DW_OP_mod:
-	  ax_simple (expr, aop_rem_unsigned);
+	  ax_simple (ax, aop_rem_unsigned);
 	  break;
 
 	case DW_OP_mul:
-	  ax_simple (expr, aop_mul);
+	  ax_simple (ax, aop_mul);
 	  break;
 
 	case DW_OP_or:
-	  ax_simple (expr, aop_bit_or);
+	  ax_simple (ax, aop_bit_or);
 	  break;
 
 	case DW_OP_plus:
-	  ax_simple (expr, aop_add);
+	  ax_simple (ax, aop_add);
 	  break;
 
 	case DW_OP_shl:
-	  ax_simple (expr, aop_lsh);
+	  ax_simple (ax, aop_lsh);
 	  break;
 
 	case DW_OP_shr:
-	  ax_simple (expr, aop_rsh_unsigned);
+	  ax_simple (ax, aop_rsh_unsigned);
 	  break;
 
 	case DW_OP_shra:
-	  ax_simple (expr, aop_rsh_signed);
+	  ax_simple (ax, aop_rsh_signed);
 	  break;
 
 	case DW_OP_xor:
-	  ax_simple (expr, aop_bit_xor);
+	  ax_simple (ax, aop_bit_xor);
 	  break;
 
 	case DW_OP_le:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* Note no swap here: A <= B is !(B < A).  */
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_ge:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
 	  /* A >= B is !(A < B).  */
-	  ax_simple (expr, aop_less_signed);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_less_signed);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_eq:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* No need for a second swap here.  */
-	  ax_simple (expr, aop_equal);
+	  ax_simple (ax, aop_equal);
 	  break;
 
 	case DW_OP_lt:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_simple (expr, aop_less_signed);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_simple (ax, aop_less_signed);
 	  break;
 
 	case DW_OP_gt:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* Note no swap here: A > B is B < A.  */
-	  ax_simple (expr, aop_less_signed);
+	  ax_simple (ax, aop_less_signed);
 	  break;
 
 	case DW_OP_ne:
 	  /* Sign extend the operands.  */
-	  ax_ext (expr, addr_size_bits);
-	  ax_simple (expr, aop_swap);
-	  ax_ext (expr, addr_size_bits);
+	  ax_ext (ax, addr_size_bits);
+	  ax_simple (ax, aop_swap);
+	  ax_ext (ax, addr_size_bits);
 	  /* No need for a swap here.  */
-	  ax_simple (expr, aop_equal);
-	  ax_simple (expr, aop_log_not);
+	  ax_simple (ax, aop_equal);
+	  ax_simple (ax, aop_log_not);
 	  break;
 
 	case DW_OP_call_frame_cfa:
@@ -2470,26 +2450,25 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    int regnum;
 	    CORE_ADDR text_offset;
 	    LONGEST off;
-	    const gdb_byte *cfa_start, *cfa_end;
+	    gdb::array_view<const gdb_byte> cfa_expr;
 
-	    if (dwarf2_fetch_cfa_info (arch, expr->scope, per_cu,
-				       &regnum, &off,
-				       &text_offset, &cfa_start, &cfa_end))
+	    if (dwarf2_fetch_cfa_info (arch, ax->scope, per_cu, &regnum,
+				       &off, &text_offset, cfa_expr))
 	      {
 		/* Register.  */
-		ax_reg (expr, regnum);
+		ax_reg (ax, regnum);
 		if (off != 0)
 		  {
-		    ax_const_l (expr, off);
-		    ax_simple (expr, aop_add);
+		    ax_const_l (ax, off);
+		    ax_simple (ax, aop_add);
 		  }
 	      }
 	    else
 	      {
 		/* Another expression.  */
-		ax_const_l (expr, text_offset);
-		dwarf2_compile_expr_to_ax (expr, loc, addr_size, cfa_start,
-					   cfa_end, per_cu, per_objfile);
+		ax_const_l (ax, text_offset);
+		dwarf2_compile_expr_to_ax (ax, loc, addr_size, cfa_expr,
+					   per_cu, per_objfile);
 	      }
 
 	    loc->kind = axs_lvalue_memory;
@@ -2508,7 +2487,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	case DW_OP_skip:
 	  offset = extract_signed_integer (op_ptr, 2, byte_order);
 	  op_ptr += 2;
-	  i = ax_goto (expr, aop_goto);
+	  i = ax_goto (ax, aop_goto);
 	  dw_labels.push_back (op_ptr + offset - base);
 	  patches.push_back (i);
 	  break;
@@ -2517,8 +2496,8 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	  offset = extract_signed_integer (op_ptr, 2, byte_order);
 	  op_ptr += 2;
 	  /* Zero extend the operand.  */
-	  ax_zero_ext (expr, addr_size_bits);
-	  i = ax_goto (expr, aop_if_goto);
+	  ax_zero_ext (ax, addr_size_bits);
+	  i = ax_goto (ax, aop_if_goto);
 	  dw_labels.push_back (op_ptr + offset - base);
 	  patches.push_back (i);
 	  break;
@@ -2551,18 +2530,18 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    switch (loc->kind)
 	      {
 	      case axs_lvalue_register:
-		ax_reg (expr, loc->u.reg);
+		ax_reg (ax, loc->u.reg);
 		break;
 
 	      case axs_lvalue_memory:
 		/* Offset the pointer, if needed.  */
 		if (uoffset > 8)
 		  {
-		    ax_const_l (expr, uoffset / 8);
-		    ax_simple (expr, aop_add);
+		    ax_const_l (ax, uoffset / 8);
+		    ax_simple (ax, aop_add);
 		    uoffset %= 8;
 		  }
-		access_memory (arch, expr, size);
+		access_memory (arch, ax, size);
 		break;
 	      }
 
@@ -2575,18 +2554,18 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	      {
 		if (bits_big_endian)
 		  {
-		    ax_simple (expr, aop_swap);
-		    ax_const_l (expr, size);
-		    ax_simple (expr, aop_lsh);
+		    ax_simple (ax, aop_swap);
+		    ax_const_l (ax, size);
+		    ax_simple (ax, aop_lsh);
 		    /* We don't need a second swap here, because
 		       aop_bit_or is symmetric.  */
 		  }
 		else
 		  {
-		    ax_const_l (expr, size);
-		    ax_simple (expr, aop_lsh);
+		    ax_const_l (ax, size);
+		    ax_simple (ax, aop_lsh);
 		  }
-		ax_simple (expr, aop_bit_or);
+		ax_simple (ax, aop_bit_or);
 	      }
 
 	    bits_collected += size;
@@ -2606,9 +2585,9 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    uoffset = extract_unsigned_integer (op_ptr, size, byte_order);
 	    op_ptr += size;
 
-	    auto get_frame_pc_from_expr = [expr] ()
+	    auto get_frame_pc_from_expr = [ax] ()
 	      {
-		return expr->scope;
+		return ax->scope;
 	      };
 	    cu_offset cuoffset = (cu_offset) uoffset;
 	    block = dwarf2_fetch_die_loc_cu_off (cuoffset, per_cu, per_objfile,
@@ -2617,9 +2596,8 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
 	    /* DW_OP_call_ref is currently not supported.  */
 	    gdb_assert (block.per_cu == per_cu);
 
-	    dwarf2_compile_expr_to_ax (expr, loc, addr_size, block.data,
-				       block.data + block.size, per_cu,
-				       per_objfile);
+	    dwarf2_compile_expr_to_ax (ax, loc, addr_size, block.expr (),
+				       per_cu, per_objfile);
 	  }
 	  break;
 
@@ -2640,7 +2618,7 @@ dwarf2_compile_expr_to_ax (struct agent_expr *expr, struct axs_value *loc,
       int targ = offsets[dw_labels[i]];
       if (targ == -1)
 	internal_error (_("invalid label"));
-      ax_label (expr, patches[i], targ);
+      ax_label (ax, patches[i], targ);
     }
 }
 
@@ -2654,9 +2632,8 @@ locexpr_read_variable (struct symbol *symbol, const frame_info_ptr &frame)
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (symbol);
   struct value *val;
 
-  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, dlbaton->data,
-				  dlbaton->size, dlbaton->per_cu,
-				  dlbaton->per_objfile);
+  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, dlbaton->expr (),
+				  dlbaton->per_cu, dlbaton->per_objfile);
 
   return val;
 }
@@ -2671,8 +2648,7 @@ locexpr_read_variable_at_entry (struct symbol *symbol, const frame_info_ptr &fra
   struct dwarf2_locexpr_baton *dlbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (symbol);
 
-  return value_of_dwarf_block_entry (symbol->type (), frame, dlbaton->data,
-				     dlbaton->size);
+  return value_of_dwarf_block_entry (symbol->type (), frame, dlbaton->expr ());
 }
 
 /* Return true if DATA points to the end of a piece.  END is one past
@@ -2751,8 +2727,7 @@ locexpr_describe_location_piece (struct symbol *symbol, struct ui_file *stream,
       struct symbol *framefunc;
       int frame_reg = 0;
       int64_t frame_offset;
-      const gdb_byte *base_data, *new_data, *save_data = data;
-      size_t base_size;
+      const gdb_byte *new_data, *save_data = data;
       int64_t base_offset = 0;
 
       new_data = safe_read_sleb128 (data + 1, end, &frame_offset);
@@ -2772,30 +2747,34 @@ locexpr_describe_location_piece (struct symbol *symbol, struct ui_file *stream,
 	error (_("No function found for block for symbol \"%s\"."),
 	       symbol->print_name ());
 
-      func_get_frame_base_dwarf_block (framefunc, addr, &base_data, &base_size);
+      auto frame_base_expr = func_get_frame_base_dwarf_block (framefunc, addr);
+      gdb_byte op0 = frame_base_expr[0];
 
-      if (base_data[0] >= DW_OP_breg0 && base_data[0] <= DW_OP_breg31)
+      if (op0 >= DW_OP_breg0 && op0 <= DW_OP_breg31)
 	{
 	  const gdb_byte *buf_end;
 
-	  frame_reg = base_data[0] - DW_OP_breg0;
-	  buf_end = safe_read_sleb128 (base_data + 1, base_data + base_size,
+	  frame_reg = op0 - DW_OP_breg0;
+	  buf_end = safe_read_sleb128 (frame_base_expr.data () + 1,
+				       (frame_base_expr.data ()
+					+ frame_base_expr.size ()),
 				       &base_offset);
 	/* If a location description is allowed to be placed on a DWARF
 	   stack, this becomes a valid case which is too complex to be
 	   described here.  */
-	  if (buf_end != base_data + base_size)
+	  if (buf_end != frame_base_expr.data () + frame_base_expr.size ())
 	    return save_data;
 	}
-      else if (base_data[0] >= DW_OP_reg0 && base_data[0] <= DW_OP_reg31)
+      else if (op0 >= DW_OP_reg0 && op0 <= DW_OP_reg31)
 	{
 	/* If the next operation doesn't define the end of a piece, the
 	   expression is too complex to be described here.  */
-	  if (!piece_end_p (base_data + 1, base_data + base_size))
+	  if (!piece_end_p (frame_base_expr.data () + 1,
+			    frame_base_expr.data () + frame_base_expr.size ()))
 	    return save_data;
 
 	  /* The frame base is just the register, with no offset.  */
-	  frame_reg = base_data[0] - DW_OP_reg0;
+	  frame_reg = op0 - DW_OP_reg0;
 	  base_offset = 0;
 	}
       else
@@ -3585,12 +3564,13 @@ show_dwarf_always_disassemble (struct ui_file *file, int from_tty,
 static void
 locexpr_describe_location_1 (struct symbol *symbol, CORE_ADDR addr,
 			     struct ui_file *stream,
-			     const gdb_byte *data, size_t size,
+			     gdb::array_view<const gdb_byte> expr,
 			     unsigned int addr_size,
 			     int offset_size, dwarf2_per_cu *per_cu,
 			     dwarf2_per_objfile *per_objfile)
 {
-  const gdb_byte *end = data + size;
+  const gdb_byte *data = expr.data ();
+  const gdb_byte *const end = expr.data () + expr.size ();
   int first_piece = 1, bad = 0;
   objfile *objfile = per_objfile->objfile;
 
@@ -3697,7 +3677,7 @@ locexpr_describe_location (struct symbol *symbol, CORE_ADDR addr,
   int offset_size = dlbaton->per_cu->offset_size ();
 
   locexpr_describe_location_1 (symbol, addr, stream,
-			       dlbaton->data, dlbaton->size,
+			       dlbaton->expr (),
 			       addr_size, offset_size,
 			       dlbaton->per_cu, dlbaton->per_objfile);
 }
@@ -3716,9 +3696,8 @@ locexpr_tracepoint_var_ref (struct symbol *symbol, struct agent_expr *ax,
   if (dlbaton->size == 0)
     value->optimized_out = 1;
   else
-    dwarf2_compile_expr_to_ax (ax, value, addr_size, dlbaton->data,
-			       dlbaton->data + dlbaton->size, dlbaton->per_cu,
-			       dlbaton->per_objfile);
+    dwarf2_compile_expr_to_ax (ax, value, addr_size, dlbaton->expr (),
+			       dlbaton->per_cu, dlbaton->per_objfile);
 }
 
 /* symbol_computed_ops 'generate_c_location' method.  */
@@ -3733,14 +3712,14 @@ locexpr_generate_c_location (struct symbol *sym, string_file *stream,
   struct dwarf2_locexpr_baton *dlbaton
     = (struct dwarf2_locexpr_baton *) SYMBOL_LOCATION_BATON (sym);
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
+  auto expr = dlbaton->expr ();
 
-  if (dlbaton->size == 0)
+  if (expr.empty ())
     error (_("symbol \"%s\" is optimized out"), sym->natural_name ());
 
-  compile_dwarf_expr_to_c (stream, result_name,
-			   sym, pc, gdbarch, registers_used, addr_size,
-			   dlbaton->data, dlbaton->data + dlbaton->size,
-			   dlbaton->per_cu, dlbaton->per_objfile);
+  compile_dwarf_expr_to_c (stream, result_name, sym, pc, gdbarch,
+			   registers_used, addr_size, expr, dlbaton->per_cu,
+			   dlbaton->per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");
 #endif
@@ -3769,13 +3748,11 @@ loclist_read_variable (struct symbol *symbol, const frame_info_ptr &frame)
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
   struct value *val;
-  const gdb_byte *data;
-  size_t size;
   ensure_have_frame (frame, "loclist");
 
   CORE_ADDR pc = get_frame_address_in_block (frame);
-  data = dwarf2_find_location_expression (dlbaton, &size, pc);
-  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, data, size,
+  auto expr = dwarf2_find_location_expression (dlbaton, pc);
+  val = dwarf2_evaluate_loc_desc (symbol->type (), frame, expr,
 				  dlbaton->per_cu, dlbaton->per_objfile);
 
   return val;
@@ -3794,8 +3771,6 @@ loclist_read_variable_at_entry (struct symbol *symbol, const frame_info_ptr &fra
 {
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
-  const gdb_byte *data;
-  size_t size;
   CORE_ADDR pc;
 
   ensure_have_frame (frame, "loclist at entry");
@@ -3803,11 +3778,11 @@ loclist_read_variable_at_entry (struct symbol *symbol, const frame_info_ptr &fra
   if (!get_frame_func_if_available (frame, &pc))
     return value::allocate_optimized_out (symbol->type ());
 
-  data = dwarf2_find_location_expression (dlbaton, &size, pc, true);
-  if (data == NULL)
+  auto expr = dwarf2_find_location_expression (dlbaton, pc, true);
+  if (expr.empty ())
     return value::allocate_optimized_out (symbol->type ());
 
-  return value_of_dwarf_block_entry (symbol->type (), frame, data, size);
+  return value_of_dwarf_block_entry (symbol->type (), frame, expr);
 }
 
 /* Print a natural-language description of SYMBOL to STREAM.  This
@@ -3918,9 +3893,10 @@ loclist_describe_location (struct symbol *symbol, CORE_ADDR addr,
 		  paddress (gdbarch, high_reloc));
 
       /* Now describe this particular location.  */
-      locexpr_describe_location_1 (symbol, low_reloc, stream, loc_ptr, length,
-				   addr_size, offset_size,
-				   dlbaton->per_cu, per_objfile);
+      locexpr_describe_location_1 (symbol, low_reloc, stream,
+				   gdb::make_array_view (loc_ptr, length),
+				   addr_size, offset_size, dlbaton->per_cu,
+				   per_objfile);
 
       gdb_printf (stream, "\n");
 
@@ -3936,16 +3912,14 @@ loclist_tracepoint_var_ref (struct symbol *symbol, struct agent_expr *ax,
 {
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (symbol);
-  const gdb_byte *data;
-  size_t size;
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
 
-  data = dwarf2_find_location_expression (dlbaton, &size, ax->scope);
-  if (size == 0)
+  auto expr = dwarf2_find_location_expression (dlbaton, ax->scope);
+  if (expr.empty ())
     value->optimized_out = 1;
   else
-    dwarf2_compile_expr_to_ax (ax, value, addr_size, data, data + size,
-			       dlbaton->per_cu, dlbaton->per_objfile);
+    dwarf2_compile_expr_to_ax (ax, value, addr_size, expr, dlbaton->per_cu,
+			       dlbaton->per_objfile);
 }
 
 /* symbol_computed_ops 'generate_c_location' method.  */
@@ -3960,17 +3934,13 @@ loclist_generate_c_location (struct symbol *sym, string_file *stream,
   struct dwarf2_loclist_baton *dlbaton
     = (struct dwarf2_loclist_baton *) SYMBOL_LOCATION_BATON (sym);
   unsigned int addr_size = dlbaton->per_cu->addr_size ();
-  const gdb_byte *data;
-  size_t size;
+  auto expr = dwarf2_find_location_expression (dlbaton, pc);
 
-  data = dwarf2_find_location_expression (dlbaton, &size, pc);
-  if (size == 0)
+  if (expr.empty ())
     error (_("symbol \"%s\" is optimized out"), sym->natural_name ());
 
-  compile_dwarf_expr_to_c (stream, result_name,
-			   sym, pc, gdbarch, registers_used, addr_size,
-			   data, data + size,
-			   dlbaton->per_cu,
+  compile_dwarf_expr_to_c (stream, result_name, sym, pc, gdbarch,
+			   registers_used, addr_size, expr, dlbaton->per_cu,
 			   dlbaton->per_objfile);
 #else
   gdb_assert_not_reached ("Compile support was disabled");

--- a/gdb/dwarf2/loc.h
+++ b/gdb/dwarf2/loc.h
@@ -21,6 +21,7 @@
 #define GDB_DWARF2_LOC_H
 
 #include "gdbtypes.h"
+#include "dwarf2/attribute.h"
 #include "dwarf2/expr.h"
 
 struct symbol_computed_ops;
@@ -37,23 +38,16 @@ struct axs_value;
 extern unsigned int entry_values_debug;
 
 /* Find a particular location expression from a location list.  */
-const gdb_byte *dwarf2_find_location_expression
-  (const dwarf2_loclist_baton *baton,
-   size_t *locexpr_length,
-   CORE_ADDR pc,
-   bool at_entry = false);
+gdb::array_view<const gdb_byte> dwarf2_find_location_expression
+  (const dwarf2_loclist_baton *baton, CORE_ADDR pc, bool at_entry = false);
 
-/* Find the frame base information for FRAMEFUNC at PC.  START is an
-   out parameter which is set to point to the DWARF expression to
-   compute.  LENGTH is an out parameter which is set to the length of
-   the DWARF expression.  This throws an exception on error or if an
-   expression is not found; the returned length will never be
-   zero.  */
+/* Find the frame base information for FRAMEFUNC at PC and return the
+   DWARF expression to compute.
 
-extern void func_get_frame_base_dwarf_block (struct symbol *framefunc,
-					     CORE_ADDR pc,
-					     const gdb_byte **start,
-					     size_t *length);
+   Throw an exception if no expression is found.  */
+
+gdb::array_view<const gdb_byte> func_get_frame_base_dwarf_block
+  (struct symbol *framefunc, CORE_ADDR pc);
 
 /* A helper function to find the definition of NAME and compute its
    value.  Returns nullptr if the name is not found.  */
@@ -72,13 +66,13 @@ call_site_parameter *dwarf_expr_reg_to_entry_parameter
    dwarf2_per_objfile **per_objfile_return);
 
 
-/* Evaluate a location description, starting at DATA and with length
-   SIZE, to find the current location of variable of TYPE in the context
-   of FRAME.  AS_LVAL defines if the resulting struct value is expected to
-   be a value or a location description.  */
+/* Evaluate the location description LOC_DESC to find the current location
+   of variable of TYPE in the context of FRAME.  AS_LVAL defines if the
+   resulting struct value is expected to be a value or a location
+   description.  */
 
 value *dwarf2_evaluate_loc_desc (type *type, const frame_info_ptr &frame,
-				 const gdb_byte *data, size_t size,
+				 gdb::array_view<const gdb_byte> loc_desc,
 				 dwarf2_per_cu *per_cu,
 				 dwarf2_per_objfile *per_objfile,
 				 bool as_lval = true);
@@ -132,8 +126,26 @@ void dwarf2_compile_property_to_c (string_file *stream,
 
 struct dwarf2_locexpr_baton
 {
-  /* Pointer to the start of the location expression.  Valid only if SIZE is
-     not zero.  */
+  /* Return the expression in this baton.  */
+  gdb::array_view<const gdb_byte> expr () const
+  { return gdb::make_array_view (data, size); }
+
+  /* Set the expression in this baton from EXPR.  */
+  void set_expr (gdb::array_view<const gdb_byte> expr)
+  {
+    data = expr.data ();
+    size = expr.size ();
+  }
+
+  /* Set the expression in this baton from BLOCK.  */
+  void set_expr (const dwarf_block &block)
+  {
+    data = block.data;
+    size = block.size;
+  }
+
+  /* Pointer to the start of the location expression.  nullptr for optimized
+     out expressions.  */
   const gdb_byte *data;
 
   /* Length of the location expression.  For optimized out expressions it is
@@ -176,6 +188,10 @@ struct dwarf2_field_location_baton : public dwarf2_locexpr_baton
 
 struct dwarf2_loclist_baton
 {
+  /* Return the location list in this baton.  */
+  gdb::array_view<const gdb_byte> expr () const
+  { return gdb::make_array_view (data, size); }
+
   /* The initial base address for the location list, based on the compilation
      unit.  */
   unrelocated_addr base_address;

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -5269,8 +5269,7 @@ dwarf2_compute_name (const char *name,
 
 		      if (baton != NULL)
 			v = dwarf2_evaluate_loc_desc (type, NULL,
-						      baton->data,
-						      baton->size,
+						      baton->expr (),
 						      baton->per_cu,
 						      baton->per_objfile);
 		      else if (bytes != NULL)
@@ -8102,13 +8101,10 @@ read_call_site_scope (struct die_info *die, struct dwarf2_cu *cu)
     /* Keep NULL DWARF_BLOCK.  */;
   else if (attr->form_is_block ())
     {
-      struct dwarf2_locexpr_baton *dlbaton;
-      struct dwarf_block *block = attr->as_block ();
+      dwarf2_locexpr_baton *dlbaton
+	= OBSTACK_ZALLOC (&objfile->objfile_obstack, dwarf2_locexpr_baton);
 
-      dlbaton = OBSTACK_ZALLOC (&objfile->objfile_obstack,
-				struct dwarf2_locexpr_baton);
-      dlbaton->data = block->data;
-      dlbaton->size = block->size;
+      dlbaton->set_expr (*attr->as_block ());
       dlbaton->per_objfile = per_objfile;
       dlbaton->per_cu = cu->per_cu;
 
@@ -8228,14 +8224,12 @@ read_call_site_scope (struct die_info *die, struct dwarf2_cu *cu)
 	}
       else
 	{
-	  struct dwarf_block *block = loc->as_block ();
+	  auto block = loc->as_block ()->view ();
 
-	  parameter->u.dwarf_reg = dwarf_block_to_dwarf_reg
-	    (block->data, &block->data[block->size]);
+	  parameter->u.dwarf_reg = dwarf_block_to_dwarf_reg (block);
 	  if (parameter->u.dwarf_reg != -1)
 	    parameter->kind = CALL_SITE_PARAMETER_DWARF_REG;
-	  else if (dwarf_block_to_sp_offset (gdbarch, block->data,
-					     &block->data[block->size],
+	  else if (dwarf_block_to_sp_offset (gdbarch, block,
 					     &parameter->u.fb_offset))
 	    parameter->kind = CALL_SITE_PARAMETER_FB_OFFSET;
 	  else
@@ -9389,8 +9383,9 @@ handle_member_location (struct die_info *die, struct dwarf2_cu *cu,
 	      else
 		dlbaton = OBSTACK_ZALLOC (&objfile->objfile_obstack,
 					  struct dwarf2_locexpr_baton);
-	      dlbaton->data = data_member_location_attr->as_block ()->data;
-	      dlbaton->size = data_member_location_attr->as_block ()->size;
+
+	      dlbaton->set_expr (*data_member_location_attr->as_block ());
+
 	      /* When using this baton, we want to compute the address
 		 of the field, not the value.  This is why
 		 is_reference is set to false here.  */
@@ -9423,8 +9418,8 @@ handle_member_location (struct die_info *die, struct dwarf2_cu *cu,
 	      dwarf2_locexpr_baton *dlbaton
 		= OBSTACK_ZALLOC (&per_objfile->objfile->objfile_obstack,
 				  dwarf2_locexpr_baton);
-	      dlbaton->data = data_bit_offset_attr->as_block ()->data;
-	      dlbaton->size = data_bit_offset_attr->as_block ()->size;
+
+	      dlbaton->set_expr (*data_bit_offset_attr->as_block ());
 	      dlbaton->per_objfile = per_objfile;
 	      dlbaton->per_cu = cu->per_cu;
 
@@ -11755,7 +11750,6 @@ mark_common_block_symbol_computed (struct symbol *sym,
   dwarf2_per_objfile *per_objfile = cu->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
   struct dwarf2_locexpr_baton *baton;
-  gdb_byte *ptr;
   unsigned int cu_off;
   enum bfd_endian byte_order = gdbarch_byte_order (objfile->arch ());
   LONGEST offset = 0;
@@ -11771,18 +11765,19 @@ mark_common_block_symbol_computed (struct symbol *sym,
   baton->per_cu = cu->per_cu;
   gdb_assert (baton->per_cu);
 
-  baton->size = 5 /* DW_OP_call4 */ + 1 /* DW_OP_plus */;
+  std::size_t size = 5 /* DW_OP_call4 */ + 1 /* DW_OP_plus */;
 
   if (member_loc->form_is_constant ())
     {
       offset = member_loc->unsigned_constant ().value_or (0);
-      baton->size += 1 /* DW_OP_addr */ + cu->header.addr_size;
+      size += 1 /* DW_OP_addr */ + cu->header.addr_size;
     }
   else
-    baton->size += member_loc->as_block ()->size;
+    size += member_loc->as_block ()->size;
 
-  ptr = (gdb_byte *) obstack_alloc (&objfile->objfile_obstack, baton->size);
-  baton->data = ptr;
+  gdb_byte *const start
+    = (gdb_byte *) obstack_alloc (&objfile->objfile_obstack, size);
+  gdb_byte *ptr = start;
 
   *ptr++ = DW_OP_call4;
   cu_off = common_die->sect_off - cu->per_cu->sect_off ();
@@ -11805,7 +11800,9 @@ mark_common_block_symbol_computed (struct symbol *sym,
     }
 
   *ptr++ = DW_OP_plus;
-  gdb_assert (ptr - baton->data == baton->size);
+  gdb_assert (ptr - start == size);
+
+  baton->set_expr (gdb::make_array_view (start, size));
 
   SYMBOL_LOCATION_BATON (sym) = baton;
   sym->set_loc_class_index (dwarf2_locexpr_index);
@@ -12787,13 +12784,10 @@ get_mpz_for_rational (dwarf2_cu *cu, gdb_mpz *value, attribute *attr)
       *value = gdb_mpz (1);
     }
   else if (attr->form_is_block ())
-    {
-      dwarf_block *blk = attr->as_block ();
-      value->read (gdb::make_array_view (blk->data, blk->size),
-		   bfd_big_endian (cu->per_objfile->objfile->obfd.get ())
-		   ? BFD_ENDIAN_BIG : BFD_ENDIAN_LITTLE,
-		   true);
-    }
+    value->read (attr->as_block ()->view (),
+		 (bfd_big_endian (cu->per_objfile->objfile->obfd.get ())
+		  ? BFD_ENDIAN_BIG : BFD_ENDIAN_LITTLE),
+		 true);
   else
     {
       /* Rational constants for Ada are always unsigned.  */
@@ -13441,8 +13435,7 @@ attr_to_dynamic_prop (const struct attribute *attr, struct die_info *die,
       else
 	block = *attr->as_block ();
 
-      baton->locexpr.size = block.size;
-      baton->locexpr.data = block.data;
+      baton->locexpr.set_expr (block);
       switch (attr->name)
 	{
 	case DW_AT_string_length:
@@ -13498,9 +13491,7 @@ attr_to_dynamic_prop (const struct attribute *attr, struct die_info *die,
 		baton->property_type = die_type (target_die, target_cu);
 		baton->locexpr.per_cu = cu->per_cu;
 		baton->locexpr.per_objfile = per_objfile;
-		struct dwarf_block *block = target_attr->as_block ();
-		baton->locexpr.size = block->size;
-		baton->locexpr.data = block->data;
+		baton->locexpr.set_expr (*target_attr->as_block ());
 		baton->locexpr.is_reference = true;
 		prop->set_locexpr (baton);
 		gdb_assert (prop->baton () != NULL);
@@ -16015,9 +16006,9 @@ dwarf2_const_value_attr (const struct attribute *attr, struct type *type,
 	(*baton)->per_cu = cu->per_cu;
 	gdb_assert ((*baton)->per_cu);
 
-	(*baton)->size = 2 + cu_header->addr_size;
-	data = (gdb_byte *) obstack_alloc (obstack, (*baton)->size);
-	(*baton)->data = data;
+	std::size_t size = 2 + cu_header->addr_size;
+	data = (gdb_byte *) obstack_alloc (obstack, size);
+	(*baton)->set_expr (gdb::make_array_view (data, size));
 
 	data[0] = DW_OP_addr;
 	store_unsigned_integer (&data[1], cu_header->addr_size,
@@ -17080,23 +17071,17 @@ dwarf2_fetch_die_loc_sect_off (sect_offset sect_off, dwarf2_per_cu *per_cu,
 
   if (!attr)
     {
-      /* DWARF: "If there is no such attribute, then there is no effect.".
-	 DATA is ignored if SIZE is 0.  */
-
-      retval.data = NULL;
-      retval.size = 0;
+      /* DWARF: "If there is no such attribute, then there is no effect.".  */
+      retval.set_expr (gdb::array_view<const gdb_byte> ());
     }
   else if (attr->form_is_section_offset ())
     {
       struct dwarf2_loclist_baton loclist_baton;
       CORE_ADDR pc = get_frame_pc ();
-      size_t size;
 
       fill_in_loclist_baton (cu, &loclist_baton, attr);
 
-      retval.data = dwarf2_find_location_expression (&loclist_baton,
-						     &size, pc);
-      retval.size = size;
+      retval.set_expr (dwarf2_find_location_expression (&loclist_baton, pc));
     }
   else
     {
@@ -17106,9 +17091,7 @@ dwarf2_fetch_die_loc_sect_off (sect_offset sect_off, dwarf2_per_cu *per_cu,
 		 " [in module %s]"),
 	       sect_offset_str (sect_off), objfile_name (objfile));
 
-      struct dwarf_block *block = attr->as_block ();
-      retval.data = block->data;
-      retval.size = block->size;
+      retval.set_expr (*attr->as_block ());
     }
   retval.per_objfile = per_objfile;
   retval.per_cu = cu->per_cu;
@@ -17932,9 +17915,7 @@ dwarf2_symbol_mark_computed (const struct attribute *attr, struct symbol *sym,
 	     info_buffer for SYM's objfile; right now we never release
 	     that buffer, but when we do clean up properly this may
 	     need to change.  */
-	  struct dwarf_block *block = attr->as_block ();
-	  baton->size = block->size;
-	  baton->data = block->data;
+	  baton->set_expr (*attr->as_block ());
 	}
       else
 	{

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -13397,10 +13397,7 @@ var_decl_name (struct die_info *die, struct dwarf2_cu *cu)
   if (attr == nullptr || !attr->as_boolean ())
     return nullptr;
 
-  attr = dwarf2_attr (die, DW_AT_name, cu);
-  if (attr == nullptr)
-    return nullptr;
-  return attr->as_string ();
+  return dwarf2_full_name (nullptr, die, cu);
 }
 
 /* Parse dwarf attribute if it's a block, reference or constant and put the

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -15484,13 +15484,428 @@ new_symbol_file_line (struct die_info *die, struct dwarf2_cu *cu,
   sym->set_symtab (fe->symtab (*file_cu));
 }
 
+/* Given a DWARF information entry CU/DIE with LINKAGENAME and PHYSNAME, fill
+   in SYM according to DIE->tag.  */
+
+static void
+new_symbol (struct die_info *die, struct dwarf2_cu *cu, struct symbol *sym,
+	    const char *linkagename, const char *physname)
+{
+  dwarf2_per_objfile *per_objfile = cu->per_objfile;
+  struct objfile *objfile = per_objfile->objfile;
+  struct attribute *attr = nullptr;
+  struct attribute *attr2 = nullptr;
+  std::vector<symbol *> *list_to_add = nullptr;
+  bool suppress_add = false;
+
+  switch (die->tag)
+    {
+    case DW_TAG_label:
+      {
+	attr = dwarf2_attr (die, DW_AT_low_pc, cu);
+	if (attr != nullptr)
+	  {
+	    CORE_ADDR addr = per_objfile->relocate (attr->as_address ());
+	    sym->set_section_index (SECT_OFF_TEXT (objfile));
+	    sym->set_value_address (addr);
+	    sym->set_loc_class_index (LOC_LABEL);
+	  }
+	else
+	  sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
+	type_allocator alloc (objfile, cu->lang ());
+	struct type *addr_type
+	  = alloc.copy_type (builtin_type (objfile)->builtin_core_addr);
+	sym->set_type (addr_type);
+	sym->set_domain (LABEL_DOMAIN);
+	list_to_add = cu->list_in_scope;
+      }
+      break;
+    case DW_TAG_entry_point:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      /* DW_TAG_entry_point provides an additional entry_point to an
+	 existing sub_program.  Therefore, we inherit the "external"
+	 attribute from the sub_program to which the entry_point
+	 belongs to.  */
+      attr2 = dwarf2_attr (die->parent, DW_AT_external, cu);
+      if (attr2 != nullptr && attr2->as_boolean ())
+	list_to_add = &cu->get_builder ()->get_global_symbols ();
+      else
+	list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_subprogram:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      attr2 = dwarf2_attr (die, DW_AT_external, cu);
+      if ((attr2 != nullptr && attr2->as_boolean ())
+	  || cu->lang () == language_ada
+	  || cu->lang () == language_fortran)
+	{
+	  /* Subprograms marked external are stored as a global symbol.
+	     Ada and Fortran subprograms, whether marked external or
+	     not, are always stored as a global symbol, because we want
+	     to be able to access them globally.  For instance, we want
+	     to be able to break on a nested subprogram without having
+	     to specify the context.  */
+	  list_to_add = &cu->get_builder ()->get_global_symbols ();
+	}
+      else
+	list_to_add = cu->list_in_scope;
+
+      if (is_ada_import_or_export (cu, physname, linkagename))
+	{
+	  /* This is either a Pragma Import or Export.  They can
+	     be distinguished by the declaration flag.  */
+	  sym->set_linkage_name (physname);
+	  if (die_is_declaration (die, cu))
+	    {
+	      /* For Import, create a symbol using the source
+		 name, and have it refer to the linkage name.  */
+	      SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
+	      sym->set_loc_class_index (ada_block_index);
+	    }
+	  else
+	    {
+	      /* For Export, create a symbol using the source
+		 name, then create a second symbol that refers
+		 back to it.  */
+	      add_ada_export_symbol (sym, linkagename, physname, cu,
+				     *list_to_add);
+	    }
+	}
+      break;
+    case DW_TAG_inlined_subroutine:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      sym->set_is_inlined (1);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_template_value_param:
+      suppress_add = true;
+      [[fallthrough]];
+    case DW_TAG_constant:
+    case DW_TAG_variable:
+    case DW_TAG_member:
+      sym->set_domain (VAR_DOMAIN);
+      /* Compilation with minimal debug info may result in
+	 variables with missing type entries.  Change the
+	 misleading `void' type to something sensible.  */
+      if (sym->type ()->code () == TYPE_CODE_VOID)
+	{
+	  type_allocator alloc (objfile, cu->lang ());
+	  struct type *int_type
+	    = alloc.copy_type (builtin_type (objfile)->builtin_int);
+	  sym->set_type (int_type);
+	}
+
+      attr = dwarf2_attr (die, DW_AT_const_value, cu);
+      /* In the case of DW_TAG_member, we should only be called for
+	 static const members.  */
+      if (die->tag == DW_TAG_member)
+	{
+	  /* dwarf2_add_field uses die_is_declaration,
+	     so we do the same.  */
+	  gdb_assert (die_is_declaration (die, cu));
+	  gdb_assert (attr);
+	}
+      if (attr != nullptr)
+	{
+	  dwarf2_const_value (attr, sym, cu);
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+	  if (!suppress_add)
+	    {
+	      if (attr2 != nullptr && attr2->as_boolean ())
+		list_to_add = &cu->get_builder ()->get_global_symbols ();
+	      else
+		list_to_add = cu->list_in_scope;
+	    }
+	  break;
+	}
+      attr = dwarf2_attr (die, DW_AT_location, cu);
+      if (attr != nullptr)
+	{
+	  var_decode_location (attr, sym, cu);
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+
+	  /* Fortran explicitly imports any global symbols to the local
+	     scope by DW_TAG_common_block.  */
+	  if (cu->lang () == language_fortran && die->parent
+	      && die->parent->tag == DW_TAG_common_block)
+	    attr2 = nullptr;
+
+	  if (sym->loc_class () == LOC_STATIC
+	      && sym->value_address () == 0
+	      && !per_objfile->per_bfd->has_section_at_zero)
+	    {
+	      /* When a static variable is eliminated by the linker,
+		 the corresponding debug information is not stripped
+		 out, but the variable address is set to null;
+		 do not add such variables into symbol table.  */
+	    }
+	  else if (attr2 != nullptr && attr2->as_boolean ())
+	    {
+	      if (sym->loc_class () == LOC_STATIC
+		  && (objfile->flags & OBJF_MAINLINE) == 0
+		  && per_objfile->per_bfd->can_copy)
+		{
+		  /* A global static variable might be subject to
+		     copy relocation.  We first check for a local
+		     minsym, though, because maybe the symbol was
+		     marked hidden, in which case this would not
+		     apply.  */
+		  bound_minimal_symbol found
+		    = (lookup_minimal_symbol_linkage
+		       (sym->linkage_name (), objfile, false));
+		  if (found.minsym != nullptr)
+		    sym->maybe_copied = 1;
+		}
+
+	      /* A variable with DW_AT_external is never static,
+		 but it may be block-scoped.  */
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+	    }
+	  else
+	    list_to_add = cu->list_in_scope;
+
+	  if (list_to_add != nullptr
+	      && is_ada_import_or_export (cu, physname, linkagename))
+	    {
+	      /* This is a Pragma Export.  A Pragma Import won't
+		 be seen here, because it will not have a location
+		 and so will be handled below.  */
+	      add_ada_export_symbol (sym, physname, linkagename, cu,
+				     *list_to_add);
+	    }
+	}
+      else
+	{
+	  /* We do not know the address of this symbol.
+	     If it is an external symbol and we have type information
+	     for it, enter the symbol as a LOC_UNRESOLVED symbol.
+	     The address of the variable will then be determined from
+	     the minimal symbol table whenever the variable is
+	     referenced.  */
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+
+	  /* Fortran explicitly imports any global symbols to the local
+	     scope by DW_TAG_common_block.  */
+	  if (cu->lang () == language_fortran && die->parent
+	      && die->parent->tag == DW_TAG_common_block)
+	    {
+	      /* SYMBOL_CLASS doesn't matter here because
+		 read_common_block is going to reset it.  */
+	      if (!suppress_add)
+		list_to_add = cu->list_in_scope;
+	    }
+	  else if (is_ada_import_or_export (cu, physname, linkagename))
+	    {
+	      /* This is a Pragma Import.  A Pragma Export won't
+		 be seen here, because it will have a location and
+		 so will be handled above.  */
+	      sym->set_linkage_name (physname);
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+	      SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
+	      sym->set_loc_class_index (ada_imported_index);
+	    }
+	  else if (attr2 != nullptr && attr2->as_boolean ()
+		   && dwarf2_attr (die, DW_AT_type, cu) != nullptr)
+	    {
+	      /* A variable with DW_AT_external is never static, but it
+		 may be block-scoped.  */
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+
+	      sym->set_loc_class_index (LOC_UNRESOLVED);
+	    }
+	  else if (!die_is_declaration (die, cu))
+	    {
+	      /* Use the default LOC_OPTIMIZED_OUT class.  */
+	      gdb_assert (sym->loc_class () == LOC_OPTIMIZED_OUT);
+	      if (!suppress_add)
+		list_to_add = cu->list_in_scope;
+	    }
+	}
+      break;
+    case DW_TAG_formal_parameter:
+      {
+	/* If we are inside a function, mark this as an argument.  If
+	   not, we might be looking at an argument to an inlined function
+	   when we do not have enough information to show inlined frames;
+	   pretend it's a local variable in that case so that the user can
+	   still see it.  */
+	sym->set_domain (VAR_DOMAIN);
+	if (cu->get_builder ()->current_context_has_function ())
+	  sym->set_is_argument (true);
+	attr = dwarf2_attr (die, DW_AT_location, cu);
+	if (attr != nullptr)
+	  var_decode_location (attr, sym, cu);
+	attr = dwarf2_attr (die, DW_AT_const_value, cu);
+	if (attr != nullptr)
+	  dwarf2_const_value (attr, sym, cu);
+
+	list_to_add = cu->list_in_scope;
+      }
+      break;
+    case DW_TAG_unspecified_parameters:
+      /* From varargs functions; gdb doesn't seem to have any
+	 interest in this information, so just ignore it for now.
+	 (FIXME?) */
+      break;
+    case DW_TAG_template_type_param:
+      suppress_add = true;
+      [[fallthrough]];
+    case DW_TAG_class_type:
+    case DW_TAG_interface_type:
+    case DW_TAG_structure_type:
+    case DW_TAG_union_type:
+    case DW_TAG_set_type:
+    case DW_TAG_enumeration_type:
+      if (cu->lang () == language_c
+	  || cu->lang () == language_cplus
+	  || cu->lang () == language_objc
+	  || cu->lang () == language_opencl
+	  || cu->lang () == language_minimal)
+	{
+	  /* These languages have a tag namespace.  Note that
+	     there's a special hack for C++ in the matching code,
+	     so we don't need to enter a separate typedef for the
+	     tag.  */
+	  sym->set_loc_class_index (LOC_TYPEDEF);
+	  sym->set_domain (STRUCT_DOMAIN);
+	}
+      else
+	{
+	  /* Other languages don't have a tag namespace.  */
+	  sym->set_loc_class_index (LOC_TYPEDEF);
+	  sym->set_domain (TYPE_DOMAIN);
+	}
+
+      /* NOTE: carlton/2003-11-10: C++ class symbols shouldn't
+	 really ever be static objects: otherwise, if you try
+	 to, say, break of a class's method and you're in a file
+	 which doesn't mention that class, it won't work unless
+	 the check for all static symbols in lookup_symbol_aux
+	 saves you.  See the OtherFileClass tests in
+	 gdb.c++/namespace.exp.  */
+
+      if (!suppress_add)
+	{
+	  buildsym_compunit *builder = cu->get_builder ();
+	  list_to_add
+	    = ((cu->list_in_scope == &builder->get_file_symbols ()
+		&& cu->lang () == language_cplus)
+	       ? &builder->get_global_symbols ()
+	       : cu->list_in_scope);
+
+	  /* The semantics of C++ state that "struct foo {
+	     ... }" also defines a typedef for "foo".  */
+	  if (cu->lang () == language_cplus
+	      || cu->lang () == language_ada
+	      || cu->lang () == language_d
+	      || cu->lang () == language_rust)
+	    {
+	      /* The symbol's name is already allocated along
+		 with this objfile, so we don't need to
+		 duplicate it for the type.  */
+	      if (sym->type ()->name () == 0)
+		sym->type ()->set_name (sym->search_name ());
+	    }
+	}
+      break;
+    case DW_TAG_unspecified_type:
+      if (cu->lang () == language_ada)
+	break;
+      [[fallthrough]];
+    case DW_TAG_typedef:
+    case DW_TAG_array_type:
+    case DW_TAG_base_type:
+    case DW_TAG_subrange_type:
+    case DW_TAG_generic_subrange:
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      sym->set_domain (TYPE_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_enumerator:
+      sym->set_domain (VAR_DOMAIN);
+      attr = dwarf2_attr (die, DW_AT_const_value, cu);
+      if (attr != nullptr)
+	dwarf2_const_value (attr, sym, cu);
+
+      /* NOTE: carlton/2003-11-10: See comment above in the
+	 DW_TAG_class_type, etc. block.  */
+
+      list_to_add
+	= ((cu->list_in_scope == &cu->get_builder ()->get_file_symbols ()
+	    && cu->lang () == language_cplus)
+	   ? &cu->get_builder ()->get_global_symbols ()
+	   : cu->list_in_scope);
+      break;
+    case DW_TAG_imported_declaration:
+    case DW_TAG_namespace:
+      sym->set_domain (TYPE_DOMAIN);
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      list_to_add = &cu->get_builder ()->get_global_symbols ();
+      break;
+    case DW_TAG_module:
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      sym->set_domain (MODULE_DOMAIN);
+      list_to_add = &cu->get_builder ()->get_global_symbols ();
+      break;
+    case DW_TAG_common_block:
+      sym->set_loc_class_index (LOC_COMMON_BLOCK);
+      sym->set_domain (COMMON_BLOCK_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_namelist:
+      sym->set_loc_class_index (LOC_STATIC);
+      sym->set_domain (VAR_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    default:
+      /* Not a tag we recognize.  Hopefully we aren't processing
+	 trash data, but since we must specifically ignore things
+	 we don't recognize, there is nothing else we should do at
+	 this point.  */
+      complaint (_("unsupported tag: '%s'"),
+		 dwarf_tag_name (die->tag));
+      break;
+    }
+
+  if (suppress_add)
+    {
+      sym->hash_next = objfile->template_symbols;
+      objfile->template_symbols = sym;
+      return;
+    }
+
+  if (list_to_add != nullptr)
+    add_symbol_to_list (sym, *list_to_add);
+}
+
 /* Given a pointer to a DWARF information entry, figure out if we need
    to make a symbol table entry for it, and if so, create a new entry
    and return a pointer to it.
-   If TYPE is NULL, determine symbol type from the die, otherwise
+   If TYPE is nullptr, determine symbol type from the die, otherwise
    used the passed type.
-   If SPACE is not NULL, use it to hold the new symbol.  If it is
-   NULL, allocate a new symbol on the objfile's obstack.  */
+   If SPACE is not nullptr, use it to hold the new symbol.  If it is
+   nullptr, allocate a new symbol on the objfile's obstack.  */
 
 static struct symbol *
 new_symbol (struct die_info *die, struct type *type, struct dwarf2_cu *cu,
@@ -15498,483 +15913,65 @@ new_symbol (struct die_info *die, struct type *type, struct dwarf2_cu *cu,
 {
   dwarf2_per_objfile *per_objfile = cu->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
-  struct symbol *sym = NULL;
-  const char *name;
-  struct attribute *attr = NULL;
-  struct attribute *attr2 = NULL;
-  std::vector<symbol *> *list_to_add = nullptr;
 
-  name = dwarf2_name (die, cu);
+  const char *name = dwarf2_name (die, cu);
   if (name == nullptr && (die->tag == DW_TAG_subprogram
 			  || die->tag == DW_TAG_inlined_subroutine
 			  || die->tag == DW_TAG_entry_point))
     name = dw2_linkage_name (die, cu);
+  if (name == nullptr)
+    return nullptr;
 
-  if (name)
-    {
-      int suppress_add = 0;
+  struct symbol *sym = space;
+  if (sym == nullptr)
+    sym = objfile->new_symbol<symbol> ();
 
-      if (space)
-	sym = space;
-      else
-	sym = objfile->new_symbol<symbol> ();
+  sym->set_language (cu->lang (), &objfile->objfile_obstack);
 
-      /* Cache this symbol's name and the name's demangled form (if any).  */
-      sym->set_language (cu->lang (), &objfile->objfile_obstack);
-      /* Fortran does not have mangling standard and the mangling does differ
-	 between gfortran, iFort etc.  */
-      const char *physname
-	= ((cu->lang () == language_fortran || cu->lang () == language_ada)
-	   ? dwarf2_full_name (name, die, cu)
-	   : dwarf2_physname (name, die, cu));
-      const char *linkagename = dw2_linkage_name (die, cu);
+  /* Fortran does not have mangling standard and the mangling does differ
+     between gfortran, iFort etc.  */
+  const char *physname
+    = ((cu->lang () == language_fortran || cu->lang () == language_ada)
+       ? dwarf2_full_name (name, die, cu)
+       : dwarf2_physname (name, die, cu));
+  const char *linkagename = dw2_linkage_name (die, cu);
 
-      if (linkagename == nullptr)
-	sym->set_linkage_name (physname);
-      else if (cu->lang () == language_ada)
-	sym->set_linkage_name (linkagename);
-      else
-	{
-	  if (physname == linkagename)
-	    sym->set_demangled_name (name, &objfile->objfile_obstack);
-	  else
-	    sym->set_demangled_name (physname, &objfile->objfile_obstack);
+  /* Cache this symbol's name and the name's demangled form (if any).  */
+  sym->set_linkage_name (linkagename != nullptr
+			 ? linkagename
+			 : physname);
+  if (linkagename != nullptr && cu->lang () != language_ada)
+    sym->set_demangled_name (physname == linkagename
+			     ? name
+			     : physname,
+			     &objfile->objfile_obstack);
 
-	  sym->set_linkage_name (linkagename);
-	}
+  /* Handle DW_AT_artificial.  */
+  struct attribute *attr = dwarf2_attr (die, DW_AT_artificial, cu);
+  if (attr != nullptr)
+    sym->set_is_artificial (attr->as_boolean ());
 
-      /* Handle DW_AT_artificial.  */
-      attr = dwarf2_attr (die, DW_AT_artificial, cu);
-      if (attr != nullptr)
-	sym->set_is_artificial (attr->as_boolean ());
+  /* Default assumptions.
+     Use the passed type or decode it from the die.  */
+  sym->set_domain (UNDEF_DOMAIN);
+  sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
+  sym->set_type (type != nullptr
+		 ? type
+		 : die_type (die, cu));
 
-      /* Default assumptions.
-	 Use the passed type or decode it from the die.  */
-      sym->set_domain (UNDEF_DOMAIN);
-      sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
-      if (type != NULL)
-	sym->set_type (type);
-      else
-	sym->set_type (die_type (die, cu));
+  /* Handle DW_AT_{call,decl}_{file,line}.  */
+  new_symbol_file_line (die, cu, sym);
 
-      /* Handle DW_AT_{call,decl}_{file,line}.  */
-      new_symbol_file_line (die, cu, sym);
+  /* Handle TAG-specific part.  */
+  new_symbol (die, cu, sym, linkagename, physname);
 
-      switch (die->tag)
-	{
-	case DW_TAG_label:
-	  {
-	    attr = dwarf2_attr (die, DW_AT_low_pc, cu);
-	    if (attr != nullptr)
-	      {
-		CORE_ADDR addr = per_objfile->relocate (attr->as_address ());
-		sym->set_section_index (SECT_OFF_TEXT (objfile));
-		sym->set_value_address (addr);
-		sym->set_loc_class_index (LOC_LABEL);
-	      }
-	    else
-	      sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
-	    type_allocator alloc (objfile, cu->lang ());
-	    struct type *addr_type
-	      = alloc.copy_type (builtin_type (objfile)->builtin_core_addr);
-	    sym->set_type (addr_type);
-	    sym->set_domain (LABEL_DOMAIN);
-	    list_to_add = cu->list_in_scope;
-	  }
-	  break;
-	case DW_TAG_entry_point:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  /* DW_TAG_entry_point provides an additional entry_point to an
-	     existing sub_program.  Therefore, we inherit the "external"
-	     attribute from the sub_program to which the entry_point
-	     belongs to.  */
-	  attr2 = dwarf2_attr (die->parent, DW_AT_external, cu);
-	  if (attr2 != nullptr && attr2->as_boolean ())
-	    list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  else
-	    list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_subprogram:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
-	  if ((attr2 != nullptr && attr2->as_boolean ())
-	      || cu->lang () == language_ada
-	      || cu->lang () == language_fortran)
-	    {
-	      /* Subprograms marked external are stored as a global symbol.
-		 Ada and Fortran subprograms, whether marked external or
-		 not, are always stored as a global symbol, because we want
-		 to be able to access them globally.  For instance, we want
-		 to be able to break on a nested subprogram without having
-		 to specify the context.  */
-	      list_to_add = &cu->get_builder ()->get_global_symbols ();
-	    }
-	  else
-	    {
-	      list_to_add = cu->list_in_scope;
-	    }
+  /* For the benefit of old versions of GCC, check for anonymous
+     namespaces based on the demangled name.  */
+  if (!cu->processing_has_namespace_info
+      && cu->lang () == language_cplus)
+    cp_scan_for_anonymous_namespaces (cu->get_builder (), sym, objfile);
 
-	  if (is_ada_import_or_export (cu, physname, linkagename))
-	    {
-	      /* This is either a Pragma Import or Export.  They can
-		 be distinguished by the declaration flag.  */
-	      sym->set_linkage_name (physname);
-	      if (die_is_declaration (die, cu))
-		{
-		  /* For Import, create a symbol using the source
-		     name, and have it refer to the linkage name.  */
-		  SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
-		  sym->set_loc_class_index (ada_block_index);
-		}
-	      else
-		{
-		  /* For Export, create a symbol using the source
-		     name, then create a second symbol that refers
-		     back to it.  */
-		  add_ada_export_symbol (sym, linkagename, physname, cu,
-					 *list_to_add);
-		}
-	    }
-	  break;
-	case DW_TAG_inlined_subroutine:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  sym->set_is_inlined (1);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_template_value_param:
-	  suppress_add = 1;
-	  [[fallthrough]];
-	case DW_TAG_constant:
-	case DW_TAG_variable:
-	case DW_TAG_member:
-	  sym->set_domain (VAR_DOMAIN);
-	  /* Compilation with minimal debug info may result in
-	     variables with missing type entries.  Change the
-	     misleading `void' type to something sensible.  */
-	  if (sym->type ()->code () == TYPE_CODE_VOID)
-	    {
-	      type_allocator alloc (objfile, cu->lang ());
-	      struct type *int_type
-		= alloc.copy_type (builtin_type (objfile)->builtin_int);
-	      sym->set_type (int_type);
-	    }
-
-	  attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	  /* In the case of DW_TAG_member, we should only be called for
-	     static const members.  */
-	  if (die->tag == DW_TAG_member)
-	    {
-	      /* dwarf2_add_field uses die_is_declaration,
-		 so we do the same.  */
-	      gdb_assert (die_is_declaration (die, cu));
-	      gdb_assert (attr);
-	    }
-	  if (attr != nullptr)
-	    {
-	      dwarf2_const_value (attr, sym, cu);
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-	      if (!suppress_add)
-		{
-		  if (attr2 != nullptr && attr2->as_boolean ())
-		    list_to_add = &cu->get_builder ()->get_global_symbols ();
-		  else
-		    list_to_add = cu->list_in_scope;
-		}
-	      break;
-	    }
-	  attr = dwarf2_attr (die, DW_AT_location, cu);
-	  if (attr != nullptr)
-	    {
-	      var_decode_location (attr, sym, cu);
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-
-	      /* Fortran explicitly imports any global symbols to the local
-		 scope by DW_TAG_common_block.  */
-	      if (cu->lang () == language_fortran && die->parent
-		  && die->parent->tag == DW_TAG_common_block)
-		attr2 = NULL;
-
-	      if (sym->loc_class () == LOC_STATIC
-		  && sym->value_address () == 0
-		  && !per_objfile->per_bfd->has_section_at_zero)
-		{
-		  /* When a static variable is eliminated by the linker,
-		     the corresponding debug information is not stripped
-		     out, but the variable address is set to null;
-		     do not add such variables into symbol table.  */
-		}
-	      else if (attr2 != nullptr && attr2->as_boolean ())
-		{
-		  if (sym->loc_class () == LOC_STATIC
-		      && (objfile->flags & OBJF_MAINLINE) == 0
-		      && per_objfile->per_bfd->can_copy)
-		    {
-		      /* A global static variable might be subject to
-			 copy relocation.  We first check for a local
-			 minsym, though, because maybe the symbol was
-			 marked hidden, in which case this would not
-			 apply.  */
-		      bound_minimal_symbol found
-			= (lookup_minimal_symbol_linkage
-			   (sym->linkage_name (), objfile, false));
-		      if (found.minsym != nullptr)
-			sym->maybe_copied = 1;
-		    }
-
-		  /* A variable with DW_AT_external is never static,
-		     but it may be block-scoped.  */
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-		}
-	      else
-		list_to_add = cu->list_in_scope;
-
-	      if (list_to_add != nullptr
-		  && is_ada_import_or_export (cu, physname, linkagename))
-		{
-		  /* This is a Pragma Export.  A Pragma Import won't
-		     be seen here, because it will not have a location
-		     and so will be handled below.  */
-		  add_ada_export_symbol (sym, physname, linkagename, cu,
-					 *list_to_add);
-		}
-	    }
-	  else
-	    {
-	      /* We do not know the address of this symbol.
-		 If it is an external symbol and we have type information
-		 for it, enter the symbol as a LOC_UNRESOLVED symbol.
-		 The address of the variable will then be determined from
-		 the minimal symbol table whenever the variable is
-		 referenced.  */
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-
-	      /* Fortran explicitly imports any global symbols to the local
-		 scope by DW_TAG_common_block.  */
-	      if (cu->lang () == language_fortran && die->parent
-		  && die->parent->tag == DW_TAG_common_block)
-		{
-		  /* SYMBOL_CLASS doesn't matter here because
-		     read_common_block is going to reset it.  */
-		  if (!suppress_add)
-		    list_to_add = cu->list_in_scope;
-		}
-	      else if (is_ada_import_or_export (cu, physname, linkagename))
-		{
-		  /* This is a Pragma Import.  A Pragma Export won't
-		     be seen here, because it will have a location and
-		     so will be handled above.  */
-		  sym->set_linkage_name (physname);
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-		  SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
-		  sym->set_loc_class_index (ada_imported_index);
-		}
-	      else if (attr2 != nullptr && attr2->as_boolean ()
-		       && dwarf2_attr (die, DW_AT_type, cu) != NULL)
-		{
-		  /* A variable with DW_AT_external is never static, but it
-		     may be block-scoped.  */
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-
-		  sym->set_loc_class_index (LOC_UNRESOLVED);
-		}
-	      else if (!die_is_declaration (die, cu))
-		{
-		  /* Use the default LOC_OPTIMIZED_OUT class.  */
-		  gdb_assert (sym->loc_class () == LOC_OPTIMIZED_OUT);
-		  if (!suppress_add)
-		    list_to_add = cu->list_in_scope;
-		}
-	    }
-	  break;
-	case DW_TAG_formal_parameter:
-	  {
-	    /* If we are inside a function, mark this as an argument.  If
-	       not, we might be looking at an argument to an inlined function
-	       when we do not have enough information to show inlined frames;
-	       pretend it's a local variable in that case so that the user can
-	       still see it.  */
-	    sym->set_domain (VAR_DOMAIN);
-	    if (cu->get_builder ()->current_context_has_function ())
-	      sym->set_is_argument (true);
-	    attr = dwarf2_attr (die, DW_AT_location, cu);
-	    if (attr != nullptr)
-	      {
-		var_decode_location (attr, sym, cu);
-	      }
-	    attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	    if (attr != nullptr)
-	      {
-		dwarf2_const_value (attr, sym, cu);
-	      }
-
-	    list_to_add = cu->list_in_scope;
-	  }
-	  break;
-	case DW_TAG_unspecified_parameters:
-	  /* From varargs functions; gdb doesn't seem to have any
-	     interest in this information, so just ignore it for now.
-	     (FIXME?) */
-	  break;
-	case DW_TAG_template_type_param:
-	  suppress_add = 1;
-	  [[fallthrough]];
-	case DW_TAG_class_type:
-	case DW_TAG_interface_type:
-	case DW_TAG_structure_type:
-	case DW_TAG_union_type:
-	case DW_TAG_set_type:
-	case DW_TAG_enumeration_type:
-	  if (cu->lang () == language_c
-	      || cu->lang () == language_cplus
-	      || cu->lang () == language_objc
-	      || cu->lang () == language_opencl
-	      || cu->lang () == language_minimal)
-	    {
-	      /* These languages have a tag namespace.  Note that
-		 there's a special hack for C++ in the matching code,
-		 so we don't need to enter a separate typedef for the
-		 tag.  */
-	      sym->set_loc_class_index (LOC_TYPEDEF);
-	      sym->set_domain (STRUCT_DOMAIN);
-	    }
-	  else
-	    {
-	      /* Other languages don't have a tag namespace.  */
-	      sym->set_loc_class_index (LOC_TYPEDEF);
-	      sym->set_domain (TYPE_DOMAIN);
-	    }
-
-	  /* NOTE: carlton/2003-11-10: C++ class symbols shouldn't
-	     really ever be static objects: otherwise, if you try
-	     to, say, break of a class's method and you're in a file
-	     which doesn't mention that class, it won't work unless
-	     the check for all static symbols in lookup_symbol_aux
-	     saves you.  See the OtherFileClass tests in
-	     gdb.c++/namespace.exp.  */
-
-	  if (!suppress_add)
-	    {
-	      buildsym_compunit *builder = cu->get_builder ();
-	      list_to_add
-		= ((cu->list_in_scope == &builder->get_file_symbols ()
-		    && cu->lang () == language_cplus)
-		   ? &builder->get_global_symbols ()
-		   : cu->list_in_scope);
-
-	      /* The semantics of C++ state that "struct foo {
-		 ... }" also defines a typedef for "foo".  */
-	      if (cu->lang () == language_cplus
-		  || cu->lang () == language_ada
-		  || cu->lang () == language_d
-		  || cu->lang () == language_rust)
-		{
-		  /* The symbol's name is already allocated along
-		     with this objfile, so we don't need to
-		     duplicate it for the type.  */
-		  if (sym->type ()->name () == 0)
-		    sym->type ()->set_name (sym->search_name ());
-		}
-	    }
-	  break;
-	case DW_TAG_unspecified_type:
-	  if (cu->lang () == language_ada)
-	    break;
-	  [[fallthrough]];
-	case DW_TAG_typedef:
-	case DW_TAG_array_type:
-	case DW_TAG_base_type:
-	case DW_TAG_subrange_type:
-	case DW_TAG_generic_subrange:
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  sym->set_domain (TYPE_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_enumerator:
-	  sym->set_domain (VAR_DOMAIN);
-	  attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	  if (attr != nullptr)
-	    {
-	      dwarf2_const_value (attr, sym, cu);
-	    }
-
-	  /* NOTE: carlton/2003-11-10: See comment above in the
-	     DW_TAG_class_type, etc. block.  */
-
-	  list_to_add
-	    = ((cu->list_in_scope == &cu->get_builder ()->get_file_symbols ()
-		&& cu->lang () == language_cplus)
-	       ? &cu->get_builder ()->get_global_symbols ()
-	       : cu->list_in_scope);
-	  break;
-	case DW_TAG_imported_declaration:
-	case DW_TAG_namespace:
-	  sym->set_domain (TYPE_DOMAIN);
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  break;
-	case DW_TAG_module:
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  sym->set_domain (MODULE_DOMAIN);
-	  list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  break;
-	case DW_TAG_common_block:
-	  sym->set_loc_class_index (LOC_COMMON_BLOCK);
-	  sym->set_domain (COMMON_BLOCK_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_namelist:
-	  sym->set_loc_class_index (LOC_STATIC);
-	  sym->set_domain (VAR_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	default:
-	  /* Not a tag we recognize.  Hopefully we aren't processing
-	     trash data, but since we must specifically ignore things
-	     we don't recognize, there is nothing else we should do at
-	     this point.  */
-	  complaint (_("unsupported tag: '%s'"),
-		     dwarf_tag_name (die->tag));
-	  break;
-	}
-
-      if (suppress_add)
-	{
-	  sym->hash_next = objfile->template_symbols;
-	  objfile->template_symbols = sym;
-	  list_to_add = NULL;
-	}
-
-      if (list_to_add != NULL)
-	add_symbol_to_list (sym, *list_to_add);
-
-      /* For the benefit of old versions of GCC, check for anonymous
-	 namespaces based on the demangled name.  */
-      if (!cu->processing_has_namespace_info
-	  && cu->lang () == language_cplus)
-	cp_scan_for_anonymous_namespaces (cu->get_builder (), sym, objfile);
-    }
-  return (sym);
+  return sym;
 }
 
 /* Read a constant value from an attribute.  Either set *VALUE, or if

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -16637,23 +16637,28 @@ determine_prefix (struct die_info *die, struct dwarf2_cu *cu)
 	  }
 	return "";
       case DW_TAG_subprogram:
-	/* Nested subroutines in Fortran get a prefix with the name
-	   of the parent's subroutine.  Entry points are prefixed by the
-	   parent's namespace.  */
-	if (cu->lang () == language_fortran)
-	  {
-	    if ((die->tag ==  DW_TAG_subprogram)
-		&& (dwarf2_name (parent, cu) != NULL))
-	      return dwarf2_name (parent, cu);
-	    else if (die->tag == DW_TAG_entry_point)
-	      return determine_prefix (parent, cu);
-	  }
-	else if (cu->lang () == language_ada
-		 && (die->tag == DW_TAG_subprogram
-		     || die->tag == DW_TAG_inlined_subroutine
-		     || die->tag == DW_TAG_lexical_block))
-	  return dwarf2_full_name (nullptr, parent, cu);
-	return "";
+	{
+	  const char *name = nullptr;
+	  /* Nested subroutines in Fortran get a prefix with the name
+	     of the parent's subroutine.  Entry points are prefixed by the
+	     parent's namespace.  */
+	  if (cu->lang () == language_fortran)
+	    {
+	      if ((die->tag ==  DW_TAG_subprogram)
+		  && (dwarf2_name (parent, cu) != NULL))
+		name = dwarf2_name (parent, cu);
+	      else if (die->tag == DW_TAG_entry_point)
+		name = determine_prefix (parent, cu);
+	    }
+	  else if (cu->lang () == language_ada
+		   && (die->tag == DW_TAG_subprogram
+		       || die->tag == DW_TAG_inlined_subroutine
+		       || die->tag == DW_TAG_lexical_block))
+	    name = dwarf2_full_name (nullptr, parent, cu);
+	  if (name == nullptr)
+	    name = "";
+	  return name;
+	}
       case DW_TAG_enumeration_type:
 	parent_type = read_type_die (parent, cu);
 	if (parent_type->is_declared_class ())

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -5277,8 +5277,7 @@ dwarf2_compute_name (const char *name,
 
 		      if (baton != NULL)
 			v = dwarf2_evaluate_loc_desc (type, NULL,
-						      baton->data,
-						      baton->size,
+						      baton->expr (),
 						      baton->per_cu,
 						      baton->per_objfile);
 		      else if (bytes != NULL)
@@ -8110,13 +8109,10 @@ read_call_site_scope (struct die_info *die, struct dwarf2_cu *cu)
     /* Keep NULL DWARF_BLOCK.  */;
   else if (attr->form_is_block ())
     {
-      struct dwarf2_locexpr_baton *dlbaton;
-      struct dwarf_block *block = attr->as_block ();
+      dwarf2_locexpr_baton *dlbaton
+	= OBSTACK_ZALLOC (&objfile->objfile_obstack, dwarf2_locexpr_baton);
 
-      dlbaton = OBSTACK_ZALLOC (&objfile->objfile_obstack,
-				struct dwarf2_locexpr_baton);
-      dlbaton->data = block->data;
-      dlbaton->size = block->size;
+      dlbaton->set_expr (*attr->as_block ());
       dlbaton->per_objfile = per_objfile;
       dlbaton->per_cu = cu->per_cu;
 
@@ -8236,14 +8232,12 @@ read_call_site_scope (struct die_info *die, struct dwarf2_cu *cu)
 	}
       else
 	{
-	  struct dwarf_block *block = loc->as_block ();
+	  auto block = loc->as_block ()->view ();
 
-	  parameter->u.dwarf_reg = dwarf_block_to_dwarf_reg
-	    (block->data, &block->data[block->size]);
+	  parameter->u.dwarf_reg = dwarf_block_to_dwarf_reg (block);
 	  if (parameter->u.dwarf_reg != -1)
 	    parameter->kind = CALL_SITE_PARAMETER_DWARF_REG;
-	  else if (dwarf_block_to_sp_offset (gdbarch, block->data,
-					     &block->data[block->size],
+	  else if (dwarf_block_to_sp_offset (gdbarch, block,
 					     &parameter->u.fb_offset))
 	    parameter->kind = CALL_SITE_PARAMETER_FB_OFFSET;
 	  else
@@ -9397,8 +9391,9 @@ handle_member_location (struct die_info *die, struct dwarf2_cu *cu,
 	      else
 		dlbaton = OBSTACK_ZALLOC (&objfile->objfile_obstack,
 					  struct dwarf2_locexpr_baton);
-	      dlbaton->data = data_member_location_attr->as_block ()->data;
-	      dlbaton->size = data_member_location_attr->as_block ()->size;
+
+	      dlbaton->set_expr (*data_member_location_attr->as_block ());
+
 	      /* When using this baton, we want to compute the address
 		 of the field, not the value.  This is why
 		 is_reference is set to false here.  */
@@ -9431,8 +9426,8 @@ handle_member_location (struct die_info *die, struct dwarf2_cu *cu,
 	      dwarf2_locexpr_baton *dlbaton
 		= OBSTACK_ZALLOC (&per_objfile->objfile->objfile_obstack,
 				  dwarf2_locexpr_baton);
-	      dlbaton->data = data_bit_offset_attr->as_block ()->data;
-	      dlbaton->size = data_bit_offset_attr->as_block ()->size;
+
+	      dlbaton->set_expr (*data_bit_offset_attr->as_block ());
 	      dlbaton->per_objfile = per_objfile;
 	      dlbaton->per_cu = cu->per_cu;
 
@@ -11763,7 +11758,6 @@ mark_common_block_symbol_computed (struct symbol *sym,
   dwarf2_per_objfile *per_objfile = cu->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
   struct dwarf2_locexpr_baton *baton;
-  gdb_byte *ptr;
   unsigned int cu_off;
   enum bfd_endian byte_order = gdbarch_byte_order (objfile->arch ());
   LONGEST offset = 0;
@@ -11779,18 +11773,19 @@ mark_common_block_symbol_computed (struct symbol *sym,
   baton->per_cu = cu->per_cu;
   gdb_assert (baton->per_cu);
 
-  baton->size = 5 /* DW_OP_call4 */ + 1 /* DW_OP_plus */;
+  std::size_t size = 5 /* DW_OP_call4 */ + 1 /* DW_OP_plus */;
 
   if (member_loc->form_is_constant ())
     {
       offset = member_loc->unsigned_constant ().value_or (0);
-      baton->size += 1 /* DW_OP_addr */ + cu->header.addr_size;
+      size += 1 /* DW_OP_addr */ + cu->header.addr_size;
     }
   else
-    baton->size += member_loc->as_block ()->size;
+    size += member_loc->as_block ()->size;
 
-  ptr = (gdb_byte *) obstack_alloc (&objfile->objfile_obstack, baton->size);
-  baton->data = ptr;
+  gdb_byte *const start
+    = (gdb_byte *) obstack_alloc (&objfile->objfile_obstack, size);
+  gdb_byte *ptr = start;
 
   *ptr++ = DW_OP_call4;
   cu_off = common_die->sect_off - cu->per_cu->sect_off ();
@@ -11813,7 +11808,9 @@ mark_common_block_symbol_computed (struct symbol *sym,
     }
 
   *ptr++ = DW_OP_plus;
-  gdb_assert (ptr - baton->data == baton->size);
+  gdb_assert (ptr - start == size);
+
+  baton->set_expr (gdb::make_array_view (start, size));
 
   SYMBOL_LOCATION_BATON (sym) = baton;
   sym->set_loc_class_index (dwarf2_locexpr_index);
@@ -12795,13 +12792,10 @@ get_mpz_for_rational (dwarf2_cu *cu, gdb_mpz *value, attribute *attr)
       *value = gdb_mpz (1);
     }
   else if (attr->form_is_block ())
-    {
-      dwarf_block *blk = attr->as_block ();
-      value->read (gdb::make_array_view (blk->data, blk->size),
-		   bfd_big_endian (cu->per_objfile->objfile->obfd.get ())
-		   ? BFD_ENDIAN_BIG : BFD_ENDIAN_LITTLE,
-		   true);
-    }
+    value->read (attr->as_block ()->view (),
+		 (bfd_big_endian (cu->per_objfile->objfile->obfd.get ())
+		  ? BFD_ENDIAN_BIG : BFD_ENDIAN_LITTLE),
+		 true);
   else
     {
       /* Rational constants for Ada are always unsigned.  */
@@ -13405,10 +13399,7 @@ var_decl_name (struct die_info *die, struct dwarf2_cu *cu)
   if (attr == nullptr || !attr->as_boolean ())
     return nullptr;
 
-  attr = dwarf2_attr (die, DW_AT_name, cu);
-  if (attr == nullptr)
-    return nullptr;
-  return attr->as_string ();
+  return dwarf2_full_name (nullptr, die, cu);
 }
 
 /* Parse dwarf attribute if it's a block, reference or constant and put the
@@ -13452,8 +13443,7 @@ attr_to_dynamic_prop (const struct attribute *attr, struct die_info *die,
       else
 	block = *attr->as_block ();
 
-      baton->locexpr.size = block.size;
-      baton->locexpr.data = block.data;
+      baton->locexpr.set_expr (block);
       switch (attr->name)
 	{
 	case DW_AT_string_length:
@@ -13509,9 +13499,7 @@ attr_to_dynamic_prop (const struct attribute *attr, struct die_info *die,
 		baton->property_type = die_type (target_die, target_cu);
 		baton->locexpr.per_cu = cu->per_cu;
 		baton->locexpr.per_objfile = per_objfile;
-		struct dwarf_block *block = target_attr->as_block ();
-		baton->locexpr.size = block->size;
-		baton->locexpr.data = block->data;
+		baton->locexpr.set_expr (*target_attr->as_block ());
 		baton->locexpr.is_reference = true;
 		prop->set_locexpr (baton);
 		gdb_assert (prop->baton () != NULL);
@@ -15494,13 +15482,428 @@ new_symbol_file_line (struct die_info *die, struct dwarf2_cu *cu,
   sym->set_symtab (fe->symtab (*file_cu));
 }
 
+/* Given a DWARF information entry CU/DIE with LINKAGENAME and PHYSNAME, fill
+   in SYM according to DIE->tag.  */
+
+static void
+new_symbol (struct die_info *die, struct dwarf2_cu *cu, struct symbol *sym,
+	    const char *linkagename, const char *physname)
+{
+  dwarf2_per_objfile *per_objfile = cu->per_objfile;
+  struct objfile *objfile = per_objfile->objfile;
+  struct attribute *attr = nullptr;
+  struct attribute *attr2 = nullptr;
+  std::vector<symbol *> *list_to_add = nullptr;
+  bool suppress_add = false;
+
+  switch (die->tag)
+    {
+    case DW_TAG_label:
+      {
+	attr = dwarf2_attr (die, DW_AT_low_pc, cu);
+	if (attr != nullptr)
+	  {
+	    CORE_ADDR addr = per_objfile->relocate (attr->as_address ());
+	    sym->set_section_index (SECT_OFF_TEXT (objfile));
+	    sym->set_value_address (addr);
+	    sym->set_loc_class_index (LOC_LABEL);
+	  }
+	else
+	  sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
+	type_allocator alloc (objfile, cu->lang ());
+	struct type *addr_type
+	  = alloc.copy_type (builtin_type (objfile)->builtin_core_addr);
+	sym->set_type (addr_type);
+	sym->set_domain (LABEL_DOMAIN);
+	list_to_add = cu->list_in_scope;
+      }
+      break;
+    case DW_TAG_entry_point:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      /* DW_TAG_entry_point provides an additional entry_point to an
+	 existing sub_program.  Therefore, we inherit the "external"
+	 attribute from the sub_program to which the entry_point
+	 belongs to.  */
+      attr2 = dwarf2_attr (die->parent, DW_AT_external, cu);
+      if (attr2 != nullptr && attr2->as_boolean ())
+	list_to_add = &cu->get_builder ()->get_global_symbols ();
+      else
+	list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_subprogram:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      attr2 = dwarf2_attr (die, DW_AT_external, cu);
+      if ((attr2 != nullptr && attr2->as_boolean ())
+	  || cu->lang () == language_ada
+	  || cu->lang () == language_fortran)
+	{
+	  /* Subprograms marked external are stored as a global symbol.
+	     Ada and Fortran subprograms, whether marked external or
+	     not, are always stored as a global symbol, because we want
+	     to be able to access them globally.  For instance, we want
+	     to be able to break on a nested subprogram without having
+	     to specify the context.  */
+	  list_to_add = &cu->get_builder ()->get_global_symbols ();
+	}
+      else
+	list_to_add = cu->list_in_scope;
+
+      if (is_ada_import_or_export (cu, physname, linkagename))
+	{
+	  /* This is either a Pragma Import or Export.  They can
+	     be distinguished by the declaration flag.  */
+	  sym->set_linkage_name (physname);
+	  if (die_is_declaration (die, cu))
+	    {
+	      /* For Import, create a symbol using the source
+		 name, and have it refer to the linkage name.  */
+	      SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
+	      sym->set_loc_class_index (ada_block_index);
+	    }
+	  else
+	    {
+	      /* For Export, create a symbol using the source
+		 name, then create a second symbol that refers
+		 back to it.  */
+	      add_ada_export_symbol (sym, linkagename, physname, cu,
+				     *list_to_add);
+	    }
+	}
+      break;
+    case DW_TAG_inlined_subroutine:
+      /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
+	 finish_block.  */
+      sym->set_domain (FUNCTION_DOMAIN);
+      sym->set_loc_class_index (LOC_BLOCK);
+      sym->set_is_inlined (1);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_template_value_param:
+      suppress_add = true;
+      [[fallthrough]];
+    case DW_TAG_constant:
+    case DW_TAG_variable:
+    case DW_TAG_member:
+      sym->set_domain (VAR_DOMAIN);
+      /* Compilation with minimal debug info may result in
+	 variables with missing type entries.  Change the
+	 misleading `void' type to something sensible.  */
+      if (sym->type ()->code () == TYPE_CODE_VOID)
+	{
+	  type_allocator alloc (objfile, cu->lang ());
+	  struct type *int_type
+	    = alloc.copy_type (builtin_type (objfile)->builtin_int);
+	  sym->set_type (int_type);
+	}
+
+      attr = dwarf2_attr (die, DW_AT_const_value, cu);
+      /* In the case of DW_TAG_member, we should only be called for
+	 static const members.  */
+      if (die->tag == DW_TAG_member)
+	{
+	  /* dwarf2_add_field uses die_is_declaration,
+	     so we do the same.  */
+	  gdb_assert (die_is_declaration (die, cu));
+	  gdb_assert (attr);
+	}
+      if (attr != nullptr)
+	{
+	  dwarf2_const_value (attr, sym, cu);
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+	  if (!suppress_add)
+	    {
+	      if (attr2 != nullptr && attr2->as_boolean ())
+		list_to_add = &cu->get_builder ()->get_global_symbols ();
+	      else
+		list_to_add = cu->list_in_scope;
+	    }
+	  break;
+	}
+      attr = dwarf2_attr (die, DW_AT_location, cu);
+      if (attr != nullptr)
+	{
+	  var_decode_location (attr, sym, cu);
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+
+	  /* Fortran explicitly imports any global symbols to the local
+	     scope by DW_TAG_common_block.  */
+	  if (cu->lang () == language_fortran && die->parent
+	      && die->parent->tag == DW_TAG_common_block)
+	    attr2 = nullptr;
+
+	  if (sym->loc_class () == LOC_STATIC
+	      && sym->value_address () == 0
+	      && !per_objfile->per_bfd->has_section_at_zero)
+	    {
+	      /* When a static variable is eliminated by the linker,
+		 the corresponding debug information is not stripped
+		 out, but the variable address is set to null;
+		 do not add such variables into symbol table.  */
+	    }
+	  else if (attr2 != nullptr && attr2->as_boolean ())
+	    {
+	      if (sym->loc_class () == LOC_STATIC
+		  && (objfile->flags & OBJF_MAINLINE) == 0
+		  && per_objfile->per_bfd->can_copy)
+		{
+		  /* A global static variable might be subject to
+		     copy relocation.  We first check for a local
+		     minsym, though, because maybe the symbol was
+		     marked hidden, in which case this would not
+		     apply.  */
+		  bound_minimal_symbol found
+		    = (lookup_minimal_symbol_linkage
+		       (sym->linkage_name (), objfile, false));
+		  if (found.minsym != nullptr)
+		    sym->maybe_copied = 1;
+		}
+
+	      /* A variable with DW_AT_external is never static,
+		 but it may be block-scoped.  */
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+	    }
+	  else
+	    list_to_add = cu->list_in_scope;
+
+	  if (list_to_add != nullptr
+	      && is_ada_import_or_export (cu, physname, linkagename))
+	    {
+	      /* This is a Pragma Export.  A Pragma Import won't
+		 be seen here, because it will not have a location
+		 and so will be handled below.  */
+	      add_ada_export_symbol (sym, physname, linkagename, cu,
+				     *list_to_add);
+	    }
+	}
+      else
+	{
+	  /* We do not know the address of this symbol.
+	     If it is an external symbol and we have type information
+	     for it, enter the symbol as a LOC_UNRESOLVED symbol.
+	     The address of the variable will then be determined from
+	     the minimal symbol table whenever the variable is
+	     referenced.  */
+	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
+
+	  /* Fortran explicitly imports any global symbols to the local
+	     scope by DW_TAG_common_block.  */
+	  if (cu->lang () == language_fortran && die->parent
+	      && die->parent->tag == DW_TAG_common_block)
+	    {
+	      /* SYMBOL_CLASS doesn't matter here because
+		 read_common_block is going to reset it.  */
+	      if (!suppress_add)
+		list_to_add = cu->list_in_scope;
+	    }
+	  else if (is_ada_import_or_export (cu, physname, linkagename))
+	    {
+	      /* This is a Pragma Import.  A Pragma Export won't
+		 be seen here, because it will have a location and
+		 so will be handled above.  */
+	      sym->set_linkage_name (physname);
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+	      SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
+	      sym->set_loc_class_index (ada_imported_index);
+	    }
+	  else if (attr2 != nullptr && attr2->as_boolean ()
+		   && dwarf2_attr (die, DW_AT_type, cu) != nullptr)
+	    {
+	      /* A variable with DW_AT_external is never static, but it
+		 may be block-scoped.  */
+	      list_to_add
+		= ((cu->list_in_scope
+		    == &cu->get_builder ()->get_file_symbols ())
+		   ? &cu->get_builder ()->get_global_symbols ()
+		   : cu->list_in_scope);
+
+	      sym->set_loc_class_index (LOC_UNRESOLVED);
+	    }
+	  else if (!die_is_declaration (die, cu))
+	    {
+	      /* Use the default LOC_OPTIMIZED_OUT class.  */
+	      gdb_assert (sym->loc_class () == LOC_OPTIMIZED_OUT);
+	      if (!suppress_add)
+		list_to_add = cu->list_in_scope;
+	    }
+	}
+      break;
+    case DW_TAG_formal_parameter:
+      {
+	/* If we are inside a function, mark this as an argument.  If
+	   not, we might be looking at an argument to an inlined function
+	   when we do not have enough information to show inlined frames;
+	   pretend it's a local variable in that case so that the user can
+	   still see it.  */
+	sym->set_domain (VAR_DOMAIN);
+	if (cu->get_builder ()->current_context_has_function ())
+	  sym->set_is_argument (true);
+	attr = dwarf2_attr (die, DW_AT_location, cu);
+	if (attr != nullptr)
+	  var_decode_location (attr, sym, cu);
+	attr = dwarf2_attr (die, DW_AT_const_value, cu);
+	if (attr != nullptr)
+	  dwarf2_const_value (attr, sym, cu);
+
+	list_to_add = cu->list_in_scope;
+      }
+      break;
+    case DW_TAG_unspecified_parameters:
+      /* From varargs functions; gdb doesn't seem to have any
+	 interest in this information, so just ignore it for now.
+	 (FIXME?) */
+      break;
+    case DW_TAG_template_type_param:
+      suppress_add = true;
+      [[fallthrough]];
+    case DW_TAG_class_type:
+    case DW_TAG_interface_type:
+    case DW_TAG_structure_type:
+    case DW_TAG_union_type:
+    case DW_TAG_set_type:
+    case DW_TAG_enumeration_type:
+      if (cu->lang () == language_c
+	  || is_cplus_dialect (cu->lang ())
+	  || cu->lang () == language_objc
+	  || cu->lang () == language_opencl
+	  || cu->lang () == language_minimal)
+	{
+	  /* These languages have a tag namespace.  Note that
+	     there's a special hack for C++ in the matching code,
+	     so we don't need to enter a separate typedef for the
+	     tag.  */
+	  sym->set_loc_class_index (LOC_TYPEDEF);
+	  sym->set_domain (STRUCT_DOMAIN);
+	}
+      else
+	{
+	  /* Other languages don't have a tag namespace.  */
+	  sym->set_loc_class_index (LOC_TYPEDEF);
+	  sym->set_domain (TYPE_DOMAIN);
+	}
+
+      /* NOTE: carlton/2003-11-10: C++ class symbols shouldn't
+	 really ever be static objects: otherwise, if you try
+	 to, say, break of a class's method and you're in a file
+	 which doesn't mention that class, it won't work unless
+	 the check for all static symbols in lookup_symbol_aux
+	 saves you.  See the OtherFileClass tests in
+	 gdb.c++/namespace.exp.  */
+
+      if (!suppress_add)
+	{
+	  buildsym_compunit *builder = cu->get_builder ();
+	  list_to_add
+	    = ((cu->list_in_scope == &builder->get_file_symbols ()
+		&& is_cplus_dialect (cu->lang ()))
+	       ? &builder->get_global_symbols ()
+	       : cu->list_in_scope);
+
+	  /* The semantics of C++ state that "struct foo {
+	     ... }" also defines a typedef for "foo".  */
+	  if (is_cplus_dialect (cu->lang ())
+	      || cu->lang () == language_ada
+	      || cu->lang () == language_d
+	      || cu->lang () == language_rust)
+	    {
+	      /* The symbol's name is already allocated along
+		 with this objfile, so we don't need to
+		 duplicate it for the type.  */
+	      if (sym->type ()->name () == 0)
+		sym->type ()->set_name (sym->search_name ());
+	    }
+	}
+      break;
+    case DW_TAG_unspecified_type:
+      if (cu->lang () == language_ada)
+	break;
+      [[fallthrough]];
+    case DW_TAG_typedef:
+    case DW_TAG_array_type:
+    case DW_TAG_base_type:
+    case DW_TAG_subrange_type:
+    case DW_TAG_generic_subrange:
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      sym->set_domain (TYPE_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_enumerator:
+      sym->set_domain (VAR_DOMAIN);
+      attr = dwarf2_attr (die, DW_AT_const_value, cu);
+      if (attr != nullptr)
+	dwarf2_const_value (attr, sym, cu);
+
+      /* NOTE: carlton/2003-11-10: See comment above in the
+	 DW_TAG_class_type, etc. block.  */
+
+      list_to_add
+	= ((cu->list_in_scope == &cu->get_builder ()->get_file_symbols ()
+	    && is_cplus_dialect (cu->lang ()))
+	   ? &cu->get_builder ()->get_global_symbols ()
+	   : cu->list_in_scope);
+      break;
+    case DW_TAG_imported_declaration:
+    case DW_TAG_namespace:
+      sym->set_domain (TYPE_DOMAIN);
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      list_to_add = &cu->get_builder ()->get_global_symbols ();
+      break;
+    case DW_TAG_module:
+      sym->set_loc_class_index (LOC_TYPEDEF);
+      sym->set_domain (MODULE_DOMAIN);
+      list_to_add = &cu->get_builder ()->get_global_symbols ();
+      break;
+    case DW_TAG_common_block:
+      sym->set_loc_class_index (LOC_COMMON_BLOCK);
+      sym->set_domain (COMMON_BLOCK_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    case DW_TAG_namelist:
+      sym->set_loc_class_index (LOC_STATIC);
+      sym->set_domain (VAR_DOMAIN);
+      list_to_add = cu->list_in_scope;
+      break;
+    default:
+      /* Not a tag we recognize.  Hopefully we aren't processing
+	 trash data, but since we must specifically ignore things
+	 we don't recognize, there is nothing else we should do at
+	 this point.  */
+      complaint (_("unsupported tag: '%s'"),
+		 dwarf_tag_name (die->tag));
+      break;
+    }
+
+  if (suppress_add)
+    {
+      sym->hash_next = objfile->template_symbols;
+      objfile->template_symbols = sym;
+      return;
+    }
+
+  if (list_to_add != nullptr)
+    add_symbol_to_list (sym, *list_to_add);
+}
+
 /* Given a pointer to a DWARF information entry, figure out if we need
    to make a symbol table entry for it, and if so, create a new entry
    and return a pointer to it.
-   If TYPE is NULL, determine symbol type from the die, otherwise
+   If TYPE is nullptr, determine symbol type from the die, otherwise
    used the passed type.
-   If SPACE is not NULL, use it to hold the new symbol.  If it is
-   NULL, allocate a new symbol on the objfile's obstack.  */
+   If SPACE is not nullptr, use it to hold the new symbol.  If it is
+   nullptr, allocate a new symbol on the objfile's obstack.  */
 
 static struct symbol *
 new_symbol (struct die_info *die, struct type *type, struct dwarf2_cu *cu,
@@ -15508,483 +15911,65 @@ new_symbol (struct die_info *die, struct type *type, struct dwarf2_cu *cu,
 {
   dwarf2_per_objfile *per_objfile = cu->per_objfile;
   struct objfile *objfile = per_objfile->objfile;
-  struct symbol *sym = NULL;
-  const char *name;
-  struct attribute *attr = NULL;
-  struct attribute *attr2 = NULL;
-  std::vector<symbol *> *list_to_add = nullptr;
 
-  name = dwarf2_name (die, cu);
+  const char *name = dwarf2_name (die, cu);
   if (name == nullptr && (die->tag == DW_TAG_subprogram
 			  || die->tag == DW_TAG_inlined_subroutine
 			  || die->tag == DW_TAG_entry_point))
     name = dw2_linkage_name (die, cu);
+  if (name == nullptr)
+    return nullptr;
 
-  if (name)
-    {
-      int suppress_add = 0;
+  struct symbol *sym = space;
+  if (sym == nullptr)
+    sym = objfile->new_symbol<symbol> ();
 
-      if (space)
-	sym = space;
-      else
-	sym = objfile->new_symbol<symbol> ();
+  sym->set_language (cu->lang (), &objfile->objfile_obstack);
 
-      /* Cache this symbol's name and the name's demangled form (if any).  */
-      sym->set_language (cu->lang (), &objfile->objfile_obstack);
-      /* Fortran does not have mangling standard and the mangling does differ
-	 between gfortran, iFort etc.  */
-      const char *physname
-	= ((cu->lang () == language_fortran || cu->lang () == language_ada)
-	   ? dwarf2_full_name (name, die, cu)
-	   : dwarf2_physname (name, die, cu));
-      const char *linkagename = dw2_linkage_name (die, cu);
+  /* Fortran does not have mangling standard and the mangling does differ
+     between gfortran, iFort etc.  */
+  const char *physname
+    = ((cu->lang () == language_fortran || cu->lang () == language_ada)
+       ? dwarf2_full_name (name, die, cu)
+       : dwarf2_physname (name, die, cu));
+  const char *linkagename = dw2_linkage_name (die, cu);
 
-      if (linkagename == nullptr)
-	sym->set_linkage_name (physname);
-      else if (cu->lang () == language_ada)
-	sym->set_linkage_name (linkagename);
-      else
-	{
-	  if (physname == linkagename)
-	    sym->set_demangled_name (name, &objfile->objfile_obstack);
-	  else
-	    sym->set_demangled_name (physname, &objfile->objfile_obstack);
+  /* Cache this symbol's name and the name's demangled form (if any).  */
+  sym->set_linkage_name (linkagename != nullptr
+			 ? linkagename
+			 : physname);
+  if (linkagename != nullptr && cu->lang () != language_ada)
+    sym->set_demangled_name (physname == linkagename
+			     ? name
+			     : physname,
+			     &objfile->objfile_obstack);
 
-	  sym->set_linkage_name (linkagename);
-	}
+  /* Handle DW_AT_artificial.  */
+  struct attribute *attr = dwarf2_attr (die, DW_AT_artificial, cu);
+  if (attr != nullptr)
+    sym->set_is_artificial (attr->as_boolean ());
 
-      /* Handle DW_AT_artificial.  */
-      attr = dwarf2_attr (die, DW_AT_artificial, cu);
-      if (attr != nullptr)
-	sym->set_is_artificial (attr->as_boolean ());
+  /* Default assumptions.
+     Use the passed type or decode it from the die.  */
+  sym->set_domain (UNDEF_DOMAIN);
+  sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
+  sym->set_type (type != nullptr
+		 ? type
+		 : die_type (die, cu));
 
-      /* Default assumptions.
-	 Use the passed type or decode it from the die.  */
-      sym->set_domain (UNDEF_DOMAIN);
-      sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
-      if (type != NULL)
-	sym->set_type (type);
-      else
-	sym->set_type (die_type (die, cu));
+  /* Handle DW_AT_{call,decl}_{file,line}.  */
+  new_symbol_file_line (die, cu, sym);
 
-      /* Handle DW_AT_{call,decl}_{file,line}.  */
-      new_symbol_file_line (die, cu, sym);
+  /* Handle TAG-specific part.  */
+  new_symbol (die, cu, sym, linkagename, physname);
 
-      switch (die->tag)
-	{
-	case DW_TAG_label:
-	  {
-	    attr = dwarf2_attr (die, DW_AT_low_pc, cu);
-	    if (attr != nullptr)
-	      {
-		CORE_ADDR addr = per_objfile->relocate (attr->as_address ());
-		sym->set_section_index (SECT_OFF_TEXT (objfile));
-		sym->set_value_address (addr);
-		sym->set_loc_class_index (LOC_LABEL);
-	      }
-	    else
-	      sym->set_loc_class_index (LOC_OPTIMIZED_OUT);
-	    type_allocator alloc (objfile, cu->lang ());
-	    struct type *addr_type
-	      = alloc.copy_type (builtin_type (objfile)->builtin_core_addr);
-	    sym->set_type (addr_type);
-	    sym->set_domain (LABEL_DOMAIN);
-	    list_to_add = cu->list_in_scope;
-	  }
-	  break;
-	case DW_TAG_entry_point:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  /* DW_TAG_entry_point provides an additional entry_point to an
-	     existing sub_program.  Therefore, we inherit the "external"
-	     attribute from the sub_program to which the entry_point
-	     belongs to.  */
-	  attr2 = dwarf2_attr (die->parent, DW_AT_external, cu);
-	  if (attr2 != nullptr && attr2->as_boolean ())
-	    list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  else
-	    list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_subprogram:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  attr2 = dwarf2_attr (die, DW_AT_external, cu);
-	  if ((attr2 != nullptr && attr2->as_boolean ())
-	      || cu->lang () == language_ada
-	      || cu->lang () == language_fortran)
-	    {
-	      /* Subprograms marked external are stored as a global symbol.
-		 Ada and Fortran subprograms, whether marked external or
-		 not, are always stored as a global symbol, because we want
-		 to be able to access them globally.  For instance, we want
-		 to be able to break on a nested subprogram without having
-		 to specify the context.  */
-	      list_to_add = &cu->get_builder ()->get_global_symbols ();
-	    }
-	  else
-	    {
-	      list_to_add = cu->list_in_scope;
-	    }
+  /* For the benefit of old versions of GCC, check for anonymous
+     namespaces based on the demangled name.  */
+  if (!cu->processing_has_namespace_info
+      && is_cplus_dialect (cu->lang ()))
+    cp_scan_for_anonymous_namespaces (cu->get_builder (), sym, objfile);
 
-	  if (is_ada_import_or_export (cu, physname, linkagename))
-	    {
-	      /* This is either a Pragma Import or Export.  They can
-		 be distinguished by the declaration flag.  */
-	      sym->set_linkage_name (physname);
-	      if (die_is_declaration (die, cu))
-		{
-		  /* For Import, create a symbol using the source
-		     name, and have it refer to the linkage name.  */
-		  SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
-		  sym->set_loc_class_index (ada_block_index);
-		}
-	      else
-		{
-		  /* For Export, create a symbol using the source
-		     name, then create a second symbol that refers
-		     back to it.  */
-		  add_ada_export_symbol (sym, linkagename, physname, cu,
-					 *list_to_add);
-		}
-	    }
-	  break;
-	case DW_TAG_inlined_subroutine:
-	  /* SYMBOL_BLOCK_VALUE (sym) will be filled in later by
-	     finish_block.  */
-	  sym->set_domain (FUNCTION_DOMAIN);
-	  sym->set_loc_class_index (LOC_BLOCK);
-	  sym->set_is_inlined (1);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_template_value_param:
-	  suppress_add = 1;
-	  [[fallthrough]];
-	case DW_TAG_constant:
-	case DW_TAG_variable:
-	case DW_TAG_member:
-	  sym->set_domain (VAR_DOMAIN);
-	  /* Compilation with minimal debug info may result in
-	     variables with missing type entries.  Change the
-	     misleading `void' type to something sensible.  */
-	  if (sym->type ()->code () == TYPE_CODE_VOID)
-	    {
-	      type_allocator alloc (objfile, cu->lang ());
-	      struct type *int_type
-		= alloc.copy_type (builtin_type (objfile)->builtin_int);
-	      sym->set_type (int_type);
-	    }
-
-	  attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	  /* In the case of DW_TAG_member, we should only be called for
-	     static const members.  */
-	  if (die->tag == DW_TAG_member)
-	    {
-	      /* dwarf2_add_field uses die_is_declaration,
-		 so we do the same.  */
-	      gdb_assert (die_is_declaration (die, cu));
-	      gdb_assert (attr);
-	    }
-	  if (attr != nullptr)
-	    {
-	      dwarf2_const_value (attr, sym, cu);
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-	      if (!suppress_add)
-		{
-		  if (attr2 != nullptr && attr2->as_boolean ())
-		    list_to_add = &cu->get_builder ()->get_global_symbols ();
-		  else
-		    list_to_add = cu->list_in_scope;
-		}
-	      break;
-	    }
-	  attr = dwarf2_attr (die, DW_AT_location, cu);
-	  if (attr != nullptr)
-	    {
-	      var_decode_location (attr, sym, cu);
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-
-	      /* Fortran explicitly imports any global symbols to the local
-		 scope by DW_TAG_common_block.  */
-	      if (cu->lang () == language_fortran && die->parent
-		  && die->parent->tag == DW_TAG_common_block)
-		attr2 = NULL;
-
-	      if (sym->loc_class () == LOC_STATIC
-		  && sym->value_address () == 0
-		  && !per_objfile->per_bfd->has_section_at_zero)
-		{
-		  /* When a static variable is eliminated by the linker,
-		     the corresponding debug information is not stripped
-		     out, but the variable address is set to null;
-		     do not add such variables into symbol table.  */
-		}
-	      else if (attr2 != nullptr && attr2->as_boolean ())
-		{
-		  if (sym->loc_class () == LOC_STATIC
-		      && (objfile->flags & OBJF_MAINLINE) == 0
-		      && per_objfile->per_bfd->can_copy)
-		    {
-		      /* A global static variable might be subject to
-			 copy relocation.  We first check for a local
-			 minsym, though, because maybe the symbol was
-			 marked hidden, in which case this would not
-			 apply.  */
-		      bound_minimal_symbol found
-			= (lookup_minimal_symbol_linkage
-			   (sym->linkage_name (), objfile, false));
-		      if (found.minsym != nullptr)
-			sym->maybe_copied = 1;
-		    }
-
-		  /* A variable with DW_AT_external is never static,
-		     but it may be block-scoped.  */
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-		}
-	      else
-		list_to_add = cu->list_in_scope;
-
-	      if (list_to_add != nullptr
-		  && is_ada_import_or_export (cu, physname, linkagename))
-		{
-		  /* This is a Pragma Export.  A Pragma Import won't
-		     be seen here, because it will not have a location
-		     and so will be handled below.  */
-		  add_ada_export_symbol (sym, physname, linkagename, cu,
-					 *list_to_add);
-		}
-	    }
-	  else
-	    {
-	      /* We do not know the address of this symbol.
-		 If it is an external symbol and we have type information
-		 for it, enter the symbol as a LOC_UNRESOLVED symbol.
-		 The address of the variable will then be determined from
-		 the minimal symbol table whenever the variable is
-		 referenced.  */
-	      attr2 = dwarf2_attr (die, DW_AT_external, cu);
-
-	      /* Fortran explicitly imports any global symbols to the local
-		 scope by DW_TAG_common_block.  */
-	      if (cu->lang () == language_fortran && die->parent
-		  && die->parent->tag == DW_TAG_common_block)
-		{
-		  /* SYMBOL_CLASS doesn't matter here because
-		     read_common_block is going to reset it.  */
-		  if (!suppress_add)
-		    list_to_add = cu->list_in_scope;
-		}
-	      else if (is_ada_import_or_export (cu, physname, linkagename))
-		{
-		  /* This is a Pragma Import.  A Pragma Export won't
-		     be seen here, because it will have a location and
-		     so will be handled above.  */
-		  sym->set_linkage_name (physname);
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-		  SYMBOL_LOCATION_BATON (sym) = (void *) linkagename;
-		  sym->set_loc_class_index (ada_imported_index);
-		}
-	      else if (attr2 != nullptr && attr2->as_boolean ()
-		       && dwarf2_attr (die, DW_AT_type, cu) != NULL)
-		{
-		  /* A variable with DW_AT_external is never static, but it
-		     may be block-scoped.  */
-		  list_to_add
-		    = ((cu->list_in_scope
-			== &cu->get_builder ()->get_file_symbols ())
-		       ? &cu->get_builder ()->get_global_symbols ()
-		       : cu->list_in_scope);
-
-		  sym->set_loc_class_index (LOC_UNRESOLVED);
-		}
-	      else if (!die_is_declaration (die, cu))
-		{
-		  /* Use the default LOC_OPTIMIZED_OUT class.  */
-		  gdb_assert (sym->loc_class () == LOC_OPTIMIZED_OUT);
-		  if (!suppress_add)
-		    list_to_add = cu->list_in_scope;
-		}
-	    }
-	  break;
-	case DW_TAG_formal_parameter:
-	  {
-	    /* If we are inside a function, mark this as an argument.  If
-	       not, we might be looking at an argument to an inlined function
-	       when we do not have enough information to show inlined frames;
-	       pretend it's a local variable in that case so that the user can
-	       still see it.  */
-	    sym->set_domain (VAR_DOMAIN);
-	    if (cu->get_builder ()->current_context_has_function ())
-	      sym->set_is_argument (true);
-	    attr = dwarf2_attr (die, DW_AT_location, cu);
-	    if (attr != nullptr)
-	      {
-		var_decode_location (attr, sym, cu);
-	      }
-	    attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	    if (attr != nullptr)
-	      {
-		dwarf2_const_value (attr, sym, cu);
-	      }
-
-	    list_to_add = cu->list_in_scope;
-	  }
-	  break;
-	case DW_TAG_unspecified_parameters:
-	  /* From varargs functions; gdb doesn't seem to have any
-	     interest in this information, so just ignore it for now.
-	     (FIXME?) */
-	  break;
-	case DW_TAG_template_type_param:
-	  suppress_add = 1;
-	  [[fallthrough]];
-	case DW_TAG_class_type:
-	case DW_TAG_interface_type:
-	case DW_TAG_structure_type:
-	case DW_TAG_union_type:
-	case DW_TAG_set_type:
-	case DW_TAG_enumeration_type:
-	  if (cu->lang () == language_c
-	      || is_cplus_dialect (cu->lang ())
-	      || cu->lang () == language_objc
-	      || cu->lang () == language_opencl
-	      || cu->lang () == language_minimal)
-	    {
-	      /* These languages have a tag namespace.  Note that
-		 there's a special hack for C++ in the matching code,
-		 so we don't need to enter a separate typedef for the
-		 tag.  */
-	      sym->set_loc_class_index (LOC_TYPEDEF);
-	      sym->set_domain (STRUCT_DOMAIN);
-	    }
-	  else
-	    {
-	      /* Other languages don't have a tag namespace.  */
-	      sym->set_loc_class_index (LOC_TYPEDEF);
-	      sym->set_domain (TYPE_DOMAIN);
-	    }
-
-	  /* NOTE: carlton/2003-11-10: C++ class symbols shouldn't
-	     really ever be static objects: otherwise, if you try
-	     to, say, break of a class's method and you're in a file
-	     which doesn't mention that class, it won't work unless
-	     the check for all static symbols in lookup_symbol_aux
-	     saves you.  See the OtherFileClass tests in
-	     gdb.c++/namespace.exp.  */
-
-	  if (!suppress_add)
-	    {
-	      buildsym_compunit *builder = cu->get_builder ();
-	      list_to_add
-		= ((cu->list_in_scope == &builder->get_file_symbols ()
-		    && is_cplus_dialect (cu->lang ()))
-		   ? &builder->get_global_symbols ()
-		   : cu->list_in_scope);
-
-	      /* The semantics of C++ state that "struct foo {
-		 ... }" also defines a typedef for "foo".  */
-	      if (is_cplus_dialect (cu->lang ())
-		  || cu->lang () == language_ada
-		  || cu->lang () == language_d
-		  || cu->lang () == language_rust)
-		{
-		  /* The symbol's name is already allocated along
-		     with this objfile, so we don't need to
-		     duplicate it for the type.  */
-		  if (sym->type ()->name () == 0)
-		    sym->type ()->set_name (sym->search_name ());
-		}
-	    }
-	  break;
-	case DW_TAG_unspecified_type:
-	  if (cu->lang () == language_ada)
-	    break;
-	  [[fallthrough]];
-	case DW_TAG_typedef:
-	case DW_TAG_array_type:
-	case DW_TAG_base_type:
-	case DW_TAG_subrange_type:
-	case DW_TAG_generic_subrange:
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  sym->set_domain (TYPE_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_enumerator:
-	  sym->set_domain (VAR_DOMAIN);
-	  attr = dwarf2_attr (die, DW_AT_const_value, cu);
-	  if (attr != nullptr)
-	    {
-	      dwarf2_const_value (attr, sym, cu);
-	    }
-
-	  /* NOTE: carlton/2003-11-10: See comment above in the
-	     DW_TAG_class_type, etc. block.  */
-
-	  list_to_add
-	    = (cu->list_in_scope == &cu->get_builder ()->get_file_symbols ()
-	       && is_cplus_dialect (cu->lang ())
-	       ? &cu->get_builder ()->get_global_symbols ()
-	       : cu->list_in_scope);
-	  break;
-	case DW_TAG_imported_declaration:
-	case DW_TAG_namespace:
-	  sym->set_domain (TYPE_DOMAIN);
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  break;
-	case DW_TAG_module:
-	  sym->set_loc_class_index (LOC_TYPEDEF);
-	  sym->set_domain (MODULE_DOMAIN);
-	  list_to_add = &cu->get_builder ()->get_global_symbols ();
-	  break;
-	case DW_TAG_common_block:
-	  sym->set_loc_class_index (LOC_COMMON_BLOCK);
-	  sym->set_domain (COMMON_BLOCK_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	case DW_TAG_namelist:
-	  sym->set_loc_class_index (LOC_STATIC);
-	  sym->set_domain (VAR_DOMAIN);
-	  list_to_add = cu->list_in_scope;
-	  break;
-	default:
-	  /* Not a tag we recognize.  Hopefully we aren't processing
-	     trash data, but since we must specifically ignore things
-	     we don't recognize, there is nothing else we should do at
-	     this point.  */
-	  complaint (_("unsupported tag: '%s'"),
-		     dwarf_tag_name (die->tag));
-	  break;
-	}
-
-      if (suppress_add)
-	{
-	  sym->hash_next = objfile->template_symbols;
-	  objfile->template_symbols = sym;
-	  list_to_add = NULL;
-	}
-
-      if (list_to_add != NULL)
-	add_symbol_to_list (sym, *list_to_add);
-
-      /* For the benefit of old versions of GCC, check for anonymous
-	 namespaces based on the demangled name.  */
-      if (!cu->processing_has_namespace_info
-	  && is_cplus_dialect (cu->lang ()))
-	cp_scan_for_anonymous_namespaces (cu->get_builder (), sym, objfile);
-    }
-  return (sym);
+  return sym;
 }
 
 /* Read a constant value from an attribute.  Either set *VALUE, or if
@@ -16031,9 +16016,9 @@ dwarf2_const_value_attr (const struct attribute *attr, struct type *type,
 	(*baton)->per_cu = cu->per_cu;
 	gdb_assert ((*baton)->per_cu);
 
-	(*baton)->size = 2 + cu_header->addr_size;
-	data = (gdb_byte *) obstack_alloc (obstack, (*baton)->size);
-	(*baton)->data = data;
+	std::size_t size = 2 + cu_header->addr_size;
+	data = (gdb_byte *) obstack_alloc (obstack, size);
+	(*baton)->set_expr (gdb::make_array_view (data, size));
 
 	data[0] = DW_OP_addr;
 	store_unsigned_integer (&data[1], cu_header->addr_size,
@@ -16650,23 +16635,28 @@ determine_prefix (struct die_info *die, struct dwarf2_cu *cu)
 	  }
 	return "";
       case DW_TAG_subprogram:
-	/* Nested subroutines in Fortran get a prefix with the name
-	   of the parent's subroutine.  Entry points are prefixed by the
-	   parent's namespace.  */
-	if (cu->lang () == language_fortran)
-	  {
-	    if ((die->tag ==  DW_TAG_subprogram)
-		&& (dwarf2_name (parent, cu) != NULL))
-	      return dwarf2_name (parent, cu);
-	    else if (die->tag == DW_TAG_entry_point)
-	      return determine_prefix (parent, cu);
-	  }
-	else if (cu->lang () == language_ada
-		 && (die->tag == DW_TAG_subprogram
-		     || die->tag == DW_TAG_inlined_subroutine
-		     || die->tag == DW_TAG_lexical_block))
-	  return dwarf2_full_name (nullptr, parent, cu);
-	return "";
+	{
+	  const char *name = nullptr;
+	  /* Nested subroutines in Fortran get a prefix with the name
+	     of the parent's subroutine.  Entry points are prefixed by the
+	     parent's namespace.  */
+	  if (cu->lang () == language_fortran)
+	    {
+	      if ((die->tag ==  DW_TAG_subprogram)
+		  && (dwarf2_name (parent, cu) != NULL))
+		name = dwarf2_name (parent, cu);
+	      else if (die->tag == DW_TAG_entry_point)
+		name = determine_prefix (parent, cu);
+	    }
+	  else if (cu->lang () == language_ada
+		   && (die->tag == DW_TAG_subprogram
+		       || die->tag == DW_TAG_inlined_subroutine
+		       || die->tag == DW_TAG_lexical_block))
+	    name = dwarf2_full_name (nullptr, parent, cu);
+	  if (name == nullptr)
+	    name = "";
+	  return name;
+	}
       case DW_TAG_enumeration_type:
 	parent_type = read_type_die (parent, cu);
 	if (parent_type->is_declared_class ())
@@ -17095,23 +17085,17 @@ dwarf2_fetch_die_loc_sect_off (sect_offset sect_off, dwarf2_per_cu *per_cu,
 
   if (!attr)
     {
-      /* DWARF: "If there is no such attribute, then there is no effect.".
-	 DATA is ignored if SIZE is 0.  */
-
-      retval.data = NULL;
-      retval.size = 0;
+      /* DWARF: "If there is no such attribute, then there is no effect.".  */
+      retval.set_expr (gdb::array_view<const gdb_byte> ());
     }
   else if (attr->form_is_section_offset ())
     {
       struct dwarf2_loclist_baton loclist_baton;
       CORE_ADDR pc = get_frame_pc ();
-      size_t size;
 
       fill_in_loclist_baton (cu, &loclist_baton, attr);
 
-      retval.data = dwarf2_find_location_expression (&loclist_baton,
-						     &size, pc);
-      retval.size = size;
+      retval.set_expr (dwarf2_find_location_expression (&loclist_baton, pc));
     }
   else
     {
@@ -17121,9 +17105,7 @@ dwarf2_fetch_die_loc_sect_off (sect_offset sect_off, dwarf2_per_cu *per_cu,
 		 " [in module %s]"),
 	       sect_offset_str (sect_off), objfile_name (objfile));
 
-      struct dwarf_block *block = attr->as_block ();
-      retval.data = block->data;
-      retval.size = block->size;
+      retval.set_expr (*attr->as_block ());
     }
   retval.per_objfile = per_objfile;
   retval.per_cu = cu->per_cu;
@@ -17947,9 +17929,7 @@ dwarf2_symbol_mark_computed (const struct attribute *attr, struct symbol *sym,
 	     info_buffer for SYM's objfile; right now we never release
 	     that buffer, but when we do clean up properly this may
 	     need to change.  */
-	  struct dwarf_block *block = attr->as_block ();
-	  baton->size = block->size;
-	  baton->data = block->data;
+	  baton->set_expr (*attr->as_block ());
 	}
       else
 	{

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -5196,13 +5196,13 @@ set_gdbarch_get_pc_address_flags (struct gdbarch *gdbarch,
 }
 
 void
-gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb)
+gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb)
 {
   gdb_assert (gdbarch != nullptr);
   gdb_assert (gdbarch->read_core_file_mappings != nullptr);
   if (gdbarch_debug >= 2)
     gdb_printf (gdb_stdlog, "gdbarch_read_core_file_mappings called\n");
-  gdbarch->read_core_file_mappings (gdbarch, cbfd, pre_loop_cb, loop_cb);
+  gdbarch->read_core_file_mappings (gdbarch, cbfd, loop_cb);
 }
 
 void

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -5478,13 +5478,13 @@ set_gdbarch_get_pc_address_flags (struct gdbarch *gdbarch,
 }
 
 void
-gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb)
+gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb)
 {
   gdb_assert (gdbarch != nullptr);
   gdb_assert (gdbarch->read_core_file_mappings != nullptr);
   if (gdbarch_debug >= 2)
     gdb_printf (gdb_stdlog, "gdbarch_read_core_file_mappings called\n");
-  gdbarch->read_core_file_mappings (gdbarch, cbfd, pre_loop_cb, loop_cb);
+  gdbarch->read_core_file_mappings (gdbarch, cbfd, loop_cb);
 }
 
 void

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1696,8 +1696,8 @@ void set_gdbarch_get_pc_address_flags (struct gdbarch *gdbarch, gdbarch_get_pc_a
 
 /* Read core file mappings */
 
-using gdbarch_read_core_file_mappings_ftype = void (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb);
-void gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb);
+using gdbarch_read_core_file_mappings_ftype = void (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb);
+void gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb);
 void set_gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, gdbarch_read_core_file_mappings_ftype *read_core_file_mappings);
 
 /* Return true if the target description for all threads should be read from the

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1786,8 +1786,8 @@ void set_gdbarch_get_pc_address_flags (struct gdbarch *gdbarch, gdbarch_get_pc_a
 
 /* Read core file mappings */
 
-using gdbarch_read_core_file_mappings_ftype = void (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb);
-void gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_pre_loop_ftype pre_loop_cb, read_core_file_mappings_loop_ftype loop_cb);
+using gdbarch_read_core_file_mappings_ftype = void (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb);
+void gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd, read_core_file_mappings_loop_ftype loop_cb);
 void set_gdbarch_read_core_file_mappings (struct gdbarch *gdbarch, gdbarch_read_core_file_mappings_ftype *read_core_file_mappings);
 
 /* Return true if the target description for all threads should be read from the

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -122,10 +122,7 @@ enum class memtag_type
   allocation,
 };
 
-/* Callback types for 'read_core_file_mappings' gdbarch method.  */
-
-using read_core_file_mappings_pre_loop_ftype =
-  gdb::function_view<void (ULONGEST count)>;
+/* Callback type for 'read_core_file_mappings' gdbarch method.  */
 
 using read_core_file_mappings_loop_ftype =
   gdb::function_view<void (ULONGEST start,

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -128,8 +128,7 @@ using read_core_file_mappings_pre_loop_ftype =
   gdb::function_view<void (ULONGEST count)>;
 
 using read_core_file_mappings_loop_ftype =
-  gdb::function_view<void (int num,
-			   ULONGEST start,
+  gdb::function_view<void (ULONGEST start,
 			   ULONGEST end,
 			   ULONGEST file_ofs,
 			   const char *filename,

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -125,14 +125,10 @@ enum class memtag_type
   allocation,
 };
 
-/* Callback types for 'read_core_file_mappings' gdbarch method.  */
-
-using read_core_file_mappings_pre_loop_ftype =
-  gdb::function_view<void (ULONGEST count)>;
+/* Callback type for 'read_core_file_mappings' gdbarch method.  */
 
 using read_core_file_mappings_loop_ftype =
-  gdb::function_view<void (int num,
-			   ULONGEST start,
+  gdb::function_view<void (ULONGEST start,
 			   ULONGEST end,
 			   ULONGEST file_ofs,
 			   const char *filename,

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2706,7 +2706,6 @@ Read core file mappings
     name="read_core_file_mappings",
     params=[
         ("struct bfd *", "cbfd"),
-        ("read_core_file_mappings_pre_loop_ftype", "pre_loop_cb"),
         ("read_core_file_mappings_loop_ftype", "loop_cb"),
     ],
     predefault="default_read_core_file_mappings",

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -2855,7 +2855,6 @@ Read core file mappings
     name="read_core_file_mappings",
     params=[
         ("struct bfd *", "cbfd"),
-        ("read_core_file_mappings_pre_loop_ftype", "pre_loop_cb"),
         ("read_core_file_mappings_loop_ftype", "loop_cb"),
     ],
     predefault="default_read_core_file_mappings",

--- a/gdb/gdbcore.h
+++ b/gdb/gdbcore.h
@@ -261,7 +261,9 @@ core_target_find_mapped_file (const char *filename,
 
 /* Type holding information about a single file mapped into the inferior
    at the point when the core file was created.  Associates a build-id
-   with the list of regions the file is mapped into.  */
+   with the list of regions the file is mapped into.  It is acceptable to
+   have a core_mapped_file with an empty filename, so long as we have a
+   build-id for the mapping.  */
 struct core_mapped_file
 {
   /* Type for a region of a file that was mapped into the inferior when
@@ -281,15 +283,22 @@ struct core_mapped_file
     /* The inferior address immediately after the mapped region.  */
     CORE_ADDR end;
 
-    /* The offset within the mapped file for this content.  */
+    /* The offset within the mapped file for this content.  If the
+       filename of the mapping is empty then this field will be 0, but has
+       no meaning.  */
     CORE_ADDR file_ofs;
   };
 
-  /* The filename as recorded in the core file.  */
+  /* The filename as recorded in the core file.  This can be empty meaning
+     that GDB was unable to find a filename for this mapping.  If the
+     filename is empty then the build_id field MUST be non-NULL.  If this
+     is empty then the region::file_ofs fields will all be 0, and have no
+     meaning.  */
   std::string filename;
 
   /* If not nullptr, then this is the build-id associated with this
-     file.  */
+     mapping.  If the filename field is empty, then this MUST be
+     non-NULL.  */
   const bfd_build_id *build_id = nullptr;
 
   /* All the mapped regions of this file.  */
@@ -297,6 +306,17 @@ struct core_mapped_file
 
   /* True if this is the main executable.  */
   bool is_main_exec = false;
+
+  /* Convert the REGIONS to a vector of mem_range objects.  */
+  std::vector<mem_range>
+  mem_ranges () const
+  {
+    std::vector<mem_range> ranges;
+    for (const core_mapped_file::region &region : this->regions)
+      ranges.emplace_back (region.start, region.end - region.start);
+    normalize_mem_ranges (&ranges);
+    return ranges;
+  }
 };
 
 extern std::vector<core_mapped_file> gdb_read_core_file_mappings

--- a/gdb/infrun.c
+++ b/gdb/infrun.c
@@ -366,6 +366,43 @@ update_signals_program_target (void)
   target_program_signals (signal_program);
 }
 
+/* See infrun.h.  */
+
+gdb_signal
+get_detach_signal (process_stratum_target *proc_target, ptid_t ptid)
+{
+  thread_info *tp = proc_target->find_thread (ptid);
+  gdb_signal signo = GDB_SIGNAL_0;
+
+  if (target_is_non_stop_p ()
+      && tp->internal_state () != THREAD_INT_RUNNING)
+    {
+      if (tp->has_pending_waitstatus ())
+	{
+	  /* If the thread has a pending event, and it was stopped
+	     with a signal, use that signal to resume it.  If it has a
+	     pending event of another kind, it was not stopped with a
+	     signal, so resume it without a signal.  */
+	  if (tp->pending_waitstatus ().kind () == TARGET_WAITKIND_STOPPED)
+	    signo = tp->pending_waitstatus ().sig ();
+	}
+      else
+	signo = tp->stop_signal ();
+    }
+  else if (!target_is_non_stop_p ())
+    {
+      ptid_t last_ptid;
+      process_stratum_target *last_target;
+
+      get_last_target_status (&last_target, &last_ptid, nullptr);
+
+      if (last_target == proc_target && ptid == last_ptid)
+	signo = tp->stop_signal ();
+    }
+
+  return signo;
+}
+
 /* Value to pass to target_resume() to cause all threads to resume.  */
 
 #define RESUME_ALL minus_one_ptid

--- a/gdb/infrun.c
+++ b/gdb/infrun.c
@@ -109,6 +109,8 @@ static bool step_over_info_valid_p (void);
 
 static bool schedlock_applies (struct thread_info *tp);
 
+static void handle_process_exited (struct execution_control_state *ecs);
+
 /* Asynchronous signal handler registered as event loop source for
    when we have pending events ready to be passed to the core.  */
 static struct async_event_handler *infrun_async_inferior_event_token;
@@ -4778,7 +4780,68 @@ fetch_inferior_event ()
 	       don't want to stop all the other threads.  */
 	    if (ecs.event_thread == nullptr
 		|| !ecs.event_thread->control.in_cond_eval)
-	      stop_all_threads_if_all_stop_mode ();
+	      {
+		stop_all_threads_if_all_stop_mode ();
+
+		/* Say the user does "next" over an exit(0) call, or
+		   out of main, either of which make the whole process
+		   exit.  If the target supports target_thread_events,
+		   then that is activated while "next" is in progress,
+		   and consequently we may be processing a thread-exit
+		   event (caused by the process exit) for a thread
+		   that reported its exit before the
+		   whole-process-exit event is reported for another
+		   thread (which is normally going to be the last
+		   event out of the inferior, but we don't know for
+		   which thread it will be).
+
+		   If we're in 'all-stop on top of non-stop' mode, and
+		   indeed the inferior process is exiting, then the
+		   stop_all_threads_if_all_stop_mode call above must
+		   have seen the process-exit event, as it will see
+		   one stop for each and every (running) thread of the
+		   process.  Look at the pending statuses of all
+		   threads, and see if we have a process-exit status.
+		   If so, prefer handling it now and report the
+		   inferior exit to the user instead of reporting the
+		   original thread exit.
+
+		   Do not do this if are handling any other kind of
+		   event, like e.g., a breakpoint hit, which the user
+		   may be interested in knowing was hit before the
+		   process exited.  If we ever have a "catch
+		   thread-exit" or something similar, we may want to
+		   skip this "prefer process-exit" if such a
+		   catchpoint is installed.  */
+		if (ecs.ws.kind () == TARGET_WAITKIND_THREAD_EXITED
+		    && !non_stop && exists_non_stop_target ())
+		  {
+		    for (thread_info &thread : inf->non_exited_threads ())
+		      {
+			if (thread.has_pending_waitstatus ()
+			    && ((thread.pending_waitstatus ().kind ()
+				 == TARGET_WAITKIND_EXITED)
+				|| (thread.pending_waitstatus ().kind ()
+				    == TARGET_WAITKIND_SIGNALLED)))
+			  {
+			    /* Found a pending process-exit event.
+			       Prefer handling and reporting it now
+			       over the thread-exit event.  */
+			    infrun_debug_printf
+			      ("found pending process-exit event, preferring it");
+			    ecs.ws = thread.pending_waitstatus ();
+			    thread.clear_pending_waitstatus ();
+			    ecs.event_thread = nullptr;
+			    ecs.ptid = thread.ptid;
+			    /* Re-record the last target status.  */
+			    set_last_target_status (ecs.target, ecs.ptid,
+						    ecs.ws);
+			    handle_process_exited (&ecs);
+			    break;
+			  }
+		      }
+		  }
+	      }
 
 	    clean_up_just_stopped_threads_fsms (&ecs);
 
@@ -6104,6 +6167,81 @@ handle_thread_exited (execution_control_state *ecs)
   return true;
 }
 
+/* Handle a process exit event.  */
+
+static void
+handle_process_exited (execution_control_state *ecs)
+{
+  /* Depending on the system, ecs->ptid may point to a thread or to a
+     process.  On some targets, target_mourn_inferior may need to have
+     access to the just-exited thread.  That is the case of
+     GNU/Linux's "checkpoint" support, for example.  Switch context
+     appropriately.  */
+  thread_info *thr = ecs->target->find_thread (ecs->ptid);
+  if (thr != nullptr)
+    switch_to_thread (thr);
+  else
+    {
+      inferior *inf = find_inferior_ptid (ecs->target, ecs->ptid);
+      switch_to_inferior_no_thread (inf);
+    }
+
+  handle_vfork_child_exec_or_exit (0);
+  target_terminal::ours ();	/* Must do this before mourn anyway.  */
+
+  /* Clearing any previous state of convenience variables.  */
+  clear_exit_convenience_vars ();
+
+  if (ecs->ws.kind () == TARGET_WAITKIND_EXITED)
+    {
+      /* Record the exit code in the convenience variable $_exitcode,
+	 so that the user can inspect this again later.  */
+      set_internalvar_integer (lookup_internalvar ("_exitcode"),
+			       (LONGEST) ecs->ws.exit_status ());
+
+      /* Also record this in the inferior itself.  */
+      current_inferior ()->has_exit_code = true;
+      current_inferior ()->exit_code = (LONGEST) ecs->ws.exit_status ();
+
+      /* Support the --return-child-result option.  */
+      return_child_result_value = ecs->ws.exit_status ();
+
+      interps_notify_exited (ecs->ws.exit_status ());
+    }
+  else
+    {
+      struct gdbarch *gdbarch = current_inferior ()->arch ();
+
+      if (gdbarch_gdb_signal_to_target_p (gdbarch))
+	{
+	  /* Set the value of the internal variable $_exitsignal,
+	     which holds the signal uncaught by the inferior.  */
+	  set_internalvar_integer (lookup_internalvar ("_exitsignal"),
+				   gdbarch_gdb_signal_to_target (gdbarch,
+								 ecs->ws.sig ()));
+	}
+      else
+	{
+	  /* We don't have access to the target's method used for
+	     converting between signal numbers (GDB's internal
+	     representation <-> target's representation).
+	     Therefore, we cannot do a good job at displaying this
+	     information to the user.  It's better to just warn
+	     her about it (if infrun debugging is enabled), and
+	     give up.  */
+	  infrun_debug_printf ("Cannot fill $_exitsignal with the correct "
+			       "signal number.");
+	}
+
+      interps_notify_signal_exited (ecs->ws.sig ());
+    }
+
+  gdb_flush (gdb_stdout);
+  target_mourn_inferior (inferior_ptid);
+  stop_print_frame = false;
+  stop_waiting (ecs);
+}
+
 /* Given an execution control state that has been freshly filled in by
    an event from the inferior, figure out what it means and take
    appropriate action.
@@ -6313,74 +6451,7 @@ handle_inferior_event (struct execution_control_state *ecs)
 
     case TARGET_WAITKIND_EXITED:
     case TARGET_WAITKIND_SIGNALLED:
-      {
-	/* Depending on the system, ecs->ptid may point to a thread or
-	   to a process.  On some targets, target_mourn_inferior may
-	   need to have access to the just-exited thread.  That is the
-	   case of GNU/Linux's "checkpoint" support, for example.
-	   Call the switch_to_xxx routine as appropriate.  */
-	thread_info *thr = ecs->target->find_thread (ecs->ptid);
-	if (thr != nullptr)
-	  switch_to_thread (thr);
-	else
-	  {
-	    inferior *inf = find_inferior_ptid (ecs->target, ecs->ptid);
-	    switch_to_inferior_no_thread (inf);
-	  }
-      }
-      handle_vfork_child_exec_or_exit (0);
-      target_terminal::ours ();	/* Must do this before mourn anyway.  */
-
-      /* Clearing any previous state of convenience variables.  */
-      clear_exit_convenience_vars ();
-
-      if (ecs->ws.kind () == TARGET_WAITKIND_EXITED)
-	{
-	  /* Record the exit code in the convenience variable $_exitcode, so
-	     that the user can inspect this again later.  */
-	  set_internalvar_integer (lookup_internalvar ("_exitcode"),
-				   (LONGEST) ecs->ws.exit_status ());
-
-	  /* Also record this in the inferior itself.  */
-	  current_inferior ()->has_exit_code = true;
-	  current_inferior ()->exit_code = (LONGEST) ecs->ws.exit_status ();
-
-	  /* Support the --return-child-result option.  */
-	  return_child_result_value = ecs->ws.exit_status ();
-
-	  interps_notify_exited (ecs->ws.exit_status ());
-	}
-      else
-	{
-	  struct gdbarch *gdbarch = current_inferior ()->arch ();
-
-	  if (gdbarch_gdb_signal_to_target_p (gdbarch))
-	    {
-	      /* Set the value of the internal variable $_exitsignal,
-		 which holds the signal uncaught by the inferior.  */
-	      set_internalvar_integer (lookup_internalvar ("_exitsignal"),
-				       gdbarch_gdb_signal_to_target (gdbarch,
-							  ecs->ws.sig ()));
-	    }
-	  else
-	    {
-	      /* We don't have access to the target's method used for
-		 converting between signal numbers (GDB's internal
-		 representation <-> target's representation).
-		 Therefore, we cannot do a good job at displaying this
-		 information to the user.  It's better to just warn
-		 her about it (if infrun debugging is enabled), and
-		 give up.  */
-	      infrun_debug_printf ("Cannot fill $_exitsignal with the correct "
-				   "signal number.");
-	    }
-
-	  interps_notify_signal_exited (ecs->ws.sig ());
-	}
-
-      gdb_flush (gdb_stdout);
-      target_mourn_inferior (inferior_ptid);
-      stop_print_frame = false;
+      handle_process_exited (ecs);
       stop_waiting (ecs);
       return;
 

--- a/gdb/infrun.c
+++ b/gdb/infrun.c
@@ -107,6 +107,8 @@ static bool step_over_info_valid_p (void);
 
 static bool schedlock_applies (struct thread_info *tp);
 
+static void handle_process_exited (struct execution_control_state *ecs);
+
 /* Asynchronous signal handler registered as event loop source for
    when we have pending events ready to be passed to the core.  */
 static struct async_event_handler *infrun_async_inferior_event_token;
@@ -381,6 +383,43 @@ void
 update_signals_program_target (void)
 {
   target_program_signals (signal_program);
+}
+
+/* See infrun.h.  */
+
+gdb_signal
+get_detach_signal (process_stratum_target *proc_target, ptid_t ptid)
+{
+  thread_info *tp = proc_target->find_thread (ptid);
+  gdb_signal signo = GDB_SIGNAL_0;
+
+  if (target_is_non_stop_p ()
+      && tp->internal_state () != THREAD_INT_RUNNING)
+    {
+      if (tp->has_pending_waitstatus ())
+	{
+	  /* If the thread has a pending event, and it was stopped
+	     with a signal, use that signal to resume it.  If it has a
+	     pending event of another kind, it was not stopped with a
+	     signal, so resume it without a signal.  */
+	  if (tp->pending_waitstatus ().kind () == TARGET_WAITKIND_STOPPED)
+	    signo = tp->pending_waitstatus ().sig ();
+	}
+      else
+	signo = tp->stop_signal ();
+    }
+  else if (!target_is_non_stop_p ())
+    {
+      ptid_t last_ptid;
+      process_stratum_target *last_target;
+
+      get_last_target_status (&last_target, &last_ptid, nullptr);
+
+      if (last_target == proc_target && ptid == last_ptid)
+	signo = tp->stop_signal ();
+    }
+
+  return signo;
 }
 
 /* Value to pass to target_resume() to cause all threads to resume.  */
@@ -4801,7 +4840,68 @@ fetch_inferior_event ()
 	       don't want to stop all the other threads.  */
 	    if (ecs.event_thread == nullptr
 		|| !ecs.event_thread->control.in_cond_eval)
-	      stop_all_threads_if_all_stop_mode ();
+	      {
+		stop_all_threads_if_all_stop_mode ();
+
+		/* Say the user does "next" over an exit(0) call, or
+		   out of main, either of which make the whole process
+		   exit.  If the target supports target_thread_events,
+		   then that is activated while "next" is in progress,
+		   and consequently we may be processing a thread-exit
+		   event (caused by the process exit) for a thread
+		   that reported its exit before the
+		   whole-process-exit event is reported for another
+		   thread (which is normally going to be the last
+		   event out of the inferior, but we don't know for
+		   which thread it will be).
+
+		   If we're in 'all-stop on top of non-stop' mode, and
+		   indeed the inferior process is exiting, then the
+		   stop_all_threads_if_all_stop_mode call above must
+		   have seen the process-exit event, as it will see
+		   one stop for each and every (running) thread of the
+		   process.  Look at the pending statuses of all
+		   threads, and see if we have a process-exit status.
+		   If so, prefer handling it now and report the
+		   inferior exit to the user instead of reporting the
+		   original thread exit.
+
+		   Do not do this if are handling any other kind of
+		   event, like e.g., a breakpoint hit, which the user
+		   may be interested in knowing was hit before the
+		   process exited.  If we ever have a "catch
+		   thread-exit" or something similar, we may want to
+		   skip this "prefer process-exit" if such a
+		   catchpoint is installed.  */
+		if (ecs.ws.kind () == TARGET_WAITKIND_THREAD_EXITED
+		    && !non_stop && exists_non_stop_target ())
+		  {
+		    for (thread_info &thread : inf->non_exited_threads ())
+		      {
+			if (thread.has_pending_waitstatus ()
+			    && ((thread.pending_waitstatus ().kind ()
+				 == TARGET_WAITKIND_EXITED)
+				|| (thread.pending_waitstatus ().kind ()
+				    == TARGET_WAITKIND_SIGNALLED)))
+			  {
+			    /* Found a pending process-exit event.
+			       Prefer handling and reporting it now
+			       over the thread-exit event.  */
+			    infrun_debug_printf
+			      ("found pending process-exit event, preferring it");
+			    ecs.ws = thread.pending_waitstatus ();
+			    thread.clear_pending_waitstatus ();
+			    ecs.event_thread = nullptr;
+			    ecs.ptid = thread.ptid;
+			    /* Re-record the last target status.  */
+			    set_last_target_status (ecs.target, ecs.ptid,
+						    ecs.ws);
+			    handle_process_exited (&ecs);
+			    break;
+			  }
+		      }
+		  }
+	      }
 
 	    clean_up_just_stopped_threads_fsms (&ecs);
 
@@ -6140,6 +6240,81 @@ handle_thread_exited (execution_control_state *ecs)
   return true;
 }
 
+/* Handle a process exit event.  */
+
+static void
+handle_process_exited (execution_control_state *ecs)
+{
+  /* Depending on the system, ecs->ptid may point to a thread or to a
+     process.  On some targets, target_mourn_inferior may need to have
+     access to the just-exited thread.  That is the case of
+     GNU/Linux's "checkpoint" support, for example.  Switch context
+     appropriately.  */
+  thread_info *thr = ecs->target->find_thread (ecs->ptid);
+  if (thr != nullptr)
+    switch_to_thread (thr);
+  else
+    {
+      inferior *inf = find_inferior_ptid (ecs->target, ecs->ptid);
+      switch_to_inferior_no_thread (inf);
+    }
+
+  handle_vfork_child_exec_or_exit (0);
+  target_terminal::ours ();	/* Must do this before mourn anyway.  */
+
+  /* Clearing any previous state of convenience variables.  */
+  clear_exit_convenience_vars ();
+
+  if (ecs->ws.kind () == TARGET_WAITKIND_EXITED)
+    {
+      /* Record the exit code in the convenience variable $_exitcode,
+	 so that the user can inspect this again later.  */
+      set_internalvar_integer (lookup_internalvar ("_exitcode"),
+			       (LONGEST) ecs->ws.exit_status ());
+
+      /* Also record this in the inferior itself.  */
+      current_inferior ()->has_exit_code = true;
+      current_inferior ()->exit_code = (LONGEST) ecs->ws.exit_status ();
+
+      /* Support the --return-child-result option.  */
+      return_child_result_value = ecs->ws.exit_status ();
+
+      interps_notify_exited (ecs->ws.exit_status ());
+    }
+  else
+    {
+      struct gdbarch *gdbarch = current_inferior ()->arch ();
+
+      if (gdbarch_gdb_signal_to_target_p (gdbarch))
+	{
+	  /* Set the value of the internal variable $_exitsignal,
+	     which holds the signal uncaught by the inferior.  */
+	  set_internalvar_integer (lookup_internalvar ("_exitsignal"),
+				   gdbarch_gdb_signal_to_target (gdbarch,
+								 ecs->ws.sig ()));
+	}
+      else
+	{
+	  /* We don't have access to the target's method used for
+	     converting between signal numbers (GDB's internal
+	     representation <-> target's representation).
+	     Therefore, we cannot do a good job at displaying this
+	     information to the user.  It's better to just warn
+	     her about it (if infrun debugging is enabled), and
+	     give up.  */
+	  infrun_debug_printf ("Cannot fill $_exitsignal with the correct "
+			       "signal number.");
+	}
+
+      interps_notify_signal_exited (ecs->ws.sig ());
+    }
+
+  gdb_flush (gdb_stdout);
+  target_mourn_inferior (inferior_ptid);
+  stop_print_frame = false;
+  stop_waiting (ecs);
+}
+
 /* Given an execution control state that has been freshly filled in by
    an event from the inferior, figure out what it means and take
    appropriate action.
@@ -6349,74 +6524,7 @@ handle_inferior_event (struct execution_control_state *ecs)
 
     case TARGET_WAITKIND_EXITED:
     case TARGET_WAITKIND_SIGNALLED:
-      {
-	/* Depending on the system, ecs->ptid may point to a thread or
-	   to a process.  On some targets, target_mourn_inferior may
-	   need to have access to the just-exited thread.  That is the
-	   case of GNU/Linux's "checkpoint" support, for example.
-	   Call the switch_to_xxx routine as appropriate.  */
-	thread_info *thr = ecs->target->find_thread (ecs->ptid);
-	if (thr != nullptr)
-	  switch_to_thread (thr);
-	else
-	  {
-	    inferior *inf = find_inferior_ptid (ecs->target, ecs->ptid);
-	    switch_to_inferior_no_thread (inf);
-	  }
-      }
-      handle_vfork_child_exec_or_exit (0);
-      target_terminal::ours ();	/* Must do this before mourn anyway.  */
-
-      /* Clearing any previous state of convenience variables.  */
-      clear_exit_convenience_vars ();
-
-      if (ecs->ws.kind () == TARGET_WAITKIND_EXITED)
-	{
-	  /* Record the exit code in the convenience variable $_exitcode, so
-	     that the user can inspect this again later.  */
-	  set_internalvar_integer (lookup_internalvar ("_exitcode"),
-				   (LONGEST) ecs->ws.exit_status ());
-
-	  /* Also record this in the inferior itself.  */
-	  current_inferior ()->has_exit_code = true;
-	  current_inferior ()->exit_code = (LONGEST) ecs->ws.exit_status ();
-
-	  /* Support the --return-child-result option.  */
-	  return_child_result_value = ecs->ws.exit_status ();
-
-	  interps_notify_exited (ecs->ws.exit_status ());
-	}
-      else
-	{
-	  struct gdbarch *gdbarch = current_inferior ()->arch ();
-
-	  if (gdbarch_gdb_signal_to_target_p (gdbarch))
-	    {
-	      /* Set the value of the internal variable $_exitsignal,
-		 which holds the signal uncaught by the inferior.  */
-	      set_internalvar_integer (lookup_internalvar ("_exitsignal"),
-				       gdbarch_gdb_signal_to_target (gdbarch,
-							  ecs->ws.sig ()));
-	    }
-	  else
-	    {
-	      /* We don't have access to the target's method used for
-		 converting between signal numbers (GDB's internal
-		 representation <-> target's representation).
-		 Therefore, we cannot do a good job at displaying this
-		 information to the user.  It's better to just warn
-		 her about it (if infrun debugging is enabled), and
-		 give up.  */
-	      infrun_debug_printf ("Cannot fill $_exitsignal with the correct "
-				   "signal number.");
-	    }
-
-	  interps_notify_signal_exited (ecs->ws.sig ());
-	}
-
-      gdb_flush (gdb_stdout);
-      target_mourn_inferior (inferior_ptid);
-      stop_print_frame = false;
+      handle_process_exited (ecs);
       stop_waiting (ecs);
       return;
 

--- a/gdb/infrun.h
+++ b/gdb/infrun.h
@@ -320,6 +320,12 @@ extern void all_uis_on_sync_execution_starting (void);
    detach.  */
 extern void restart_after_all_stop_detach (process_stratum_target *proc_target);
 
+/* While detaching, return the signal PTID was supposed to be resumed
+   with, if it were resumed, so we can pass it down to PTID while
+   detaching.  */
+extern gdb_signal get_detach_signal (process_stratum_target *proc_target,
+				     ptid_t ptid);
+
 /* RAII object to temporarily disable the requirement for target
    stacks to commit their resumed threads.
 

--- a/gdb/infrun.h
+++ b/gdb/infrun.h
@@ -333,6 +333,12 @@ extern void all_uis_on_sync_execution_starting (void);
    detach.  */
 extern void restart_after_all_stop_detach (process_stratum_target *proc_target);
 
+/* While detaching, return the signal PTID was supposed to be resumed
+   with, if it were resumed, so we can pass it down to PTID while
+   detaching.  */
+extern gdb_signal get_detach_signal (process_stratum_target *proc_target,
+				     ptid_t ptid);
+
 /* RAII object to temporarily disable the requirement for target
    stacks to commit their resumed threads.
 

--- a/gdb/linux-nat.c
+++ b/gdb/linux-nat.c
@@ -1320,13 +1320,13 @@ detach_one_pid (int pid, int signo)
 			    pid, strsignal (signo));
 }
 
-/* Get pending signal of THREAD as a host signal number, for detaching
+/* Get pending signal of LP as a host signal number, for detaching
    purposes.  This is the signal the thread last stopped for, which we
    need to deliver to the thread when detaching, otherwise, it'd be
    suppressed/lost.  */
 
 static int
-get_detach_signal (struct lwp_info *lp)
+get_lwp_detach_signal (struct lwp_info *lp)
 {
   enum gdb_signal signo = GDB_SIGNAL_0;
 
@@ -1356,38 +1356,7 @@ get_detach_signal (struct lwp_info *lp)
   else if (lp->status)
     signo = gdb_signal_from_host (WSTOPSIG (lp->status));
   else
-    {
-      thread_info *tp = linux_target->find_thread (lp->ptid);
-
-      if (target_is_non_stop_p ()
-	  && tp->internal_state () != THREAD_INT_RUNNING)
-	{
-	  if (tp->has_pending_waitstatus ())
-	    {
-	      /* If the thread has a pending event, and it was stopped with a
-		 signal, use that signal to resume it.  If it has a pending
-		 event of another kind, it was not stopped with a signal, so
-		 resume it without a signal.  */
-	      if (tp->pending_waitstatus ().kind () == TARGET_WAITKIND_STOPPED)
-		signo = tp->pending_waitstatus ().sig ();
-	      else
-		signo = GDB_SIGNAL_0;
-	    }
-	  else
-	    signo = tp->stop_signal ();
-	}
-      else if (!target_is_non_stop_p ())
-	{
-	  ptid_t last_ptid;
-	  process_stratum_target *last_target;
-
-	  get_last_target_status (&last_target, &last_ptid, nullptr);
-
-	  if (last_target == linux_target
-	      && lp->ptid.lwp () == last_ptid.lwp ())
-	    signo = tp->stop_signal ();
-	}
-    }
+    signo = get_detach_signal (linux_target, lp->ptid);
 
   if (signo == GDB_SIGNAL_0)
     {
@@ -1517,7 +1486,7 @@ detach_one_lwp (struct lwp_info *lp, int *signo_p)
   if (signo_p == NULL)
     {
       /* Pass on any pending signal for this LWP.  */
-      signo = get_detach_signal (lp);
+      signo = get_lwp_detach_signal (lp);
     }
   else
     signo = *signo_p;
@@ -1604,7 +1573,7 @@ linux_nat_target::detach (inferior *inf, int from_tty)
       if (main_lwp != nullptr)
 	{
 	  /* Pass on any pending signal for the last LWP.  */
-	  int signo = get_detach_signal (main_lwp);
+	  int signo = get_lwp_detach_signal (main_lwp);
 
 	  detach_one_lwp (main_lwp, &signo);
 	}

--- a/gdb/linux-tdep.c
+++ b/gdb/linux-tdep.c
@@ -1091,6 +1091,33 @@ linux_info_proc (struct gdbarch *gdbarch, const char *args,
     }
 }
 
+/* Return a map from the start address of any LOAD segment in CBFD to the
+   associated build-id.  The map only contains entries for those segments
+   where a build-id is found, so the build-id will never be NULL, but not
+   every segment will have an entry in the map.  */
+
+static gdb::unordered_map<CORE_ADDR, const bfd_build_id *>
+linux_read_build_ids_from_core_file_mappings (struct bfd *cbfd)
+{
+  gdb::unordered_map<CORE_ADDR, const bfd_build_id *> vma_to_build_id_map;
+
+  auto restore_cbfd_build_id = make_scoped_restore (&cbfd->build_id);
+
+  /* Search for solib build-ids in the core file.  Each time one is found,
+     map the start vma of the corresponding elf header to the build-id.  */
+  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
+    {
+      cbfd->build_id = nullptr;
+
+      if (sec->flags & SEC_LOAD
+	  && (get_elf_backend_data (cbfd)->elf_backend_core_find_build_id
+	      (cbfd, (bfd_vma) sec->filepos)))
+	vma_to_build_id_map[sec->vma] = cbfd->build_id;
+    }
+
+  return vma_to_build_id_map;
+}
+
 /* Implementation of `gdbarch_read_core_file_mappings', as defined in
    gdbarch.h.
 
@@ -1107,103 +1134,39 @@ linux_info_proc (struct gdbarch *gdbarch, const char *args,
 	long file_ofs
       followed by COUNT filenames in ASCII: "FILE1" NUL "FILE2" NUL...
 
+   In addition to reading the NT_FILE note, this function also considers
+   all of the LOADable segments (which BFD turns into sections).  If a
+   segment is loadable, has a build-id, and isn't covered by an NT_FILE
+   entry, then we consider it an anonymous mapping.  Tracking these is
+   useful when we load shared libraries.  If a shared library corresponds
+   to an anonymous mapping then we can validate the build-id of the shared
+   library.  This is useful when core files are created without an NT_FILE
+   note.
+
    CBFD is the BFD of the core file.
 
    LOOP_CB is the callback function that will be executed once
    for each mapping.  */
 
 static void
-linux_read_core_file_mappings
-  (struct gdbarch *gdbarch,
-   struct bfd *cbfd,
-   read_core_file_mappings_loop_ftype  loop_cb)
+linux_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
+			       read_core_file_mappings_loop_ftype  loop_cb)
 {
   /* Ensure that ULONGEST is big enough for reading 64-bit core files.  */
   static_assert (sizeof (ULONGEST) >= 8);
 
-  /* It's not required that the NT_FILE note exists, so return silently
-     if it's not found.  Beyond this point though, we'll complain
-     if problems are found.  */
-  asection *section = bfd_get_section_by_name (cbfd, ".note.linuxcore.file");
-  if (section == nullptr)
-    return;
+  /* Map from the start address of LOAD segments to the associated
+     build-id, but only for segments that have a build-id.  */
+  gdb::unordered_map<CORE_ADDR, const bfd_build_id *> vma_map
+    = linux_read_build_ids_from_core_file_mappings (cbfd);
 
-  unsigned int addr_size_bits = gdbarch_addr_bit (gdbarch);
-  unsigned int addr_size = addr_size_bits / 8;
-  size_t note_size = bfd_section_size (section);
+  /* Track the start address of each mapping found.  This allows us to
+     quickly drop duplicates when processing the NT_FILE note then the LOAD
+     segments.  */
+  gdb::unordered_set<CORE_ADDR> mapping_start_addresses;
 
-  if (note_size < 2 * addr_size)
-    {
-      warning (_("malformed core note - too short for header"));
-      return;
-    }
-
-  gdb::byte_vector contents (note_size);
-  if (!bfd_get_section_contents (cbfd, section, contents.data (), 0,
-				 note_size))
-    {
-      warning (_("could not get core note contents"));
-      return;
-    }
-
-  gdb_byte *descdata = contents.data ();
-  char *descend = (char *) descdata + note_size;
-
-  if (descdata[note_size - 1] != '\0')
-    {
-      warning (_("malformed note - does not end with \\0"));
-      return;
-    }
-
-  ULONGEST count = bfd_get (addr_size_bits, cbfd, descdata);
-  descdata += addr_size;
-
-  ULONGEST page_size = bfd_get (addr_size_bits, cbfd, descdata);
-  descdata += addr_size;
-
-  if (note_size < 2 * addr_size + count * 3 * addr_size)
-    {
-      warning (_("malformed note - too short for supplied file count"));
-      return;
-    }
-
-  char *filenames = (char *) descdata + count * 3 * addr_size;
-
-  /* Make sure that the correct number of filenames exist.  Complain
-     if there aren't enough or are too many.  */
-  char *f = filenames;
-  for (int i = 0; i < count; i++)
-    {
-      if (f >= descend)
-	{
-	  warning (_("malformed note - filename area is too small"));
-	  return;
-	}
-      f += strnlen (f, descend - f) + 1;
-    }
-  /* Complain, but don't return early if the filename area is too big.  */
-  if (f != descend)
-    warning (_("malformed note - filename area is too big"));
-
-  const bfd_build_id *orig_build_id = cbfd->build_id;
-  gdb::unordered_map<ULONGEST, const bfd_build_id *> vma_map;
-
-  /* Search for solib build-ids in the core file.  Each time one is found,
-     map the start vma of the corresponding elf header to the build-id.  */
-  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
-    {
-      cbfd->build_id = nullptr;
-
-      if (sec->flags & SEC_LOAD
-	  && (get_elf_backend_data (cbfd)->elf_backend_core_find_build_id
-	       (cbfd, (bfd_vma) sec->filepos)))
-	vma_map[sec->vma] = cbfd->build_id;
-    }
-
-  cbfd->build_id = orig_build_id;
-
-  /* Vector to collect proc mappings.  */
-  struct proc_mapping
+  /* Vector to collect all mappings.  */
+  struct a_mapping
   {
     ULONGEST start;
     ULONGEST end;
@@ -1211,38 +1174,165 @@ linux_read_core_file_mappings
     const char *filename;
     const bfd_build_id *build_id;
   };
-  std::vector<struct proc_mapping> proc_mappings;
+  std::vector<struct a_mapping> all_mappings;
 
-  /* Collect proc mappings.  */
-  for (int i = 0; i < count; i++)
+  /* If we find the NT_FILE section in the lambda below then we need
+     to load its contents, and those contents need to remain live
+     until the end of this function.  This vector will hold the
+     contents.  */
+  gdb::byte_vector contents;
+
+  /* Read mapping from the NT_FILE note if it exists.  It is not
+     required that this note exist so wrap the parsing within a lambda
+     function, this allows us to return if the note doesn't exist, or
+     is malformed.
+
+     After parsing the NT_FILE note we will also parse the segment
+     table to fill in any additional mappings that the NT_FILE didn't
+     cover, e.g. if NT_FILE was missing or unreadable.  */
+  auto read_mappings_from_nt_file_note = [&] ()
     {
-      struct proc_mapping m;
-      m.start = bfd_get (addr_size_bits, cbfd, descdata);
-      descdata += addr_size;
-      m.end = bfd_get (addr_size_bits, cbfd, descdata);
-      descdata += addr_size;
-      m.file_ofs = bfd_get (addr_size_bits, cbfd, descdata) * page_size;
-      descdata += addr_size;
-      m.filename = filenames;
-      filenames += strlen ((char *) filenames) + 1;
+      asection *section = bfd_get_section_by_name (cbfd, ".note.linuxcore.file");
+      if (section == nullptr)
+	return;
 
-      m.build_id = nullptr;
-      auto vma_map_it = vma_map.find (m.start);
+      unsigned int addr_size_bits = gdbarch_addr_bit (gdbarch);
+      unsigned int addr_size = addr_size_bits / 8;
+      size_t note_size = bfd_section_size (section);
+
+      if (note_size < 2 * addr_size)
+	{
+	  warning (_("malformed core note - too short for header"));
+	  return;
+	}
+
+      contents.resize (note_size);
+      if (!bfd_get_section_contents (cbfd, section, contents.data (), 0,
+				     note_size))
+	{
+	  warning (_("could not get core note contents"));
+	  return;
+	}
+
+      gdb_byte *descdata = contents.data ();
+      char *descend = (char *) descdata + note_size;
+
+      if (descdata[note_size - 1] != '\0')
+	{
+	  warning (_("malformed note - does not end with \\0"));
+	  return;
+	}
+
+      ULONGEST count = bfd_get (addr_size_bits, cbfd, descdata);
+      descdata += addr_size;
+
+      ULONGEST page_size = bfd_get (addr_size_bits, cbfd, descdata);
+      descdata += addr_size;
+
+      if (note_size < 2 * addr_size + count * 3 * addr_size)
+	{
+	  warning (_("malformed note - too short for supplied file count"));
+	  return;
+	}
+
+      char *filenames = (char *) descdata + count * 3 * addr_size;
+
+      /* Make sure that the correct number of filenames exist.  Complain
+	 if there aren't enough or are too many.  */
+      char *f = filenames;
+      for (int i = 0; i < count; i++)
+	{
+	  if (f >= descend)
+	    {
+	      warning (_("malformed note - filename area is too small"));
+	      return;
+	    }
+	  f += strnlen (f, descend - f) + 1;
+	}
+      /* Complain, but don't return early if the filename area is too big.  */
+      if (f != descend)
+	warning (_("malformed note - filename area is too big"));
+
+      /* Collect proc mappings.  */
+      for (int i = 0; i < count; i++)
+	{
+	  struct a_mapping m;
+	  m.start = bfd_get (addr_size_bits, cbfd, descdata);
+	  descdata += addr_size;
+	  m.end = bfd_get (addr_size_bits, cbfd, descdata);
+	  descdata += addr_size;
+	  m.file_ofs = bfd_get (addr_size_bits, cbfd, descdata) * page_size;
+	  descdata += addr_size;
+	  m.filename = filenames;
+	  filenames += strlen ((char *) filenames) + 1;
+
+	  m.build_id = nullptr;
+	  auto vma_map_it = vma_map.find (m.start);
+	  if (vma_map_it != vma_map.end ())
+	    m.build_id = vma_map_it->second;
+
+	  all_mappings.push_back (m);
+	  mapping_start_addresses.insert (m.start);
+	}
+    };
+  read_mappings_from_nt_file_note ();
+
+  /* Now look through the LOAD segments.  These have all been converted to
+     sections with the SEC_LOAD flag by BFD.  If we find a section that
+     contains a build-id, and which wasn't covered by an NT_FILE note, then
+     we create a mapping entry with no filename.  */
+  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
+    {
+      /* Skip non LOAD segments.  */
+      if ((sec->flags & SEC_LOAD) == 0)
+	continue;
+
+      CORE_ADDR start = bfd_section_vma (sec);
+
+      /* If there is already a mapping at this address (likely from the
+	 NT_FILE processing above) then skip this LOAD segment.  Currently
+	 this is assuming that the mapping from NT_FILE will be the same
+	 size as the LOAD segment, if this ever turns out not to be the
+	 case then we might need to be smarter here and figure out
+	 non-overlapping regions.  But that seems like unnecessary
+	 complexity for now.  */
+      auto mapping_start_addresses_it = mapping_start_addresses.find (start);
+      if (mapping_start_addresses_it != mapping_start_addresses.end ())
+	continue;
+
+      /* This LOAD segment is not covered by an NT_FILE entry, so we are
+	 not going to have a filename associated with the mapping.  Still,
+	 we might be able to find a build-id, and if we can, then tracking
+	 this mapping is still useful as, when we load shared libraries, if
+	 a library sits in this mapping we can validate the library's
+	 build-id.  If we cannot find a build-id for this mapping then
+	 there's no point tracking it, as it tells us nothing of value; no
+	 filename, no build-id.  */
+      const bfd_build_id *build_id = nullptr;
+      auto vma_map_it = vma_map.find (start);
       if (vma_map_it != vma_map.end ())
-	m.build_id = vma_map_it->second;
+	build_id = vma_map_it->second;
+      if (build_id == nullptr)
+	continue;
 
-      proc_mappings.push_back (m);
+      /* Create an anonymous mapping object, one without a filename.  */
+      CORE_ADDR end = start + bfd_section_size (sec);
+
+      struct a_mapping m { .start = start, .end = end,
+	.file_ofs = 0, .filename = nullptr, .build_id = build_id };
+      all_mappings.push_back (m);
+      mapping_start_addresses.insert (start);
     }
 
-  /* Sort proc mappings.  */
-  std::sort (proc_mappings.begin (), proc_mappings.end (),
-	     [] (const proc_mapping &a, const proc_mapping &b)
-	       {
-		 return a.start < b.start;
-	       });
+  /* Sort the mappings.  */
+  std::sort (all_mappings.begin (), all_mappings.end (),
+	     [] (const a_mapping &a, const a_mapping &b)
+	     {
+	       return a.start < b.start;
+	     });
 
-  /* Call loop_cb with sorted proc mappings.  */
-  for (const auto &m : proc_mappings)
+  /* Call loop_cb with sorted mappings.  */
+  for (const a_mapping &m : all_mappings)
     loop_cb (m.start, m.end, m.file_ofs, m.filename, m.build_id);
 }
 
@@ -1258,6 +1348,10 @@ linux_core_info_proc_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
     [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
+	/* Ignore anonymous mappings.  */
+	if (filename == nullptr)
+	  return;
+
 	if (!emitter.has_value ())
 	  {
 	    gdb_printf (_("Mapped address spaces:\n\n"));

--- a/gdb/linux-tdep.c
+++ b/gdb/linux-tdep.c
@@ -1109,11 +1109,6 @@ linux_info_proc (struct gdbarch *gdbarch, const char *args,
 
    CBFD is the BFD of the core file.
 
-   PRE_LOOP_CB is the callback function to invoke prior to starting
-   the loop which processes individual entries.  This callback will
-   only be executed after the note has been examined in enough
-   detail to verify that it's not malformed in some way.
-
    LOOP_CB is the callback function that will be executed once
    for each mapping.  */
 
@@ -1121,7 +1116,6 @@ static void
 linux_read_core_file_mappings
   (struct gdbarch *gdbarch,
    struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
    read_core_file_mappings_loop_ftype  loop_cb)
 {
   /* Ensure that ULONGEST is big enough for reading 64-bit core files.  */
@@ -1207,7 +1201,6 @@ linux_read_core_file_mappings
     }
 
   cbfd->build_id = orig_build_id;
-  pre_loop_cb (count);
 
   /* Vector to collect proc mappings.  */
   struct proc_mapping
@@ -1249,11 +1242,8 @@ linux_read_core_file_mappings
 	       });
 
   /* Call loop_cb with sorted proc mappings.  */
-  for (int i = 0; i < count; i++)
-    {
-      const auto &m = proc_mappings[i];
-      loop_cb (m.start, m.end, m.file_ofs, m.filename, m.build_id);
-    }
+  for (const auto &m : proc_mappings)
+    loop_cb (m.start, m.end, m.file_ofs, m.filename, m.build_id);
 }
 
 /* Implement "info proc mappings" for corefile CBFD.  */
@@ -1265,21 +1255,22 @@ linux_core_info_proc_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
   std::optional<ui_out_emit_table> emitter;
 
   linux_read_core_file_mappings (gdbarch, cbfd,
-    [&] (ULONGEST count)
-      {
-	gdb_printf (_("Mapped address spaces:\n\n"));
-	emitter.emplace (current_uiout, 5, -1, "ProcMappings");
-	int width = gdbarch_addr_bit (gdbarch) == 32 ? 10 : 18;
-	current_uiout->table_header (width, ui_left, "start", "Start Addr");
-	current_uiout->table_header (width, ui_left, "end", "End Addr");
-	current_uiout->table_header (width, ui_left, "size", "Size");
-	current_uiout->table_header (width, ui_left, "offset", "Offset");
-	current_uiout->table_header (0, ui_left, "objfile", "File");
-	current_uiout->table_body ();
-      },
-    [=] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
+    [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
+	if (!emitter.has_value ())
+	  {
+	    gdb_printf (_("Mapped address spaces:\n\n"));
+	    emitter.emplace (current_uiout, 5, -1, "ProcMappings");
+	    int width = gdbarch_addr_bit (gdbarch) == 32 ? 10 : 18;
+	    current_uiout->table_header (width, ui_left, "start", "Start Addr");
+	    current_uiout->table_header (width, ui_left, "end", "End Addr");
+	    current_uiout->table_header (width, ui_left, "size", "Size");
+	    current_uiout->table_header (width, ui_left, "offset", "Offset");
+	    current_uiout->table_header (0, ui_left, "objfile", "File");
+	    current_uiout->table_body ();
+	  }
+
 	ui_out_emit_tuple tuple_emitter (current_uiout, nullptr);
 	current_uiout->field_core_addr ("start", gdbarch, start);
 	current_uiout->field_core_addr ("end", gdbarch, end);

--- a/gdb/linux-tdep.c
+++ b/gdb/linux-tdep.c
@@ -1212,7 +1212,6 @@ linux_read_core_file_mappings
   /* Vector to collect proc mappings.  */
   struct proc_mapping
   {
-    int num;
     ULONGEST start;
     ULONGEST end;
     ULONGEST file_ofs;
@@ -1224,7 +1223,7 @@ linux_read_core_file_mappings
   /* Collect proc mappings.  */
   for (int i = 0; i < count; i++)
     {
-      struct proc_mapping m = { .num = i };
+      struct proc_mapping m;
       m.start = bfd_get (addr_size_bits, cbfd, descdata);
       descdata += addr_size;
       m.end = bfd_get (addr_size_bits, cbfd, descdata);
@@ -1253,7 +1252,7 @@ linux_read_core_file_mappings
   for (int i = 0; i < count; i++)
     {
       const auto &m = proc_mappings[i];
-      loop_cb (m.num, m.start, m.end, m.file_ofs, m.filename, m.build_id);
+      loop_cb (m.start, m.end, m.file_ofs, m.filename, m.build_id);
     }
 }
 
@@ -1278,7 +1277,7 @@ linux_core_info_proc_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
 	current_uiout->table_header (0, ui_left, "objfile", "File");
 	current_uiout->table_body ();
       },
-    [=] (int num, ULONGEST start, ULONGEST end, ULONGEST file_ofs,
+    [=] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
 	ui_out_emit_tuple tuple_emitter (current_uiout, nullptr);

--- a/gdb/linux-tdep.c
+++ b/gdb/linux-tdep.c
@@ -1091,6 +1091,33 @@ linux_info_proc (struct gdbarch *gdbarch, const char *args,
     }
 }
 
+/* Return a map from the start address of any LOAD segment in CBFD to the
+   associated build-id.  The map only contains entries for those segments
+   where a build-id is found, so the build-id will never be NULL, but not
+   every segment will have an entry in the map.  */
+
+static gdb::unordered_map<CORE_ADDR, const bfd_build_id *>
+linux_read_build_ids_from_core_file_mappings (struct bfd *cbfd)
+{
+  gdb::unordered_map<CORE_ADDR, const bfd_build_id *> vma_to_build_id_map;
+
+  auto restore_cbfd_build_id = make_scoped_restore (&cbfd->build_id);
+
+  /* Search for solib build-ids in the core file.  Each time one is found,
+     map the start vma of the corresponding elf header to the build-id.  */
+  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
+    {
+      cbfd->build_id = nullptr;
+
+      if (sec->flags & SEC_LOAD
+	  && (get_elf_backend_data (cbfd)->elf_backend_core_find_build_id
+	      (cbfd, (bfd_vma) sec->filepos)))
+	vma_to_build_id_map[sec->vma] = cbfd->build_id;
+    }
+
+  return vma_to_build_id_map;
+}
+
 /* Implementation of `gdbarch_read_core_file_mappings', as defined in
    gdbarch.h.
 
@@ -1107,154 +1134,206 @@ linux_info_proc (struct gdbarch *gdbarch, const char *args,
 	long file_ofs
       followed by COUNT filenames in ASCII: "FILE1" NUL "FILE2" NUL...
 
-   CBFD is the BFD of the core file.
+   In addition to reading the NT_FILE note, this function also considers
+   all of the LOADable segments (which BFD turns into sections).  If a
+   segment is loadable, has a build-id, and isn't covered by an NT_FILE
+   entry, then we consider it an anonymous mapping.  Tracking these is
+   useful when we load shared libraries.  If a shared library corresponds
+   to an anonymous mapping then we can validate the build-id of the shared
+   library.  This is useful when core files are created without an NT_FILE
+   note.
 
-   PRE_LOOP_CB is the callback function to invoke prior to starting
-   the loop which processes individual entries.  This callback will
-   only be executed after the note has been examined in enough
-   detail to verify that it's not malformed in some way.
+   CBFD is the BFD of the core file.
 
    LOOP_CB is the callback function that will be executed once
    for each mapping.  */
 
 static void
-linux_read_core_file_mappings
-  (struct gdbarch *gdbarch,
-   struct bfd *cbfd,
-   read_core_file_mappings_pre_loop_ftype pre_loop_cb,
-   read_core_file_mappings_loop_ftype  loop_cb)
+linux_read_core_file_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
+			       read_core_file_mappings_loop_ftype  loop_cb)
 {
   /* Ensure that ULONGEST is big enough for reading 64-bit core files.  */
   static_assert (sizeof (ULONGEST) >= 8);
 
-  /* It's not required that the NT_FILE note exists, so return silently
-     if it's not found.  Beyond this point though, we'll complain
-     if problems are found.  */
-  asection *section = bfd_get_section_by_name (cbfd, ".note.linuxcore.file");
-  if (section == nullptr)
-    return;
+  /* Map from the start address of LOAD segments to the associated
+     build-id, but only for segments that have a build-id.  */
+  gdb::unordered_map<CORE_ADDR, const bfd_build_id *> vma_map
+    = linux_read_build_ids_from_core_file_mappings (cbfd);
 
-  unsigned int addr_size_bits = gdbarch_addr_bit (gdbarch);
-  unsigned int addr_size = addr_size_bits / 8;
-  size_t note_size = bfd_section_size (section);
+  /* Track the start address of each mapping found.  This allows us to
+     quickly drop duplicates when processing the NT_FILE note then the LOAD
+     segments.  */
+  gdb::unordered_set<CORE_ADDR> mapping_start_addresses;
 
-  if (note_size < 2 * addr_size)
-    {
-      warning (_("malformed core note - too short for header"));
-      return;
-    }
-
-  gdb::byte_vector contents (note_size);
-  if (!bfd_get_section_contents (cbfd, section, contents.data (), 0,
-				 note_size))
-    {
-      warning (_("could not get core note contents"));
-      return;
-    }
-
-  gdb_byte *descdata = contents.data ();
-  char *descend = (char *) descdata + note_size;
-
-  if (descdata[note_size - 1] != '\0')
-    {
-      warning (_("malformed note - does not end with \\0"));
-      return;
-    }
-
-  ULONGEST count = bfd_get (addr_size_bits, cbfd, descdata);
-  descdata += addr_size;
-
-  ULONGEST page_size = bfd_get (addr_size_bits, cbfd, descdata);
-  descdata += addr_size;
-
-  if (note_size < 2 * addr_size + count * 3 * addr_size)
-    {
-      warning (_("malformed note - too short for supplied file count"));
-      return;
-    }
-
-  char *filenames = (char *) descdata + count * 3 * addr_size;
-
-  /* Make sure that the correct number of filenames exist.  Complain
-     if there aren't enough or are too many.  */
-  char *f = filenames;
-  for (int i = 0; i < count; i++)
-    {
-      if (f >= descend)
-	{
-	  warning (_("malformed note - filename area is too small"));
-	  return;
-	}
-      f += strnlen (f, descend - f) + 1;
-    }
-  /* Complain, but don't return early if the filename area is too big.  */
-  if (f != descend)
-    warning (_("malformed note - filename area is too big"));
-
-  const bfd_build_id *orig_build_id = cbfd->build_id;
-  gdb::unordered_map<ULONGEST, const bfd_build_id *> vma_map;
-
-  /* Search for solib build-ids in the core file.  Each time one is found,
-     map the start vma of the corresponding elf header to the build-id.  */
-  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
-    {
-      cbfd->build_id = nullptr;
-
-      if (sec->flags & SEC_LOAD
-	  && (get_elf_backend_data (cbfd)->elf_backend_core_find_build_id
-	       (cbfd, (bfd_vma) sec->filepos)))
-	vma_map[sec->vma] = cbfd->build_id;
-    }
-
-  cbfd->build_id = orig_build_id;
-  pre_loop_cb (count);
-
-  /* Vector to collect proc mappings.  */
-  struct proc_mapping
+  /* Vector to collect all mappings.  */
+  struct a_mapping
   {
-    int num;
     ULONGEST start;
     ULONGEST end;
     ULONGEST file_ofs;
     const char *filename;
     const bfd_build_id *build_id;
   };
-  std::vector<struct proc_mapping> proc_mappings;
+  std::vector<struct a_mapping> all_mappings;
 
-  /* Collect proc mappings.  */
-  for (int i = 0; i < count; i++)
+  /* If we find the NT_FILE section in the lambda below then we need
+     to load its contents, and those contents need to remain live
+     until the end of this function.  This vector will hold the
+     contents.  */
+  gdb::byte_vector contents;
+
+  /* Read mapping from the NT_FILE note if it exists.  It is not
+     required that this note exist so wrap the parsing within a lambda
+     function, this allows us to return if the note doesn't exist, or
+     is malformed.
+
+     After parsing the NT_FILE note we will also parse the segment
+     table to fill in any additional mappings that the NT_FILE didn't
+     cover, e.g. if NT_FILE was missing or unreadable.  */
+  auto read_mappings_from_nt_file_note = [&] ()
     {
-      struct proc_mapping m = { .num = i };
-      m.start = bfd_get (addr_size_bits, cbfd, descdata);
-      descdata += addr_size;
-      m.end = bfd_get (addr_size_bits, cbfd, descdata);
-      descdata += addr_size;
-      m.file_ofs = bfd_get (addr_size_bits, cbfd, descdata) * page_size;
-      descdata += addr_size;
-      m.filename = filenames;
-      filenames += strlen ((char *) filenames) + 1;
+      asection *section = bfd_get_section_by_name (cbfd, ".note.linuxcore.file");
+      if (section == nullptr)
+	return;
 
-      m.build_id = nullptr;
-      auto vma_map_it = vma_map.find (m.start);
+      unsigned int addr_size_bits = gdbarch_addr_bit (gdbarch);
+      unsigned int addr_size = addr_size_bits / 8;
+      size_t note_size = bfd_section_size (section);
+
+      if (note_size < 2 * addr_size)
+	{
+	  warning (_("malformed core note - too short for header"));
+	  return;
+	}
+
+      contents.resize (note_size);
+      if (!bfd_get_section_contents (cbfd, section, contents.data (), 0,
+				     note_size))
+	{
+	  warning (_("could not get core note contents"));
+	  return;
+	}
+
+      gdb_byte *descdata = contents.data ();
+      char *descend = (char *) descdata + note_size;
+
+      if (descdata[note_size - 1] != '\0')
+	{
+	  warning (_("malformed note - does not end with \\0"));
+	  return;
+	}
+
+      ULONGEST count = bfd_get (addr_size_bits, cbfd, descdata);
+      descdata += addr_size;
+
+      ULONGEST page_size = bfd_get (addr_size_bits, cbfd, descdata);
+      descdata += addr_size;
+
+      if (note_size < 2 * addr_size + count * 3 * addr_size)
+	{
+	  warning (_("malformed note - too short for supplied file count"));
+	  return;
+	}
+
+      char *filenames = (char *) descdata + count * 3 * addr_size;
+
+      /* Make sure that the correct number of filenames exist.  Complain
+	 if there aren't enough or are too many.  */
+      char *f = filenames;
+      for (int i = 0; i < count; i++)
+	{
+	  if (f >= descend)
+	    {
+	      warning (_("malformed note - filename area is too small"));
+	      return;
+	    }
+	  f += strnlen (f, descend - f) + 1;
+	}
+      /* Complain, but don't return early if the filename area is too big.  */
+      if (f != descend)
+	warning (_("malformed note - filename area is too big"));
+
+      /* Collect proc mappings.  */
+      for (int i = 0; i < count; i++)
+	{
+	  struct a_mapping m;
+	  m.start = bfd_get (addr_size_bits, cbfd, descdata);
+	  descdata += addr_size;
+	  m.end = bfd_get (addr_size_bits, cbfd, descdata);
+	  descdata += addr_size;
+	  m.file_ofs = bfd_get (addr_size_bits, cbfd, descdata) * page_size;
+	  descdata += addr_size;
+	  m.filename = filenames;
+	  filenames += strlen ((char *) filenames) + 1;
+
+	  m.build_id = nullptr;
+	  auto vma_map_it = vma_map.find (m.start);
+	  if (vma_map_it != vma_map.end ())
+	    m.build_id = vma_map_it->second;
+
+	  all_mappings.push_back (m);
+	  mapping_start_addresses.insert (m.start);
+	}
+    };
+  read_mappings_from_nt_file_note ();
+
+  /* Now look through the LOAD segments.  These have all been converted to
+     sections with the SEC_LOAD flag by BFD.  If we find a section that
+     contains a build-id, and which wasn't covered by an NT_FILE note, then
+     we create a mapping entry with no filename.  */
+  for (bfd_section *sec = cbfd->sections; sec != nullptr; sec = sec->next)
+    {
+      /* Skip non LOAD segments.  */
+      if ((sec->flags & SEC_LOAD) == 0)
+	continue;
+
+      CORE_ADDR start = bfd_section_vma (sec);
+
+      /* If there is already a mapping at this address (likely from the
+	 NT_FILE processing above) then skip this LOAD segment.  Currently
+	 this is assuming that the mapping from NT_FILE will be the same
+	 size as the LOAD segment, if this ever turns out not to be the
+	 case then we might need to be smarter here and figure out
+	 non-overlapping regions.  But that seems like unnecessary
+	 complexity for now.  */
+      auto mapping_start_addresses_it = mapping_start_addresses.find (start);
+      if (mapping_start_addresses_it != mapping_start_addresses.end ())
+	continue;
+
+      /* This LOAD segment is not covered by an NT_FILE entry, so we are
+	 not going to have a filename associated with the mapping.  Still,
+	 we might be able to find a build-id, and if we can, then tracking
+	 this mapping is still useful as, when we load shared libraries, if
+	 a library sits in this mapping we can validate the library's
+	 build-id.  If we cannot find a build-id for this mapping then
+	 there's no point tracking it, as it tells us nothing of value; no
+	 filename, no build-id.  */
+      const bfd_build_id *build_id = nullptr;
+      auto vma_map_it = vma_map.find (start);
       if (vma_map_it != vma_map.end ())
-	m.build_id = vma_map_it->second;
+	build_id = vma_map_it->second;
+      if (build_id == nullptr)
+	continue;
 
-      proc_mappings.push_back (m);
+      /* Create an anonymous mapping object, one without a filename.  */
+      CORE_ADDR end = start + bfd_section_size (sec);
+
+      struct a_mapping m { .start = start, .end = end,
+	.file_ofs = 0, .filename = nullptr, .build_id = build_id };
+      all_mappings.push_back (m);
+      mapping_start_addresses.insert (start);
     }
 
-  /* Sort proc mappings.  */
-  std::sort (proc_mappings.begin (), proc_mappings.end (),
-	     [] (const proc_mapping &a, const proc_mapping &b)
-	       {
-		 return a.start < b.start;
-	       });
+  /* Sort the mappings.  */
+  std::sort (all_mappings.begin (), all_mappings.end (),
+	     [] (const a_mapping &a, const a_mapping &b)
+	     {
+	       return a.start < b.start;
+	     });
 
-  /* Call loop_cb with sorted proc mappings.  */
-  for (int i = 0; i < count; i++)
-    {
-      const auto &m = proc_mappings[i];
-      loop_cb (m.num, m.start, m.end, m.file_ofs, m.filename, m.build_id);
-    }
+  /* Call loop_cb with sorted mappings.  */
+  for (const a_mapping &m : all_mappings)
+    loop_cb (m.start, m.end, m.file_ofs, m.filename, m.build_id);
 }
 
 /* Implement "info proc mappings" for corefile CBFD.  */
@@ -1266,21 +1345,26 @@ linux_core_info_proc_mappings (struct gdbarch *gdbarch, struct bfd *cbfd,
   std::optional<ui_out_emit_table> emitter;
 
   linux_read_core_file_mappings (gdbarch, cbfd,
-    [&] (ULONGEST count)
-      {
-	gdb_printf (_("Mapped address spaces:\n\n"));
-	emitter.emplace (current_uiout, 5, -1, "ProcMappings");
-	int width = gdbarch_addr_bit (gdbarch) == 32 ? 10 : 18;
-	current_uiout->table_header (width, ui_left, "start", "Start Addr");
-	current_uiout->table_header (width, ui_left, "end", "End Addr");
-	current_uiout->table_header (width, ui_left, "size", "Size");
-	current_uiout->table_header (width, ui_left, "offset", "Offset");
-	current_uiout->table_header (0, ui_left, "objfile", "File");
-	current_uiout->table_body ();
-      },
-    [=] (int num, ULONGEST start, ULONGEST end, ULONGEST file_ofs,
+    [&] (ULONGEST start, ULONGEST end, ULONGEST file_ofs,
 	 const char *filename, const bfd_build_id *build_id)
       {
+	/* Ignore anonymous mappings.  */
+	if (filename == nullptr)
+	  return;
+
+	if (!emitter.has_value ())
+	  {
+	    gdb_printf (_("Mapped address spaces:\n\n"));
+	    emitter.emplace (current_uiout, 5, -1, "ProcMappings");
+	    int width = gdbarch_addr_bit (gdbarch) == 32 ? 10 : 18;
+	    current_uiout->table_header (width, ui_left, "start", "Start Addr");
+	    current_uiout->table_header (width, ui_left, "end", "End Addr");
+	    current_uiout->table_header (width, ui_left, "size", "Size");
+	    current_uiout->table_header (width, ui_left, "offset", "Offset");
+	    current_uiout->table_header (0, ui_left, "objfile", "File");
+	    current_uiout->table_body ();
+	  }
+
 	ui_out_emit_tuple tuple_emitter (current_uiout, nullptr);
 	current_uiout->field_core_addr ("start", gdbarch, start);
 	current_uiout->field_core_addr ("end", gdbarch, end);

--- a/gdb/mi/mi-cmd-stack.c
+++ b/gdb/mi/mi-cmd-stack.c
@@ -633,34 +633,25 @@ list_args_or_locals (const frame_print_options &fp_opts,
 	    }
 	  if (print_me)
 	    {
-	      struct symbol *sym2;
 	      struct frame_arg arg, entryarg;
 
-	      if (sym->is_argument ())
-		sym2 = (lookup_symbol_search_name
-			(sym->search_name (),
-			 block, SEARCH_VAR_DOMAIN).symbol);
-	      else
-		sym2 = sym;
-	      gdb_assert (sym2 != NULL);
-
-	      arg.sym = sym2;
+	      arg.sym = sym;
 	      arg.entry_kind = print_entry_values_no;
-	      entryarg.sym = sym2;
+	      entryarg.sym = sym;
 	      entryarg.entry_kind = print_entry_values_no;
 
 	      switch (values)
 		{
 		case PRINT_SIMPLE_VALUES:
-		  if (!mi_simple_type_p (sym2->type ()))
+		  if (!mi_simple_type_p (sym->type ()))
 		    break;
 		  [[fallthrough]];
 
 		case PRINT_ALL_VALUES:
 		  if (sym->is_argument ())
-		    read_frame_arg (fp_opts, sym2, fi, &arg, &entryarg);
+		    read_frame_arg (fp_opts, sym, fi, &arg, &entryarg);
 		  else
-		    read_frame_local (sym2, fi, &arg);
+		    read_frame_local (sym, fi, &arg);
 		  break;
 		}
 

--- a/gdb/nat/windows-nat.c
+++ b/gdb/nat/windows-nat.c
@@ -694,6 +694,31 @@ windows_process_info::add_all_dlls ()
 
 /* See nat/windows-nat.h.  */
 
+std::string
+event_code_to_string (DWORD event_code)
+{
+#define CASE(X) \
+  case X: return #X
+
+  switch (event_code)
+    {
+    CASE (CREATE_THREAD_DEBUG_EVENT);
+    CASE (EXIT_THREAD_DEBUG_EVENT);
+    CASE (CREATE_PROCESS_DEBUG_EVENT);
+    CASE (EXIT_PROCESS_DEBUG_EVENT);
+    CASE (LOAD_DLL_DEBUG_EVENT);
+    CASE (UNLOAD_DLL_DEBUG_EVENT);
+    CASE (EXCEPTION_DEBUG_EVENT);
+    CASE (OUTPUT_DEBUG_STRING_EVENT);
+    default:
+      return string_printf ("unknown event code %u", (unsigned) event_code);
+    }
+
+#undef CASE
+}
+
+/* See nat/windows-nat.h.  */
+
 ptid_t
 get_last_debug_event_ptid ()
 {

--- a/gdb/nat/windows-nat.c
+++ b/gdb/nat/windows-nat.c
@@ -728,17 +728,20 @@ get_last_debug_event_ptid ()
 /* See nat/windows-nat.h.  */
 
 BOOL
-continue_last_debug_event (DWORD continue_status, bool debug_events)
+continue_last_debug_event (DWORD cont_status, bool debug_events)
 {
-  DEBUG_EVENTS ("ContinueDebugEvent (cpid=%d, ctid=0x%x, %s)",
-		(unsigned) last_wait_event.dwProcessId,
-		(unsigned) last_wait_event.dwThreadId,
-		continue_status == DBG_CONTINUE ?
-		"DBG_CONTINUE" : "DBG_EXCEPTION_NOT_HANDLED");
+  DEBUG_EVENTS
+    ("ContinueDebugEvent (cpid=%d, ctid=0x%x, %s)",
+     (unsigned) last_wait_event.dwProcessId,
+     (unsigned) last_wait_event.dwThreadId,
+     cont_status == DBG_CONTINUE ? "DBG_CONTINUE" :
+     cont_status == DBG_EXCEPTION_NOT_HANDLED ? "DBG_EXCEPTION_NOT_HANDLED" :
+     cont_status == DBG_REPLY_LATER ? "DBG_REPLY_LATER" :
+     "DBG_???");
 
   return ContinueDebugEvent (last_wait_event.dwProcessId,
 			     last_wait_event.dwThreadId,
-			     continue_status);
+			     cont_status);
 }
 
 /* See nat/windows-nat.h.  */

--- a/gdb/nat/windows-nat.c
+++ b/gdb/nat/windows-nat.c
@@ -918,6 +918,26 @@ disable_randomization_available ()
 /* See windows-nat.h.  */
 
 bool
+dbg_reply_later_available ()
+{
+  static int available = -1;
+  if (available == -1)
+    {
+      /* DBG_REPLY_LATER is supported since Windows 10, Version 1507.
+	 If supported, this fails with ERROR_INVALID_HANDLE (tested on
+	 Win10 and Win11).  If not supported, it fails with
+	 ERROR_INVALID_PARAMETER (tested on Win7).  */
+      if (ContinueDebugEvent (0, 0, DBG_REPLY_LATER))
+	internal_error (_("ContinueDebugEvent call should not "
+			  "have succeeded"));
+      available = (GetLastError () != ERROR_INVALID_PARAMETER);
+    }
+  return available;
+}
+
+/* See windows-nat.h.  */
+
+bool
 initialize_loadable ()
 {
   bool result = true;

--- a/gdb/nat/windows-nat.c
+++ b/gdb/nat/windows-nat.c
@@ -694,6 +694,31 @@ windows_process_info::add_all_dlls ()
 
 /* See nat/windows-nat.h.  */
 
+std::string
+event_code_to_string (DWORD event_code)
+{
+#define CASE(X) \
+  case X: return #X
+
+  switch (event_code)
+    {
+    CASE (CREATE_THREAD_DEBUG_EVENT);
+    CASE (EXIT_THREAD_DEBUG_EVENT);
+    CASE (CREATE_PROCESS_DEBUG_EVENT);
+    CASE (EXIT_PROCESS_DEBUG_EVENT);
+    CASE (LOAD_DLL_DEBUG_EVENT);
+    CASE (UNLOAD_DLL_DEBUG_EVENT);
+    CASE (EXCEPTION_DEBUG_EVENT);
+    CASE (OUTPUT_DEBUG_STRING_EVENT);
+    default:
+      return string_printf ("unknown event code %u", (unsigned) event_code);
+    }
+
+#undef CASE
+}
+
+/* See nat/windows-nat.h.  */
+
 ptid_t
 get_last_debug_event_ptid ()
 {
@@ -703,17 +728,20 @@ get_last_debug_event_ptid ()
 /* See nat/windows-nat.h.  */
 
 BOOL
-continue_last_debug_event (DWORD continue_status, bool debug_events)
+continue_last_debug_event (DWORD cont_status, bool debug_events)
 {
-  DEBUG_EVENTS ("ContinueDebugEvent (cpid=%d, ctid=0x%x, %s)",
-		(unsigned) last_wait_event.dwProcessId,
-		(unsigned) last_wait_event.dwThreadId,
-		continue_status == DBG_CONTINUE ?
-		"DBG_CONTINUE" : "DBG_EXCEPTION_NOT_HANDLED");
+  DEBUG_EVENTS
+    ("ContinueDebugEvent (cpid=%d, ctid=0x%x, %s)",
+     (unsigned) last_wait_event.dwProcessId,
+     (unsigned) last_wait_event.dwThreadId,
+     cont_status == DBG_CONTINUE ? "DBG_CONTINUE" :
+     cont_status == DBG_EXCEPTION_NOT_HANDLED ? "DBG_EXCEPTION_NOT_HANDLED" :
+     cont_status == DBG_REPLY_LATER ? "DBG_REPLY_LATER" :
+     "DBG_???");
 
   return ContinueDebugEvent (last_wait_event.dwProcessId,
 			     last_wait_event.dwThreadId,
-			     continue_status);
+			     cont_status);
 }
 
 /* See nat/windows-nat.h.  */
@@ -913,6 +941,26 @@ disable_randomization_available ()
   return (InitializeProcThreadAttributeList != nullptr
 	  && UpdateProcThreadAttribute != nullptr
 	  && DeleteProcThreadAttributeList != nullptr);
+}
+
+/* See windows-nat.h.  */
+
+bool
+dbg_reply_later_available ()
+{
+  static int available = -1;
+  if (available == -1)
+    {
+      /* DBG_REPLY_LATER is supported since Windows 10, Version 1507.
+	 If supported, this fails with ERROR_INVALID_HANDLE (tested on
+	 Win10 and Win11).  If not supported, it fails with
+	 ERROR_INVALID_PARAMETER (tested on Win7).  */
+      if (ContinueDebugEvent (0, 0, DBG_REPLY_LATER))
+	internal_error (_("ContinueDebugEvent call should not "
+			  "have succeeded"));
+      available = (GetLastError () != ERROR_INVALID_PARAMETER);
+    }
+  return available;
 }
 
 /* See windows-nat.h.  */

--- a/gdb/nat/windows-nat.h
+++ b/gdb/nat/windows-nat.h
@@ -40,6 +40,24 @@ namespace windows_nat
 
 struct windows_process_info;
 
+/* The reason for explicitly stopping a thread.  Note the enumerators
+   are ordered such that when comparing two stopping_kind's numerical
+   value, the highest should prevail.  */
+enum stopping_kind
+  {
+    /* Not really stopping the thread.  */
+    SK_NOT_STOPPING = 0,
+
+    /* We're stopping the thread for internal reasons, the stop should
+       not be reported as an event to the core.  */
+    SK_INTERNAL = 1,
+
+    /* We're stopping the thread for external reasons, meaning, the
+       core/user asked us to stop the thread, so we must report a stop
+       event to the core.  */
+    SK_EXTERNAL = 2,
+  };
+
 /* Thread information structure used to track extra information about
    each thread.  */
 struct windows_thread_info
@@ -123,9 +141,10 @@ struct windows_thread_info
   int suspended = 0;
 
   /* This flag indicates whether we are explicitly stopping this
-     thread in response to a target_stop request.  This allows
-     distinguishing between threads that are explicitly stopped by the
-     debugger and threads that are stopped due to other reasons.
+     thread in response to a target_stop request or for
+     backend-internal reasons.  This allows distinguishing between
+     threads that are explicitly stopped by the debugger and threads
+     that are stopped due to other reasons.
 
      Typically, when we want to stop a thread, we suspend it, enqueue
      a pending GDB_SIGNAL_0 stop status on the thread, and then set
@@ -134,7 +153,7 @@ struct windows_thread_info
      already has an event to report.  In such case, we simply set the
      'stopping' flag without suspending the thread or enqueueing a
      pending stop.  See stop_one_thread.  */
-  bool stopping = false;
+  stopping_kind stopping = SK_NOT_STOPPING;
 
 /* Info about a potential pending stop.
 

--- a/gdb/nat/windows-nat.h
+++ b/gdb/nat/windows-nat.h
@@ -535,6 +535,15 @@ enum_process_modules (WOW64_CONTEXT *, HANDLE process,
 }
 #endif
 
+/* This is available starting with Windows 10.  */
+#ifndef DBG_REPLY_LATER
+# define DBG_REPLY_LATER 0x40010001L
+#endif
+
+/* Return true if it's possible to use DBG_REPLY_LATER with
+   ContinueDebugEvent on this host.  */
+extern bool dbg_reply_later_available ();
+
 /* Load any functions which may not be available in ancient versions
    of Windows.  */
 

--- a/gdb/nat/windows-nat.h
+++ b/gdb/nat/windows-nat.h
@@ -87,11 +87,54 @@ struct windows_thread_info
   /* Thread Information Block address.  */
   CORE_ADDR thread_local_base;
 
+#ifdef __CYGWIN__
+  /* These two fields are used to handle Cygwin signals.  When a
+     thread is signaled, the "sig" thread inside the Cygwin runtime
+     reports the fact to us via a special OutputDebugString message.
+     In order to make stepping into a signal handler work, we can only
+     resume the "sig" thread when we also resume the target signaled
+     thread.  When we intercept a Cygwin signal, we set up a cross
+     link between the two threads using the two fields below, so we
+     can always identify one from the other.  See the "Cygwin signals"
+     description in gdb/windows-nat.c for more.  */
+
+  /* If this thread received a signal, then 'cygwin_sig_thread' points
+     to the "sig" thread within the Cygwin runtime.  */
+  windows_thread_info *cygwin_sig_thread = nullptr;
+
+  /* If this thread is the Cygwin runtime's "sig" thread, then
+     'signaled_thread' points at the thread that received a
+     signal.  */
+  windows_thread_info *signaled_thread = nullptr;
+#endif
+
+  /* If the thread had its event postponed with DBG_REPLY_LATER, when
+     we later ResumeThread this thread, WaitForDebugEvent will
+     re-report the postponed event.  This field holds the continue
+     status value to be automatically passed to ContinueDebugEvent
+     when we encounter this re-reported event.  0 if the thread has
+     not had its event postponed with DBG_REPLY_LATER. */
+  DWORD reply_later = 0;
+
   /* This keeps track of whether SuspendThread was called on this
      thread.  -1 means there was a failure or that the thread was
      explicitly not suspended, 1 means it was called, and 0 means it
      was not.  */
   int suspended = 0;
+
+  /* This flag indicates whether we are explicitly stopping this
+     thread in response to a target_stop request.  This allows
+     distinguishing between threads that are explicitly stopped by the
+     debugger and threads that are stopped due to other reasons.
+
+     Typically, when we want to stop a thread, we suspend it, enqueue
+     a pending GDB_SIGNAL_0 stop status on the thread, and then set
+     this flag to true.  However, if the thread has had its event
+     previously postponed with DBG_REPLY_LATER, it means that it
+     already has an event to report.  In such case, we simply set the
+     'stopping' flag without suspending the thread or enqueueing a
+     pending stop.  See stop_one_thread.  */
+  bool stopping = false;
 
 /* Info about a potential pending stop.
 
@@ -181,15 +224,15 @@ struct windows_process_info
   virtual void fill_thread_context (windows_thread_info *th) = 0;
 
   /* Handle OUTPUT_DEBUG_STRING_EVENT from child process.  Updates
-     OURSTATUS and returns the thread id if this represents a thread
-     change (this is specific to Cygwin), otherwise 0.
+     OURSTATUS and returns true if this represents a Cygwin signal,
+     otherwise false.
 
      Cygwin prepends its messages with a "cygwin:".  Interpret this as
      a Cygwin signal.  Otherwise just print the string as a warning.
 
      This function must be supplied by the embedding application.  */
-  virtual DWORD handle_output_debug_string (const DEBUG_EVENT &current_event,
-					    struct target_waitstatus *ourstatus) = 0;
+  virtual bool handle_output_debug_string (const DEBUG_EVENT &current_event,
+					   struct target_waitstatus *ourstatus) = 0;
 
   /* Handle a DLL load event.
 

--- a/gdb/nat/windows-nat.h
+++ b/gdb/nat/windows-nat.h
@@ -285,6 +285,10 @@ private:
   int get_exec_module_filename (char *exe_name_ret, size_t exe_name_max_len);
 };
 
+/* Return a string version of EVENT_CODE.  */
+
+extern std::string event_code_to_string (DWORD event_code);
+
 /* A simple wrapper for ContinueDebugEvent that continues the last
    waited-for event.  If DEBUG_EVENTS is true, logging will be
    enabled.  */

--- a/gdb/nat/windows-nat.h
+++ b/gdb/nat/windows-nat.h
@@ -40,6 +40,24 @@ namespace windows_nat
 
 struct windows_process_info;
 
+/* The reason for explicitly stopping a thread.  Note the enumerators
+   are ordered such that when comparing two stopping_kind's numerical
+   value, the highest should prevail.  */
+enum stopping_kind
+  {
+    /* Not really stopping the thread.  */
+    SK_NOT_STOPPING = 0,
+
+    /* We're stopping the thread for internal reasons, the stop should
+       not be reported as an event to the core.  */
+    SK_INTERNAL = 1,
+
+    /* We're stopping the thread for external reasons, meaning, the
+       core/user asked us to stop the thread, so we must report a stop
+       event to the core.  */
+    SK_EXTERNAL = 2,
+  };
+
 /* Thread information structure used to track extra information about
    each thread.  */
 struct windows_thread_info
@@ -87,11 +105,55 @@ struct windows_thread_info
   /* Thread Information Block address.  */
   CORE_ADDR thread_local_base;
 
+#ifdef __CYGWIN__
+  /* These two fields are used to handle Cygwin signals.  When a
+     thread is signaled, the "sig" thread inside the Cygwin runtime
+     reports the fact to us via a special OutputDebugString message.
+     In order to make stepping into a signal handler work, we can only
+     resume the "sig" thread when we also resume the target signaled
+     thread.  When we intercept a Cygwin signal, we set up a cross
+     link between the two threads using the two fields below, so we
+     can always identify one from the other.  See the "Cygwin signals"
+     description in gdb/windows-nat.c for more.  */
+
+  /* If this thread received a signal, then 'cygwin_sig_thread' points
+     to the "sig" thread within the Cygwin runtime.  */
+  windows_thread_info *cygwin_sig_thread = nullptr;
+
+  /* If this thread is the Cygwin runtime's "sig" thread, then
+     'signaled_thread' points at the thread that received a
+     signal.  */
+  windows_thread_info *signaled_thread = nullptr;
+#endif
+
+  /* If the thread had its event postponed with DBG_REPLY_LATER, when
+     we later ResumeThread this thread, WaitForDebugEvent will
+     re-report the postponed event.  This field holds the continue
+     status value to be automatically passed to ContinueDebugEvent
+     when we encounter this re-reported event.  0 if the thread has
+     not had its event postponed with DBG_REPLY_LATER. */
+  DWORD reply_later = 0;
+
   /* This keeps track of whether SuspendThread was called on this
      thread.  -1 means there was a failure or that the thread was
      explicitly not suspended, 1 means it was called, and 0 means it
      was not.  */
   int suspended = 0;
+
+  /* This flag indicates whether we are explicitly stopping this
+     thread in response to a target_stop request or for
+     backend-internal reasons.  This allows distinguishing between
+     threads that are explicitly stopped by the debugger and threads
+     that are stopped due to other reasons.
+
+     Typically, when we want to stop a thread, we suspend it, enqueue
+     a pending GDB_SIGNAL_0 stop status on the thread, and then set
+     this flag to true.  However, if the thread has had its event
+     previously postponed with DBG_REPLY_LATER, it means that it
+     already has an event to report.  In such case, we simply set the
+     'stopping' flag without suspending the thread or enqueueing a
+     pending stop.  See stop_one_thread.  */
+  stopping_kind stopping = SK_NOT_STOPPING;
 
 /* Info about a potential pending stop.
 
@@ -181,15 +243,15 @@ struct windows_process_info
   virtual void fill_thread_context (windows_thread_info *th) = 0;
 
   /* Handle OUTPUT_DEBUG_STRING_EVENT from child process.  Updates
-     OURSTATUS and returns the thread id if this represents a thread
-     change (this is specific to Cygwin), otherwise 0.
+     OURSTATUS and returns true if this represents a Cygwin signal,
+     otherwise false.
 
      Cygwin prepends its messages with a "cygwin:".  Interpret this as
      a Cygwin signal.  Otherwise just print the string as a warning.
 
      This function must be supplied by the embedding application.  */
-  virtual DWORD handle_output_debug_string (const DEBUG_EVENT &current_event,
-					    struct target_waitstatus *ourstatus) = 0;
+  virtual bool handle_output_debug_string (const DEBUG_EVENT &current_event,
+					   struct target_waitstatus *ourstatus) = 0;
 
   /* Handle a DLL load event.
 
@@ -284,6 +346,10 @@ private:
 
   int get_exec_module_filename (char *exe_name_ret, size_t exe_name_max_len);
 };
+
+/* Return a string version of EVENT_CODE.  */
+
+extern std::string event_code_to_string (DWORD event_code);
 
 /* A simple wrapper for ContinueDebugEvent that continues the last
    waited-for event.  If DEBUG_EVENTS is true, logging will be
@@ -534,6 +600,15 @@ enum_process_modules (WOW64_CONTEXT *, HANDLE process,
 			       LIST_MODULES_32BIT);
 }
 #endif
+
+/* This is available starting with Windows 10.  */
+#ifndef DBG_REPLY_LATER
+# define DBG_REPLY_LATER 0x40010001L
+#endif
+
+/* Return true if it's possible to use DBG_REPLY_LATER with
+   ContinueDebugEvent on this host.  */
+extern bool dbg_reply_later_available ();
 
 /* Load any functions which may not be available in ancient versions
    of Windows.  */

--- a/gdb/stack.c
+++ b/gdb/stack.c
@@ -801,70 +801,6 @@ print_frame_args (const frame_print_options &fp_opts,
 	      break;
 	    }
 
-	  /* We have to look up the symbol because arguments can have
-	     two entries (one a parameter, one a local) and the one we
-	     want is the local, which lookup_symbol will find for us.
-	     This includes gcc1 (not gcc2) on SPARC when passing a
-	     small structure and gcc2 when the argument type is float
-	     and it is passed as a double and converted to float by
-	     the prologue (in the latter case the type of the LOC_ARG
-	     symbol is double and the type of the LOC_LOCAL symbol is
-	     float).  */
-	  /* But if the parameter name is null, don't try it.  Null
-	     parameter names occur on the RS/6000, for traceback
-	     tables.  FIXME, should we even print them?  */
-
-	  if (*sym->linkage_name ())
-	    {
-	      struct symbol *nsym;
-
-	      nsym = lookup_symbol_search_name (sym->search_name (),
-						b, SEARCH_VAR_DOMAIN).symbol;
-	      gdb_assert (nsym != NULL);
-	      if (nsym->loc_class () == LOC_REGISTER
-		  && !nsym->is_argument ())
-		{
-		  /* There is a LOC_ARG/LOC_REGISTER pair.  This means
-		     that it was passed on the stack and loaded into a
-		     register, or passed in a register and stored in a
-		     stack slot.  GDB 3.x used the LOC_ARG; GDB
-		     4.0-4.11 used the LOC_REGISTER.
-
-		     Reasons for using the LOC_ARG:
-
-		     (1) Because find_saved_registers may be slow for
-			 remote debugging.
-
-		     (2) Because registers are often reused and stack
-			 slots rarely (never?) are.  Therefore using
-			 the stack slot is much less likely to print
-			 garbage.
-
-		     Reasons why we might want to use the LOC_REGISTER:
-
-		     (1) So that the backtrace prints the same value
-			 as "print foo".  I see no compelling reason
-			 why this needs to be the case; having the
-			 backtrace print the value which was passed
-			 in, and "print foo" print the value as
-			 modified within the called function, makes
-			 perfect sense to me.
-
-		     Additional note: It might be nice if "info args"
-		     displayed both values.
-
-		     One more note: There is a case with SPARC
-		     structure passing where we need to use the
-		     LOC_REGISTER, but this is dealt with by creating
-		     a single LOC_REGPARM in symbol reading.  */
-
-		  /* Leave sym (the LOC_ARG) alone.  */
-		  ;
-		}
-	      else
-		sym = nsym;
-	    }
-
 	  /* Print the current arg.  */
 	  if (!first)
 	    uiout->text (", ");
@@ -2446,23 +2382,7 @@ iterate_over_block_arg_vars (const struct block *b,
     {
       /* Don't worry about things which aren't arguments.  */
       if (sym->is_argument ())
-	{
-	  /* We have to look up the symbol because arguments can have
-	     two entries (one a parameter, one a local) and the one we
-	     want is the local, which lookup_symbol will find for us.
-	     This includes gcc1 (not gcc2) on the sparc when passing a
-	     small structure and gcc2 when the argument type is float
-	     and it is passed as a double and converted to float by
-	     the prologue (in the latter case the type of the LOC_ARG
-	     symbol is double and the type of the LOC_LOCAL symbol is
-	     float).  There are also LOC_ARG/LOC_REGISTER pairs which
-	     are not combined in symbol-reading.  */
-
-	  struct symbol *sym2
-	    = lookup_symbol_search_name (sym->search_name (),
-					 b, SEARCH_VAR_DOMAIN).symbol;
-	  cb (sym->print_name (), sym2);
-	}
+	cb (sym->print_name (), sym);
     }
 }
 

--- a/gdb/stack.c
+++ b/gdb/stack.c
@@ -802,70 +802,6 @@ print_frame_args (const frame_print_options &fp_opts,
 	      break;
 	    }
 
-	  /* We have to look up the symbol because arguments can have
-	     two entries (one a parameter, one a local) and the one we
-	     want is the local, which lookup_symbol will find for us.
-	     This includes gcc1 (not gcc2) on SPARC when passing a
-	     small structure and gcc2 when the argument type is float
-	     and it is passed as a double and converted to float by
-	     the prologue (in the latter case the type of the LOC_ARG
-	     symbol is double and the type of the LOC_LOCAL symbol is
-	     float).  */
-	  /* But if the parameter name is null, don't try it.  Null
-	     parameter names occur on the RS/6000, for traceback
-	     tables.  FIXME, should we even print them?  */
-
-	  if (*sym->linkage_name ())
-	    {
-	      struct symbol *nsym;
-
-	      nsym = lookup_symbol_search_name (sym->search_name (),
-						b, SEARCH_VAR_DOMAIN).symbol;
-	      gdb_assert (nsym != NULL);
-	      if (nsym->loc_class () == LOC_REGISTER
-		  && !nsym->is_argument ())
-		{
-		  /* There is a LOC_ARG/LOC_REGISTER pair.  This means
-		     that it was passed on the stack and loaded into a
-		     register, or passed in a register and stored in a
-		     stack slot.  GDB 3.x used the LOC_ARG; GDB
-		     4.0-4.11 used the LOC_REGISTER.
-
-		     Reasons for using the LOC_ARG:
-
-		     (1) Because find_saved_registers may be slow for
-			 remote debugging.
-
-		     (2) Because registers are often reused and stack
-			 slots rarely (never?) are.  Therefore using
-			 the stack slot is much less likely to print
-			 garbage.
-
-		     Reasons why we might want to use the LOC_REGISTER:
-
-		     (1) So that the backtrace prints the same value
-			 as "print foo".  I see no compelling reason
-			 why this needs to be the case; having the
-			 backtrace print the value which was passed
-			 in, and "print foo" print the value as
-			 modified within the called function, makes
-			 perfect sense to me.
-
-		     Additional note: It might be nice if "info args"
-		     displayed both values.
-
-		     One more note: There is a case with SPARC
-		     structure passing where we need to use the
-		     LOC_REGISTER, but this is dealt with by creating
-		     a single LOC_REGPARM in symbol reading.  */
-
-		  /* Leave sym (the LOC_ARG) alone.  */
-		  ;
-		}
-	      else
-		sym = nsym;
-	    }
-
 	  /* Print the current arg.  */
 	  if (!first)
 	    uiout->text (", ");
@@ -2454,23 +2390,7 @@ iterate_over_block_arg_vars (const struct block *b,
     {
       /* Don't worry about things which aren't arguments.  */
       if (sym->is_argument ())
-	{
-	  /* We have to look up the symbol because arguments can have
-	     two entries (one a parameter, one a local) and the one we
-	     want is the local, which lookup_symbol will find for us.
-	     This includes gcc1 (not gcc2) on the sparc when passing a
-	     small structure and gcc2 when the argument type is float
-	     and it is passed as a double and converted to float by
-	     the prologue (in the latter case the type of the LOC_ARG
-	     symbol is double and the type of the LOC_LOCAL symbol is
-	     float).  There are also LOC_ARG/LOC_REGISTER pairs which
-	     are not combined in symbol-reading.  */
-
-	  struct symbol *sym2
-	    = lookup_symbol_search_name (sym->search_name (),
-					 b, SEARCH_VAR_DOMAIN).symbol;
-	  cb (sym->print_name (), sym2);
-	}
+	cb (sym->print_name (), sym);
     }
 }
 

--- a/gdb/symtab.c
+++ b/gdb/symtab.c
@@ -5440,8 +5440,13 @@ rbreak_command (const char *regexp, int from_tty)
 	}
     }
 
+  /* Compute this property now.  We want to use the property after
+     std::move (file_name), but at that point we can no longer compute it
+     because the std::move nullifies file_name.  */
+  bool file_name_p = file_name != nullptr;
+
   global_symbol_searcher spec (SEARCH_FUNCTION_DOMAIN, regexp);
-  if (file_name != nullptr)
+  if (file_name_p)
     spec.add_filename (std::move (file_name));
   std::vector<symbol_search> symbols = spec.search ();
 
@@ -5454,7 +5459,7 @@ rbreak_command (const char *regexp, int from_tty)
       std::string name;
       if (p.msymbol.minsym == nullptr)
 	{
-	  if (file_name != nullptr)
+	  if (file_name_p)
 	    {
 	      struct symtab *symtab = p.symbol->symtab ();
 	      const char *fullname = symtab_to_fullname (symtab);

--- a/gdb/symtab.c
+++ b/gdb/symtab.c
@@ -5441,8 +5441,13 @@ rbreak_command (const char *regexp, int from_tty)
 	}
     }
 
+  /* Compute this property now.  We want to use the property after
+     std::move (file_name), but at that point we can no longer compute it
+     because the std::move nullifies file_name.  */
+  bool file_name_p = file_name != nullptr;
+
   global_symbol_searcher spec (SEARCH_FUNCTION_DOMAIN, regexp);
-  if (file_name != nullptr)
+  if (file_name_p)
     spec.add_filename (std::move (file_name));
   std::vector<symbol_search> symbols = spec.search ();
 
@@ -5455,7 +5460,7 @@ rbreak_command (const char *regexp, int from_tty)
       std::string name;
       if (p.msymbol.minsym == nullptr)
 	{
-	  if (file_name != nullptr)
+	  if (file_name_p)
 	    {
 	      struct symtab *symtab = p.symbol->symtab ();
 	      const char *fullname = symtab_to_fullname (symtab);

--- a/gdb/symtab.h
+++ b/gdb/symtab.h
@@ -1154,12 +1154,11 @@ struct symbol_computed_ops
 
 struct symbol_block_ops
 {
-  /* Fill in *START and *LENGTH with DWARF block data of function
-     FRAMEFUNC valid for inferior context address PC.  Set *LENGTH to
-     zero if such location is not valid for PC; *START is left
-     uninitialized in such case.  */
-  void (*find_frame_base_location) (struct symbol *framefunc, CORE_ADDR pc,
-				    const gdb_byte **start, size_t *length);
+  /* Return the DWARF block data of function FRAMEFUNC valid for inferior
+     context address PC.  Return an empty view if no such location is
+     valid for PC.  */
+  gdb::array_view<const gdb_byte> (*find_frame_base_location)
+    (struct symbol *framefunc, CORE_ADDR pc);
 
   /* Return the frame base address.  FRAME is the frame for which we want to
      compute the base address while FRAMEFUNC is the symbol for the

--- a/gdb/symtab.h
+++ b/gdb/symtab.h
@@ -1148,12 +1148,11 @@ struct symbol_computed_ops
 
 struct symbol_block_ops
 {
-  /* Fill in *START and *LENGTH with DWARF block data of function
-     FRAMEFUNC valid for inferior context address PC.  Set *LENGTH to
-     zero if such location is not valid for PC; *START is left
-     uninitialized in such case.  */
-  void (*find_frame_base_location) (struct symbol *framefunc, CORE_ADDR pc,
-				    const gdb_byte **start, size_t *length);
+  /* Return the DWARF block data of function FRAMEFUNC valid for inferior
+     context address PC.  Return an empty view if no such location is
+     valid for PC.  */
+  gdb::array_view<const gdb_byte> (*find_frame_base_location)
+    (struct symbol *framefunc, CORE_ADDR pc);
 
   /* Return the frame base address.  FRAME is the frame for which we want to
      compute the base address while FRAMEFUNC is the symbol for the

--- a/gdb/target/waitstatus.h
+++ b/gdb/target/waitstatus.h
@@ -105,7 +105,9 @@ enum target_waitkind
   /* The thread was created.  */
   TARGET_WAITKIND_THREAD_CREATED,
 
-  /* The thread has exited.  The exit status is in value.integer.  */
+  /* The thread has exited.  The exit status is in value.integer.  The
+     thread should still exist in the thread list when infrun receives
+     this event.  */
   TARGET_WAITKIND_THREAD_EXITED,
 };
 

--- a/gdb/testsuite/gdb.ada/aliased_array/foo.adb
+++ b/gdb/testsuite/gdb.ada/aliased_array/foo.adb
@@ -16,6 +16,10 @@
 with Pck; use Pck;
 procedure Foo is
    BT : aliased Bounded := New_Bounded (Low => 1, High => 3);
+   BT_First : Integer := BT'First;
+   BT_Last : Integer := BT'Last;
 begin
    Do_Nothing (BT'Address); -- STOP
+   Do_Nothing (BT_First'Address);
+   Do_Nothing (BT_Last'Address);
 end Foo;

--- a/gdb/testsuite/gdb.ada/enum_idx_packed/foo.adb
+++ b/gdb/testsuite/gdb.ada/enum_idx_packed/foo.adb
@@ -30,12 +30,39 @@ procedure Foo is
                                             Green => (5, 6, 7),
                                             others => (others => 72));
 
+   --  These variables ensure the bounds aren't elided by LLVM.
+   Small_First : Color := Small'First;
+   Small_Last : Color := Small'Last;
+   Multi_First1 : Color := Multi'First (1);
+   Multi_Last1 : Color := Multi'Last (1);
+   Multi_First2 : Strength := Multi'First (2);
+   Multi_Last2 : Strength := Multi'Last (2);
+
+   MM_First1 : Positive := Multi_Multi'First (1);
+   MM_Last1 : Positive := Multi_Multi'Last (1);
+   MM_First2 : Positive := Multi_Multi'First (2);
+   MM_Last2 : Positive := Multi_Multi'Last (2);
+   MM_First3 : Positive := Multi_Multi'First (3);
+   MM_Last3 : Positive := Multi_Multi'Last (3);
+
 begin
    Do_Nothing (Full'Address);  -- STOP
    Do_Nothing (Primary'Address);
    Do_Nothing (Cold'Address);
    Do_Nothing (Small'Address);
+   Do_Nothing (Small_First'Address);
+   Do_Nothing (Small_Last'Address);
    Do_Nothing (Multi'Address);
+   Do_Nothing (Multi_First1'Address);
+   Do_Nothing (Multi_Last1'Address);
+   Do_Nothing (Multi_First2'Address);
+   Do_Nothing (Multi_Last2'Address);
    Do_Nothing (Multi_Multi'Address);
    Do_Nothing (Multi_Access'Address);
+   Do_Nothing (MM_First1'Address);
+   Do_Nothing (MM_Last1'Address);
+   Do_Nothing (MM_First2'Address);
+   Do_Nothing (MM_Last2'Address);
+   Do_Nothing (MM_First3'Address);
+   Do_Nothing (MM_Last3'Address);
 end Foo;

--- a/gdb/testsuite/gdb.ada/str_chars/foo.adb
+++ b/gdb/testsuite/gdb.ada/str_chars/foo.adb
@@ -14,13 +14,7 @@
 --  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 procedure Foo is
-
-   procedure Blah (Arg : String) is
-   begin
-     null; -- STOP
-   end;
-
+   Arg : String := "abcdefghijklmnopqrstuvwxyz";
 begin
-
-   Blah ("abcdefghijklmnopqrstuvwxyz");
+   null;                        --  STOP
 end Foo;

--- a/gdb/testsuite/gdb.ada/tick_length_array_enum_idx/foo_n207_004.adb
+++ b/gdb/testsuite/gdb.ada/tick_length_array_enum_idx/foo_n207_004.adb
@@ -21,10 +21,16 @@ procedure Foo_n207_004 is
    Cold : Variable_Table := (Green => False, Blue => True, White => True);
    Vars : Variable_Table :=  New_Variable_Table (Low => Red, High => Green);
    PT_Full : Full_PT := (False, True, False, True, False);
+
+   Vars_First : Color := Vars'First;
+   Vars_Last : Color := Vars'Last;
+
 begin
    Do_Nothing (Full'Address);  -- STOP
    Do_Nothing (Prim'Address);
    Do_Nothing (Cold'Address);
    Do_Nothing (Vars'Address);
+   Do_Nothing (Vars_First'Address);
+   Do_Nothing (Vars_Last'Address);
    Do_Nothing (PT_Full'Address);
 end Foo_n207_004;

--- a/gdb/testsuite/gdb.base/corefile-buildid.exp
+++ b/gdb/testsuite/gdb.base/corefile-buildid.exp
@@ -21,6 +21,10 @@
 
 standard_testfile .c -shlib-shr.c -shlib.c
 
+# Reuse the Python script from another test.  This provides a command
+# to remove a particular note from a core file.
+set pyfile [gdb_remote_download host ${srcdir}/${subdir}/corefile-no-threads.py]
+
 # Create a corefile from PROGNAME.  Return the name of the generated
 # corefile, or the empty string if anything goes wrong.
 #
@@ -345,6 +349,21 @@ foreach_with_prefix mode { exec shared } {
 	return
     }
 
+    if { [allow_python_tests] } {
+	# Create a corefile with no NT_FILE notes.
+	gdb_start
+	set corefile_no_nt_file [standard_output_file ${corefile}-no-nt_file]
+	remote_exec build "cp $corefile $corefile_no_nt_file"
+	gdb_test_no_output "source $::pyfile" "import python scripts"
+	gdb_test "modify-core-file \"$corefile_no_nt_file\" NT_FILE" \
+	    [multi_line \
+		 "Located PT_NOTE segment: \[^\r\n\]+" \
+		 "\\s+Found note with type $hex at file offset $hex\\..*" \
+		 "Successfully updated $decimal note\\(s\\) in \[^\r\n\]+"] \
+	    "update core file"
+	gdb_exit
+    }
+
     # Create a directory for the non-stripped test, copy every build
     # artefact into this directory.
     set combined_dirname [standard_output_file ${mode}_not-stripped]
@@ -394,6 +413,14 @@ foreach_with_prefix mode { exec shared } {
 	    locate_exec_from_core_build_id $corefile $dirname \
 		$build_artefacts $sepdebug $symlink \
 		[expr {$mode eq "shared"}]
+
+	    if { [allow_python_tests] } {
+		with_test_prefix "NT_FILE removed" {
+		    locate_exec_from_core_build_id $corefile_no_nt_file $dirname \
+			$build_artefacts $sepdebug $symlink \
+			[expr {$mode eq "shared"}]
+		}
+	    }
 	}
     }
 }

--- a/gdb/testsuite/gdb.base/corefile-buildid.exp
+++ b/gdb/testsuite/gdb.base/corefile-buildid.exp
@@ -52,21 +52,32 @@ proc create_core_file { progname } {
 }
 
 
-# Build a non-shared executable.
+# Build a non-shared executable.  MODE is a suffix used to generate
+# the executable name (which should be based on global TESTFILE).
+# Returns an empty list if anything goes wrong, otherwise, returns a
+# list containing the absolute filename of the executable.
 
-proc build_corefile_buildid_exec { progname } {
-    return [expr {[build_executable "build non-shared exec" $progname $::srcfile] != -1}]
+proc build_corefile_buildid_exec { mode } {
+    set progname $::testfile-$mode
+    if {[build_executable "build non-shared exec" $progname $::srcfile] == -1} {
+	return {}
+    }
+    return [list [standard_output_file $progname]]
 }
 
-# Build a shared executable.
+# Build a shared executable.  MODE is a suffix used to generate the
+# executable name (which should be based on global TESTFILE).  Returns
+# an empty list if anything goes wrong, otherwise, returns a list
+# containing the absolute filename of the executable (first) followed
+# by all the additional shared libraries.
 
-proc build_corefile_buildid_shared { progname } {
+proc build_corefile_buildid_shared { mode } {
     # Compile DSO.
+    set progname $::testfile-$mode
     set objdso [standard_output_file $::testfile-shlib-shr.so]
     if {[build_executable "build dso" $objdso $::srcfile2 {debug shlib}] == -1} {
-	return false
+	return {}
     }
-
 
     # Compile shared library.
     set srclib $::srcfile3
@@ -76,16 +87,16 @@ proc build_corefile_buildid_shared { progname } {
     set opts [list debug shlib_load shlib \
 		  additional_flags=-DSHLIB_NAME=\"$dlopen_lib\"]
     if {[build_executable "build solib" $objlib $::srcfile3 $opts] == -1} {
-	return false
+	return {}
     }
 
     # Compile main program.
     set opts [list debug shlib=$objlib additional_flags=-DTEST_SHARED]
     if {[build_executable "build shared exec" $progname $::srcfile $opts] == -1} {
-	return false
+	return {}
     }
 
-    return true
+    return [list [standard_output_file $progname] $objdso $objlib]
 }
 
 # Append DEBUGDIR to the debug-file-directory path.
@@ -145,18 +156,84 @@ proc check_exec_file {file} {
     }
 }
 
-# Test whether gdb can find an exec file from a core file's build-id.
-# The executable (and separate debuginfo if SEPDEBUG is true) is
-# copied to the .build-id directory.
-#
-# SUFFIX is appended to the .builid-id parent directory name to
-# keep all tests separate.
-# SYMLINK specifies whether build-id files should be copied or symlinked.
-# SHARED is a boolean indicating whether we are testing the shared
-# library core dump test case.
+# A convenience procedure to check if "info sharedlibrary" mentions the
+# files in the list EXPECTED_FILES.  Each filename in EXPECTED_FILES is an
+# absolute filename for a shared library GDB should have found when loading
+# the core file.
 
-proc locate_exec_from_core_build_id {corefile buildid \
-					 dirname progname \
+proc check_shlib_files { expected_files } {
+    set shlibs {}
+    set missing_shlib false
+    gdb_test_multiple "info sharedlibrary" "" {
+	-re "^info sharedlibrary\r\n" {
+	    exp_continue
+	}
+
+	-re "^From\\s+To\\s\[^\r\n\]+\r\n" {
+	    exp_continue
+	}
+
+	-re "^$::hex\\s+$::hex\\s+(?:Yes|No)\\s+(?:\\(\\*\\)\\s+)?(\[^\r\n\]+)\r\n" {
+	    set filename $expect_out(1,string)
+	    lappend shlibs $filename
+	    exp_continue
+	}
+
+	-re "^\\s+(?:Yes|No)\\s+(?:\\(\\*\\)\\s+)?(\[^\r\n\]+)\r\n" {
+	    # This shared library wasn't loaded correctly; GDB
+	    # probably failed to find the library file.  Don't add
+	    # this to the shlibs list as we want this library to
+	    # appear as missing.
+	    set missing_shlib true
+	    exp_continue
+	}
+
+	-re "^\\(\\*\\): Shared library is missing debugging information\\.\r\n" {
+	    exp_continue
+	}
+
+	-re "^$::gdb_prompt $" {
+	    # This proc is only called for the shared library test
+	    # case, in which case there should be at least two shared
+	    # libraries loaded.
+	    gdb_assert { !$missing_shlib && [llength $shlibs] >= 2 } \
+		$gdb_test_name
+	}
+    }
+
+    set count 0
+    foreach filename $expected_files {
+	incr count
+	gdb_assert { [lsearch -exact $shlibs $filename] != -1 } \
+	    "found shlib $count"
+    }
+}
+
+# Test whether gdb can find an exec file from a COREFILE's
+# build-id(s).  The basenames of the executable, and any shared
+# libraries built by this test script, that are used by the
+# executable, are in the list FILENAMES.  These files can all be found
+# in the directory DIRNAME.
+#
+# This function creates a debug directory and either copies, or
+# symlinks FILENAMES into the debug directory using the file's
+# build-id as the new filename within the newly created debug
+# directory.
+#
+# SEPDEBUG is a boolean, when true every file in FILENAMES has a
+# separate debug file, the same filename with ".debug" appended.  When
+# false, the debug information is contained within the file.
+#
+# SYMLINK is a boolean and indicates whether build-id files should be
+# copied or symlinked from DIRNAME.
+#
+# SHARED is a boolean indicating whether we are testing the shared
+# library core dump test case.  We carry out more checks when running
+# the shared library case, checking that GDB managed to load all the
+# shared libraries correctly too.
+
+proc locate_exec_from_core_build_id {corefile \
+					 dirname filenames \
 					 sepdebug symlink shared} {
     clean_restart
 
@@ -177,78 +254,130 @@ proc locate_exec_from_core_build_id {corefile buildid \
     } else {
 	set d "${d}_not-stripped"
     }
-
     set debugdir [standard_output_file $d]
-    remote_exec build \
-	"mkdir -p [file join $debugdir [file dirname $buildid]]"
 
-    set files_list {}
-    lappend files_list [file join $dirname [file tail $progname]] \
-	$buildid
-    if {$sepdebug} {
-	lappend files_list [file join $dirname [file tail $progname]].debug \
-	    "$buildid.debug"
-    }
+    # The following loop does two jobs.  The primary task is to either
+    # copy or symlink the files within DIRNAME into DEBUGDIR.  Within
+    # DEBUGDIR files are placed into a tree based on their build-id.
+    #
+    # As this loop is calculating build-ids anyway, the build-ids are
+    # recorded in the ALL_BUILDIDS list, retaining the order that
+    # items are found in FILENAMES.
+    set all_buildids {}
+    foreach filename $filenames {
+	# Get the build-id for FILENAME without ".debug" on the end.
+	# This will have the format: '.build-id/xx/xxxxx'
+	set buildid [build_id_debug_filename_get \
+			 [file join $dirname $filename] ""]
+	if {$buildid == ""} {
+	    untested "no build-id for $filename"
+	    return
+	}
+	verbose -log "build-id for $filename is $buildid"
+	lappend all_buildids $buildid
 
-    foreach {target name} $files_list {
-	set t [file join $dirname [file tail $target]]
-	if {$symlink} {
-	    remote_exec build "ln -s $t [file join $debugdir $name]"
-	} else {
-	    remote_exec build "cp $t [file join $debugdir $name]"
+	# Create the sub-directory of DEBUGDIR based on BUILDID.
+	remote_exec build \
+	    "mkdir -p [file join $debugdir [file dirname $buildid]]"
+
+	# Build a list of source target filename pairs.
+	set files_list {}
+	lappend files_list $filename $buildid
+	if {$sepdebug} {
+	    lappend files_list ${filename}.debug ${buildid}.debug
+	}
+
+	# Copy or symlink the source file from DIRNAME into DEBUGDIR.
+	foreach {target name} $files_list {
+	    set t [file join $dirname $target]
+	    set n [file join $debugdir $name]
+	    if {$symlink} {
+		remote_exec build "ln -s $t $n"
+	    } else {
+		remote_exec build "cp $t $n"
+	    }
 	}
     }
 
     # Append the debugdir to the separate debug directory search path.
     append_debug_dir $debugdir
 
+    # Load the core file.
     gdb_test "core-file $corefile" "Program terminated with .*" \
 	"load core file"
+
+    # What do we expect the name of the executable to appear as?
     if {$symlink} {
-	set expected_file [file join $dirname [file tail $progname]]
+	set expected_file [file join $dirname [lindex $filenames 0]]
     } else {
-	set expected_file $buildid
+	set expected_file [file join $debugdir [lindex $all_buildids 0]]
     }
-    check_exec_file [file join $debugdir $expected_file]
+    check_exec_file $expected_file
+
+    # Check that all of the expected shared libraries have been found.
+    if {$shared} {
+	if {$symlink} {
+	    set expected_files [lmap item [lrange $filenames 1 end] {
+		file join $dirname $item
+	    }]
+	} else {
+	    set expected_files [lmap item [lrange $all_buildids 1 end] {
+		file join $debugdir $item
+	    }]
+	}
+	check_shlib_files $expected_files
+    }
 }
 
 foreach_with_prefix mode { exec shared } {
-    # Build the executable.
-    set progname ${binfile}-$mode
+    # Build the executable and optionally, any shared libraries.
     set build_proc build_corefile_buildid_${mode}
-    if { ![$build_proc $progname] } {
-	return -1
+    set build_artefacts [$build_proc $mode]
+    if { [llength $build_artefacts] == 0 } {
+	return
     }
 
-    # Generate a corefile.
+    # Generate a corefile.  The executable is the first item in
+    # BUILD_ARTEFACTS.
+    set progname [lindex $build_artefacts 0]
     set corefile [create_core_file $progname]
     if { $corefile eq "" } {
-	return -1
-    }
-
-    # Get the build-id filename without ".debug" on the end.  This
-    # will have the format: '.build-id/xx/xxxxx'
-    set buildid [build_id_debug_filename_get $progname ""]
-    if {$buildid == ""} {
-	untested "binary has no build-id"
 	return
     }
-    verbose -log "build-id is $buildid"
 
-    # Create a directory for the non-stripped test.
-    set combined_dirname [standard_output_file ${mode}_non-stripped]
+    # Create a directory for the non-stripped test, copy every build
+    # artefact into this directory.
+    set combined_dirname [standard_output_file ${mode}_not-stripped]
     remote_exec build "mkdir -p $combined_dirname"
-    remote_exec build "cp $progname $combined_dirname"
-
-    # Create a directory for the stripped test.
-    if {[gdb_gnu_strip_debug [standard_output_file $progname] no-debuglink] != 0} {
-	untested "could not strip executable  for [join $suffix \ ]"
-	return
+    foreach filename $build_artefacts {
+	remote_exec build "cp $filename $combined_dirname"
     }
+
+    # Split the debug from each build artefact.
+    foreach filename $build_artefacts {
+	if {[gdb_gnu_strip_debug $filename no-debuglink] != 0} {
+	    untested "could not strip debug from [file tail $filename]"
+	    return
+	}
+    }
+
+    # Create a directory for the stripped test, move the now stripped
+    # binary, and the stripped out debug information for every build
+    # artefact, into this new directory.
     set sepdebug_dirname [standard_output_file ${mode}_stripped]
     remote_exec build "mkdir -p $sepdebug_dirname"
-    remote_exec build "mv $progname $sepdebug_dirname"
-    remote_exec build "mv ${progname}.debug $sepdebug_dirname"
+    foreach filename $build_artefacts {
+	remote_exec build "mv $filename $sepdebug_dirname"
+	remote_exec build "mv ${filename}.debug $sepdebug_dirname"
+    }
+
+    # The build artefacts are all absolute filenames, but now they
+    # have been copied or moved into the two holding areas created
+    # above, it is more useful to have BUILD_ARTEFACTS contain just
+    # the basenames.  Update the list now.
+    set build_artefacts [lmap filename $build_artefacts {
+	file tail $filename
+    }]
 
     # Now do the actual testing part.  Fill out a debug directory with
     # build-id related files (copies or symlinks) and then load the
@@ -262,9 +391,9 @@ foreach_with_prefix mode { exec shared } {
 	}
 
 	foreach_with_prefix symlink { false true } {
-	    locate_exec_from_core_build_id $corefile $buildid \
-		$dirname $progname \
-		$sepdebug $symlink [expr {$mode eq "shared"}]
+	    locate_exec_from_core_build_id $corefile $dirname \
+		$build_artefacts $sepdebug $symlink \
+		[expr {$mode eq "shared"}]
 	}
     }
 }

--- a/gdb/testsuite/gdb.base/corefile-buildid.exp
+++ b/gdb/testsuite/gdb.base/corefile-buildid.exp
@@ -21,6 +21,10 @@
 
 standard_testfile .c -shlib-shr.c -shlib.c
 
+# Reuse the Python script from another test.  This provides a command
+# to remove a particular note from a core file.
+set pyfile [gdb_remote_download host ${srcdir}/${subdir}/corefile-no-threads.py]
+
 # Create a corefile from PROGNAME.  Return the name of the generated
 # corefile, or the empty string if anything goes wrong.
 #
@@ -52,21 +56,32 @@ proc create_core_file { progname } {
 }
 
 
-# Build a non-shared executable.
+# Build a non-shared executable.  MODE is a suffix used to generate
+# the executable name (which should be based on global TESTFILE).
+# Returns an empty list if anything goes wrong, otherwise, returns a
+# list containing the absolute filename of the executable.
 
-proc build_corefile_buildid_exec { progname } {
-    return [expr {[build_executable "build non-shared exec" $progname $::srcfile] != -1}]
+proc build_corefile_buildid_exec { mode } {
+    set progname $::testfile-$mode
+    if {[build_executable "build non-shared exec" $progname $::srcfile] == -1} {
+	return {}
+    }
+    return [list [standard_output_file $progname]]
 }
 
-# Build a shared executable.
+# Build a shared executable.  MODE is a suffix used to generate the
+# executable name (which should be based on global TESTFILE).  Returns
+# an empty list if anything goes wrong, otherwise, returns a list
+# containing the absolute filename of the executable (first) followed
+# by all the additional shared libraries.
 
-proc build_corefile_buildid_shared { progname } {
+proc build_corefile_buildid_shared { mode } {
     # Compile DSO.
+    set progname $::testfile-$mode
     set objdso [standard_output_file $::testfile-shlib-shr.so]
     if {[build_executable "build dso" $objdso $::srcfile2 {debug shlib}] == -1} {
-	return false
+	return {}
     }
-
 
     # Compile shared library.
     set srclib $::srcfile3
@@ -76,16 +91,16 @@ proc build_corefile_buildid_shared { progname } {
     set opts [list debug shlib_load shlib \
 		  additional_flags=-DSHLIB_NAME=\"$dlopen_lib\"]
     if {[build_executable "build solib" $objlib $::srcfile3 $opts] == -1} {
-	return false
+	return {}
     }
 
     # Compile main program.
     set opts [list debug shlib=$objlib additional_flags=-DTEST_SHARED]
     if {[build_executable "build shared exec" $progname $::srcfile $opts] == -1} {
-	return false
+	return {}
     }
 
-    return true
+    return [list [standard_output_file $progname] $objdso $objlib]
 }
 
 # Append DEBUGDIR to the debug-file-directory path.
@@ -145,18 +160,84 @@ proc check_exec_file {file} {
     }
 }
 
-# Test whether gdb can find an exec file from a core file's build-id.
-# The executable (and separate debuginfo if SEPDEBUG is true) is
-# copied to the .build-id directory.
-#
-# SUFFIX is appended to the .builid-id parent directory name to
-# keep all tests separate.
-# SYMLINK specifies whether build-id files should be copied or symlinked.
-# SHARED is a boolean indicating whether we are testing the shared
-# library core dump test case.
+# A convenience procedure to check if "info sharedlibrary" mentions the
+# files in the list EXPECTED_FILES.  Each filename in EXPECTED_FILES is an
+# absolute filename for a shared library GDB should have found when loading
+# the core file.
 
-proc locate_exec_from_core_build_id {corefile buildid \
-					 dirname progname \
+proc check_shlib_files { expected_files } {
+    set shlibs {}
+    set missing_shlib false
+    gdb_test_multiple "info sharedlibrary" "" {
+	-re "^info sharedlibrary\r\n" {
+	    exp_continue
+	}
+
+	-re "^From\\s+To\\s\[^\r\n\]+\r\n" {
+	    exp_continue
+	}
+
+	-re "^$::hex\\s+$::hex\\s+(?:Yes|No)\\s+(?:\\(\\*\\)\\s+)?(\[^\r\n\]+)\r\n" {
+	    set filename $expect_out(1,string)
+	    lappend shlibs $filename
+	    exp_continue
+	}
+
+	-re "^\\s+(?:Yes|No)\\s+(?:\\(\\*\\)\\s+)?(\[^\r\n\]+)\r\n" {
+	    # This shared library wasn't loaded correctly; GDB
+	    # probably failed to find the library file.  Don't add
+	    # this to the shlibs list as we want this library to
+	    # appear as missing.
+	    set missing_shlib true
+	    exp_continue
+	}
+
+	-re "^\\(\\*\\): Shared library is missing debugging information\\.\r\n" {
+	    exp_continue
+	}
+
+	-re "^$::gdb_prompt $" {
+	    # This proc is only called for the shared library test
+	    # case, in which case there should be at least two shared
+	    # libraries loaded.
+	    gdb_assert { !$missing_shlib && [llength $shlibs] >= 2 } \
+		$gdb_test_name
+	}
+    }
+
+    set count 0
+    foreach filename $expected_files {
+	incr count
+	gdb_assert { [lsearch -exact $shlibs $filename] != -1 } \
+	    "found shlib $count"
+    }
+}
+
+# Test whether gdb can find an exec file from a COREFILE's
+# build-id(s).  The basenames of the executable, and any shared
+# libraries built by this test script, that are used by the
+# executable, are in the list FILENAMES.  These files can all be found
+# in the directory DIRNAME.
+#
+# This function creates a debug directory and either copies, or
+# symlinks FILENAMES into the debug directory using the file's
+# build-id as the new filename within the newly created debug
+# directory.
+#
+# SEPDEBUG is a boolean, when true every file in FILENAMES has a
+# separate debug file, the same filename with ".debug" appended.  When
+# false, the debug information is contained within the file.
+#
+# SYMLINK is a boolean and indicates whether build-id files should be
+# copied or symlinked from DIRNAME.
+#
+# SHARED is a boolean indicating whether we are testing the shared
+# library core dump test case.  We carry out more checks when running
+# the shared library case, checking that GDB managed to load all the
+# shared libraries correctly too.
+
+proc locate_exec_from_core_build_id {corefile \
+					 dirname filenames \
 					 sepdebug symlink shared} {
     clean_restart
 
@@ -177,78 +258,145 @@ proc locate_exec_from_core_build_id {corefile buildid \
     } else {
 	set d "${d}_not-stripped"
     }
-
     set debugdir [standard_output_file $d]
-    remote_exec build \
-	"mkdir -p [file join $debugdir [file dirname $buildid]]"
 
-    set files_list {}
-    lappend files_list [file join $dirname [file tail $progname]] \
-	$buildid
-    if {$sepdebug} {
-	lappend files_list [file join $dirname [file tail $progname]].debug \
-	    "$buildid.debug"
-    }
+    # The following loop does two jobs.  The primary task is to either
+    # copy or symlink the files within DIRNAME into DEBUGDIR.  Within
+    # DEBUGDIR files are placed into a tree based on their build-id.
+    #
+    # As this loop is calculating build-ids anyway, the build-ids are
+    # recorded in the ALL_BUILDIDS list, retaining the order that
+    # items are found in FILENAMES.
+    set all_buildids {}
+    foreach filename $filenames {
+	# Get the build-id for FILENAME without ".debug" on the end.
+	# This will have the format: '.build-id/xx/xxxxx'
+	set buildid [build_id_debug_filename_get \
+			 [file join $dirname $filename] ""]
+	if {$buildid == ""} {
+	    untested "no build-id for $filename"
+	    return
+	}
+	verbose -log "build-id for $filename is $buildid"
+	lappend all_buildids $buildid
 
-    foreach {target name} $files_list {
-	set t [file join $dirname [file tail $target]]
-	if {$symlink} {
-	    remote_exec build "ln -s $t [file join $debugdir $name]"
-	} else {
-	    remote_exec build "cp $t [file join $debugdir $name]"
+	# Create the sub-directory of DEBUGDIR based on BUILDID.
+	remote_exec build \
+	    "mkdir -p [file join $debugdir [file dirname $buildid]]"
+
+	# Build a list of source target filename pairs.
+	set files_list {}
+	lappend files_list $filename $buildid
+	if {$sepdebug} {
+	    lappend files_list ${filename}.debug ${buildid}.debug
+	}
+
+	# Copy or symlink the source file from DIRNAME into DEBUGDIR.
+	foreach {target name} $files_list {
+	    set t [file join $dirname $target]
+	    set n [file join $debugdir $name]
+	    if {$symlink} {
+		remote_exec build "ln -s $t $n"
+	    } else {
+		remote_exec build "cp $t $n"
+	    }
 	}
     }
 
     # Append the debugdir to the separate debug directory search path.
     append_debug_dir $debugdir
 
+    # Load the core file.
     gdb_test "core-file $corefile" "Program terminated with .*" \
 	"load core file"
+
+    # What do we expect the name of the executable to appear as?
     if {$symlink} {
-	set expected_file [file join $dirname [file tail $progname]]
+	set expected_file [file join $dirname [lindex $filenames 0]]
     } else {
-	set expected_file $buildid
+	set expected_file [file join $debugdir [lindex $all_buildids 0]]
     }
-    check_exec_file [file join $debugdir $expected_file]
+    check_exec_file $expected_file
+
+    # Check that all of the expected shared libraries have been found.
+    if {$shared} {
+	if {$symlink} {
+	    set expected_files [lmap item [lrange $filenames 1 end] {
+		file join $dirname $item
+	    }]
+	} else {
+	    set expected_files [lmap item [lrange $all_buildids 1 end] {
+		file join $debugdir $item
+	    }]
+	}
+	check_shlib_files $expected_files
+    }
 }
 
 foreach_with_prefix mode { exec shared } {
-    # Build the executable.
-    set progname ${binfile}-$mode
+    # Build the executable and optionally, any shared libraries.
     set build_proc build_corefile_buildid_${mode}
-    if { ![$build_proc $progname] } {
-	return -1
+    set build_artefacts [$build_proc $mode]
+    if { [llength $build_artefacts] == 0 } {
+	return
     }
 
-    # Generate a corefile.
+    # Generate a corefile.  The executable is the first item in
+    # BUILD_ARTEFACTS.
+    set progname [lindex $build_artefacts 0]
     set corefile [create_core_file $progname]
     if { $corefile eq "" } {
-	return -1
-    }
-
-    # Get the build-id filename without ".debug" on the end.  This
-    # will have the format: '.build-id/xx/xxxxx'
-    set buildid [build_id_debug_filename_get $progname ""]
-    if {$buildid == ""} {
-	untested "binary has no build-id"
 	return
     }
-    verbose -log "build-id is $buildid"
 
-    # Create a directory for the non-stripped test.
-    set combined_dirname [standard_output_file ${mode}_non-stripped]
+    if { [allow_python_tests] } {
+	# Create a corefile with no NT_FILE notes.
+	gdb_start
+	set corefile_no_nt_file [standard_output_file ${corefile}-no-nt_file]
+	remote_exec build "cp $corefile $corefile_no_nt_file"
+	gdb_test_no_output "source $::pyfile" "import python scripts"
+	gdb_test "modify-core-file \"$corefile_no_nt_file\" NT_FILE" \
+	    [multi_line \
+		 "Located PT_NOTE segment: \[^\r\n\]+" \
+		 "\\s+Found note with type $hex at file offset $hex\\..*" \
+		 "Successfully updated $decimal note\\(s\\) in \[^\r\n\]+"] \
+	    "update core file"
+	gdb_exit
+    }
+
+    # Create a directory for the non-stripped test, copy every build
+    # artefact into this directory.
+    set combined_dirname [standard_output_file ${mode}_not-stripped]
     remote_exec build "mkdir -p $combined_dirname"
-    remote_exec build "cp $progname $combined_dirname"
-
-    # Create a directory for the stripped test.
-    if {[gdb_gnu_strip_debug [standard_output_file $progname] no-debuglink] != 0} {
-	untested "could not strip executable  for [join $suffix \ ]"
-	return
+    foreach filename $build_artefacts {
+	remote_exec build "cp $filename $combined_dirname"
     }
+
+    # Split the debug from each build artefact.
+    foreach filename $build_artefacts {
+	if {[gdb_gnu_strip_debug $filename no-debuglink] != 0} {
+	    untested "could not strip debug from [file tail $filename]"
+	    return
+	}
+    }
+
+    # Create a directory for the stripped test, move the now stripped
+    # binary, and the stripped out debug information for every build
+    # artefact, into this new directory.
     set sepdebug_dirname [standard_output_file ${mode}_stripped]
     remote_exec build "mkdir -p $sepdebug_dirname"
-    remote_exec build "mv $progname $sepdebug_dirname"
-    remote_exec build "mv ${progname}.debug $sepdebug_dirname"
+    foreach filename $build_artefacts {
+	remote_exec build "mv $filename $sepdebug_dirname"
+	remote_exec build "mv ${filename}.debug $sepdebug_dirname"
+    }
+
+    # The build artefacts are all absolute filenames, but now they
+    # have been copied or moved into the two holding areas created
+    # above, it is more useful to have BUILD_ARTEFACTS contain just
+    # the basenames.  Update the list now.
+    set build_artefacts [lmap filename $build_artefacts {
+	file tail $filename
+    }]
 
     # Now do the actual testing part.  Fill out a debug directory with
     # build-id related files (copies or symlinks) and then load the
@@ -262,9 +410,17 @@ foreach_with_prefix mode { exec shared } {
 	}
 
 	foreach_with_prefix symlink { false true } {
-	    locate_exec_from_core_build_id $corefile $buildid \
-		$dirname $progname \
-		$sepdebug $symlink [expr {$mode eq "shared"}]
+	    locate_exec_from_core_build_id $corefile $dirname \
+		$build_artefacts $sepdebug $symlink \
+		[expr {$mode eq "shared"}]
+
+	    if { [allow_python_tests] } {
+		with_test_prefix "NT_FILE removed" {
+		    locate_exec_from_core_build_id $corefile_no_nt_file $dirname \
+			$build_artefacts $sepdebug $symlink \
+			[expr {$mode eq "shared"}]
+		}
+	    }
 	}
     }
 }

--- a/gdb/testsuite/gdb.base/corefile-no-threads.exp
+++ b/gdb/testsuite/gdb.base/corefile-no-threads.exp
@@ -15,8 +15,8 @@
 
 # Check how GDB handles a core file which appears to have no threads
 # within it.  We do this by asking the kernel to create a "normal"
-# core file, then use a Python script modify the core file, hiding the
-# NT_PRSTATUS notes.  The NT_PRSTATUS notes contain the general
+# core file, then use a Python script to modify the core file, hiding
+# the NT_PRSTATUS notes.  The NT_PRSTATUS notes contain the general
 # purpose registers for each thread, so with these gone GDB will
 # believe the core file has no threads.
 #
@@ -52,7 +52,11 @@ clean_restart
 # Load the Python script, and run the command which modifies the core
 # file.
 gdb_test_no_output "source $::pyfile" "import python scripts"
-gdb_test "modify-core-file \"$corefile\" 0x1" ".*" \
+gdb_test "modify-core-file \"$corefile\" NT_PRSTATUS" \
+    [multi_line \
+	 "Located PT_NOTE segment: \[^\r\n\]+" \
+	 "\\s+Found note with type $hex at file offset $hex\\..*" \
+	 "Successfully updated $decimal note\\(s\\) in \[^\r\n\]+"] \
     "update core file"
 
 set saw_no_regs_warning false

--- a/gdb/testsuite/gdb.base/corefile-no-threads.py
+++ b/gdb/testsuite/gdb.base/corefile-no-threads.py
@@ -18,10 +18,10 @@
 #
 # modify-core-file <corefile> <note type> [ <name regex> ]
 #
-# Find all notes in the core file <corefile> that have the type value
-# <note type>.  Change the type of those notes to 0xffffffff, which
-# should prevent GDB from processing the note.  The <corefile> is
-# modified in place.
+# Find all notes in the core file <corefile> that have the type
+# <note type>, either a name (e.g. NT_PRSTATUS) or an integer.
+# Change the type of those notes to 0xffffffff, which should prevent
+# GDB from processing the note.  The <corefile> is modified in place.
 #
 # The optional argument <name regex> is a regular expression to match
 # against the name of the note in addition to the type value check.
@@ -130,7 +130,7 @@ def invalidate_corefile_notes(core_filepath, type_val, name_re):
     ei_data = read_field(core_data, 5, "=b")
     ei_version = read_field(core_data, 6, "=b")
 
-    # Based on the endinanness of the core file, select a character to
+    # Based on the endianness of the core file, select a character to
     # use with the 'struct' module for unpacking multi-byte fields.
     if ei_data == ELF_DATA_2_LSB:
         endian_char = "<"
@@ -194,7 +194,7 @@ def invalidate_corefile_notes(core_filepath, type_val, name_re):
     # Read the e_type field and check this is a core file.
     e_type = read_field(core_data, ELF_HDR_TYPE_OFFSET, ELF_HALF_FMT)
     if e_type != ELF_TYPE_CORE:
-        raise gdb.GdbError("Unsuported ELF e_type %d" % (e_type))
+        raise gdb.GdbError("Unsupported ELF e_type %d" % (e_type))
 
     # Read the offset to the program header table, and the number of
     # entries in the program header table.
@@ -308,6 +308,31 @@ def invalidate_corefile_notes(core_filepath, type_val, name_re):
             )
 
 
+# A limited set of note names.  Extend this as needed.
+NOTE_TYPES = {
+    "NT_PRSTATUS": 1,
+    "NT_FPREGSET": 2,
+    "NT_PRPSINFO": 3,
+    "NT_TASKSTRUCT": 4,
+    "NT_AUXV": 6,
+    "NT_SIGINFO": 0x53494749,
+    "NT_FILE": 0x46494C45,
+    "NT_PRXFPREG": 0x46E62B7F,
+}
+
+
+def parse_type(type_str):
+    """Resolves string name to integer or parses raw hex/int."""
+    if type_str in NOTE_TYPES:
+        return NOTE_TYPES[type_str]
+    try:
+        return int(type_str, 0)
+    except ValueError as e:
+        raise gdb.GdbError(
+            "Error: Unable to parse '%s' as number: %s" % (type_str, str(e))
+        )
+
+
 class modify_core_file(gdb.Command):
     """Update notes within a core file.
 
@@ -315,7 +340,8 @@ class modify_core_file(gdb.Command):
     modify-core-file COREFILE NOTE_TYPE [ NAME_REGEX ]
 
     Within COREFILE, find any notes matching NOTE_TYPE, which should
-    be an integer.  Change the type of these notes to 0xffffffff.
+    be either a note type name (e.g. NT_PRSTATUS) or an integer.
+    Change the type of these notes to 0xffffffff.
 
     If NAME_REGEX is supplied, and is not the empty string, then only
     notes whose type matches NOTE_TYPE, and whose name matches
@@ -352,12 +378,7 @@ class modify_core_file(gdb.Command):
                 "Error: Cannot write to '%s'. Check file permissions." % (filename)
             )
 
-        try:
-            type_val = int(type_str, 0)
-        except ValueError as e:
-            raise gdb.GdbError(
-                "Error: Unable to parse '%s' as number: %s" % (type_str, str(e))
-            )
+        type_val = parse_type(type_str)
 
         if name_re_str != "":
             name_re = re.compile(name_re_str)

--- a/gdb/testsuite/gdb.base/rbreak-2.c
+++ b/gdb/testsuite/gdb.base/rbreak-2.c
@@ -1,0 +1,28 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+static int
+foo (void)
+{
+  return 0;
+}
+
+int
+bar (void)
+{
+  return foo ();
+}

--- a/gdb/testsuite/gdb.base/rbreak.c
+++ b/gdb/testsuite/gdb.base/rbreak.c
@@ -1,0 +1,30 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+static int
+foo (void)
+{
+  return 1;
+}
+
+extern int bar (void);
+
+int
+main (void)
+{
+  return foo () + bar ();
+}

--- a/gdb/testsuite/gdb.base/rbreak.exp
+++ b/gdb/testsuite/gdb.base/rbreak.exp
@@ -1,0 +1,33 @@
+#   Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Check rbreak <file>:<regexp> command.
+
+standard_testfile .c -2.c
+
+if { [prepare_for_testing "failed to prepare" $testfile \
+	  [list $srcfile $srcfile2]] } {
+    return -1
+}
+
+# Regression test for PR34112.  Check that "rbreak $srcfile:foo" doesn't set
+# a breakpoint on $srcfile2:foo.
+set re_line \
+    [quotemeta \
+	 "Breakpoint @DECIMAL at @HEX: file @...$srcfile, line @DECIMAL."]
+gdb_test "rbreak $srcfile:foo" \
+    [multi_line \
+	 $re_line \
+	 ".*"]

--- a/gdb/testsuite/gdb.base/save-history.exp
+++ b/gdb/testsuite/gdb.base/save-history.exp
@@ -30,6 +30,13 @@ gdb_test_no_output "save history $filename" \
 
 set expected "set height 0\n"
 append expected "set width 0\n"
+
+# There is an additional target connection command with the
+# extended-remote board file.
+if {[target_info gdb_protocol] == "extended-remote"} {
+    append expected "target extended-remote $gdbserver_gdbport\n"
+}
+
 append expected "print 23\n"
 append expected "save history $filename\n"
 

--- a/gdb/testsuite/gdb.base/save-history.exp
+++ b/gdb/testsuite/gdb.base/save-history.exp
@@ -1,4 +1,4 @@
-# Copyright 2023 Free Software Foundation, Inc.
+# Copyright 2026 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gdb/testsuite/gdb.base/save-history.exp
+++ b/gdb/testsuite/gdb.base/save-history.exp
@@ -1,4 +1,4 @@
-# Copyright 2023 Free Software Foundation, Inc.
+# Copyright 2026 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,13 @@ gdb_test_no_output "save history $filename" \
 
 set expected "set height 0\n"
 append expected "set width 0\n"
+
+# There is an additional target connection command with the
+# extended-remote board file.
+if {[target_info gdb_protocol] == "extended-remote"} {
+    append expected "target extended-remote $gdbserver_gdbport\n"
+}
+
 append expected "print 23\n"
 append expected "save history $filename\n"
 

--- a/gdb/testsuite/gdb.base/watch_thread_num.c
+++ b/gdb/testsuite/gdb.base/watch_thread_num.c
@@ -1,9 +1,6 @@
 /* This testcase is part of GDB, the GNU debugger.
 
-   Copyright 2002-2026 Free Software Foundation, Inc.
-
-   Copyright 1992, 1993, 1994, 1995, 1999, 2002, 2003, 2007, 2008, 2009
-   Free Software Foundation, Inc.
+   Copyright 1992-2026 Free Software Foundation, Inc.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/gdb/testsuite/gdb.dwarf2/ada-var-in-module.c
+++ b/gdb/testsuite/gdb.dwarf2/ada-var-in-module.c
@@ -1,0 +1,24 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+int the_length = 5;
+int wrong_length = 9;
+int global_array[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+int
+main (void)
+{
+  return 0;
+}

--- a/gdb/testsuite/gdb.dwarf2/ada-var-in-module.exp
+++ b/gdb/testsuite/gdb.dwarf2/ada-var-in-module.exp
@@ -1,0 +1,151 @@
+# Copyright 2026 Free Software Foundation, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that an array whose upper bound references a variable
+# declaration inside a DW_TAG_module gets the correct fully qualified
+# name.  This tests that var_decl_name returns the fully qualified
+# name.
+#
+# Without the var_decl_name fix, only the non-qualified name was being
+# returned, GDB would then lookup based on this partial name, and
+# could find the wrong variable.
+
+load_lib dwarf.exp
+
+# This test can only be run on targets which support DWARF-2 and use gas.
+require dwarf2_support
+
+standard_testfile .c -dw.S
+
+# Make some DWARF for the test.
+set asm_file [standard_output_file $srcfile2]
+Dwarf::assemble $asm_file {
+    cu {} {
+	DW_TAG_compile_unit {
+	    DW_AT_language @DW_LANG_Ada95
+	    DW_AT_name	    foo.adb
+	    DW_AT_comp_dir /tmp
+	} {
+	    declare_labels integer_label array_label \
+		length_label
+
+	    # Basic integer type.
+	    integer_label: DW_TAG_base_type {
+		DW_AT_byte_size 4 DW_FORM_sdata
+		DW_AT_encoding	 @DW_ATE_signed
+		DW_AT_name	 integer
+	    }
+
+	    # A module with a variable called 'my_length', this does
+	    # not point at the array length though.  This exists to
+	    # confuse Ada's wild card variable lookup.
+	    DW_TAG_module {
+		DW_AT_name aaa
+	    } {
+		DW_TAG_variable {
+		    DW_AT_name my_length
+		    DW_AT_type :$integer_label
+		    DW_AT_external 1 flag
+		    DW_AT_location {
+			DW_OP_addr [gdb_target_symbol wrong_length]
+		    } SPECIAL_expr
+		}
+	    }
+
+	    # The 'bbb' module contains the variable that holds the
+	    # array length (the array itself is defined below).  There
+	    # MUST be a separate declaration and definition for the
+	    # variable, the bug we are testing for is when the array
+	    # bound points at the declaration.
+	    DW_TAG_module {
+		DW_AT_name bbb
+	    } {
+		length_label: DW_TAG_variable {
+		    DW_AT_name my_length
+		    DW_AT_type :$integer_label
+		    DW_AT_declaration 1 flag
+		}
+
+		DW_TAG_variable {
+		    DW_AT_name my_length
+		    DW_AT_type :$integer_label
+		    DW_AT_external 1 flag
+		    DW_AT_location {
+			DW_OP_addr [gdb_target_symbol the_length]
+		    } SPECIAL_expr
+		}
+	    }
+
+	    # Another module with a variable called 'my_length', this
+	    # also does not point at the array length.  As with the
+	    # 'aaa' module, this exists to confuse Ada's wild card
+	    # variable lookup.
+	    DW_TAG_module {
+		DW_AT_name ccc
+	    } {
+		DW_TAG_variable {
+		    DW_AT_name my_length
+		    DW_AT_type :$integer_label
+		    DW_AT_external 1 flag
+		    DW_AT_location {
+			DW_OP_addr [gdb_target_symbol wrong_length]
+		    } SPECIAL_expr
+		}
+	    }
+
+	    # Global array type.  The upper bound is held in the
+	    # 'bbb.my_length' variable.  The upper bound MUST
+	    # reference the variable declaration in order to test the
+	    # bug we are interested in.
+	    array_label: DW_TAG_array_type {
+		DW_AT_name the_array_type
+		DW_AT_type :$integer_label
+	    } {
+		DW_TAG_subrange_type {
+		    DW_AT_type	       :$integer_label
+		    DW_AT_lower_bound 1 DW_FORM_sdata
+		    DW_AT_upper_bound :$length_label
+		}
+	    }
+
+	    # Global array variable.
+	    DW_TAG_variable {
+		DW_AT_name the_array
+		DW_AT_type :$array_label
+		DW_AT_location {
+		    DW_OP_addr [gdb_target_symbol global_array]
+		} SPECIAL_expr
+		DW_AT_external 1 flag
+	    }
+	}
+    }
+}
+
+if {[prepare_for_testing "failed to prepare" ${testfile} \
+	 [list $srcfile $asm_file] {nodebug}]} {
+    return
+}
+
+# Print 'the_array'.  To establish the upper bound GDB must lookup the
+# correct variable by name.  With the bug fix in place GDB should look
+# for 'bbb.my_length' and find the correct variable.  Without the fix
+# GDB would look for just 'my_length' which is ambiguous.  The hope of
+# this test is that by having an 'aaa.my_length' and 'ccc.my_length'
+# that, without the fix, GDB will find the wrong length and use that.
+gdb_test_no_output "set language ada"
+gdb_test "print aaa.my_length" " = 9"
+gdb_test "print bbb.my_length" " = 5"
+gdb_test "print ccc.my_length" " = 9"
+gdb_test "print the_array" " = \\(1, 2, 3, 4, 5\\)"

--- a/gdb/testsuite/gdb.pascal/types.exp
+++ b/gdb/testsuite/gdb.pascal/types.exp
@@ -1,5 +1,4 @@
 # Copyright 1994-2026 Free Software Foundation, Inc.
-# Copyright 2007 Free Software Foundation, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gdb/testsuite/gdb.python/py-corefile.py
+++ b/gdb/testsuite/gdb.python/py-corefile.py
@@ -56,6 +56,10 @@ def info_proc_mappings():
 
     result = []
     for m in mappings:
+        # Ignore anonymous mappings.
+        if m.filename == "":
+            continue
+
         for r in m.regions:
             result.append(Mapping(m, r))
 

--- a/gdb/testsuite/gdb.python/py-prettyprint.exp
+++ b/gdb/testsuite/gdb.python/py-prettyprint.exp
@@ -40,7 +40,7 @@ proc run_lang_tests {exefile lang} {
     gdb_load $exefile
 
     if {![runto_main]} {
-	return
+	return -1
     }
 
     gdb_test_no_output "set print pretty on"

--- a/gdb/testsuite/gdb.rocm/names.exp
+++ b/gdb/testsuite/gdb.rocm/names.exp
@@ -69,7 +69,7 @@ set all_kernels_info {
     {long_kernel_name_0123456789                  long_kernel-0245 {long_kernel_name_0123456789 ()}}
     {long_kernel_name_abcdefghijklmnopqrstuvwxyz  long_kernel-479c {long_kernel_name_abcdefghijklmnopqrstuvwxyz ()}}
     {templ_non_type                               templ_non_type   {templ_non_type<(E)0> ()}}
-    {templ_type                                   templ_type       {templ_type<int, long> (args=2, args=2)}}
+    {templ_type                                   templ_type       {templ_type<int, long> (args=1, args=2)}}
 }
 
 # KERNEL is the kernel to launch.  It is either the name of a kernel

--- a/gdb/testsuite/gdb.server/require-running.exp
+++ b/gdb/testsuite/gdb.server/require-running.exp
@@ -1,4 +1,4 @@
-# Copyright 2025 Free Software Foundation, Inc.
+# Copyright 2026 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gdb/testsuite/gdb.threads/leader-exit-schedlock.c
+++ b/gdb/testsuite/gdb.threads/leader-exit-schedlock.c
@@ -1,0 +1,56 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2025-2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <assert.h>
+#include <unistd.h>
+
+static pthread_barrier_t threads_started_barrier;
+
+static void *
+start (void *arg)
+{
+  pthread_barrier_wait (&threads_started_barrier);
+
+  while (1)
+    sleep (1);
+
+  return NULL;
+}
+
+#define NTHREADS 10
+
+int
+main (void)
+{
+  int i;
+
+  pthread_barrier_init (&threads_started_barrier, NULL, NTHREADS + 1);
+
+  for (i = 0; i < NTHREADS; i++)
+    {
+      pthread_t thread;
+      int res;
+
+      res = pthread_create (&thread, NULL, start, NULL);
+      assert (res == 0);
+    }
+
+  pthread_barrier_wait (&threads_started_barrier);
+
+  return 0; /* break-here */
+}

--- a/gdb/testsuite/gdb.threads/leader-exit-schedlock.exp
+++ b/gdb/testsuite/gdb.threads/leader-exit-schedlock.exp
@@ -1,0 +1,215 @@
+# Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# On Linux, exiting the main thread with scheduler locking on results
+# in an inferior exit immediately.  On Windows, however, it results in
+# a normal thread exit of the main thread, with the other threads
+# staying listed.  Test this, and then test iterating over all the
+# other threads and continuing then too, one by one, with
+# scheduler-locking on.  Also test schedlock off, for completeness.
+
+standard_testfile
+
+if {[build_executable "failed to prepare" $testfile $srcfile {debug pthreads}]} {
+    return -1
+}
+
+# Run "info threads" and return a list of various information:
+#
+#  Element 0 - the highest numbered thread, zero if no thread is found.
+#  Element 1 - the "(exiting process)" thread, zero if not found.
+#  Element 2 - a list of "(exiting)" threads.
+#  Element 3 - a list of the other threads.
+
+proc info_threads {} {
+    set highest_thread 0
+    set exit_process_thread 0
+    set exit_thread_threads {}
+    set other_threads {}
+    set any "\[^\r\n\]*"
+    set ws "\[ \t\]*"
+    set eol "(?=\r\n)"
+    set common_prefix "^\r\n(?:\\*)?${ws}($::decimal)\[ \t\]*${::tdlabel_re}${any}"
+    gdb_test_multiple "info threads" "" -lbl {
+	-re "${common_prefix}\\(exiting process\\)${any}${eol}" {
+	    set highest_thread $expect_out(1,string)
+	    verbose -log "\nhighest_thread=$highest_thread, exiting process\n"
+	    set exit_process_thread $highest_thread
+	    exp_continue
+	}
+	-re "${common_prefix}\\(exiting\\)${any}${eol}" {
+	    set highest_thread $expect_out(1,string)
+	    verbose -log "\nhighest_thread=$highest_thread, exiting thread\n"
+	    lappend exit_thread_threads $highest_thread
+	    exp_continue
+	}
+	-re "${common_prefix}${eol}" {
+	    set highest_thread $expect_out(1,string)
+	    verbose -log "\nhighest_thread=$highest_thread, other thread\n"
+	    lappend other_threads $highest_thread
+	    exp_continue
+	}
+	-re "^\r\n$::gdb_prompt $" {
+	    verbose -log "\nhighest_thread=$highest_thread, prompt\n"
+	    gdb_assert {$highest_thread > 0} $gdb_test_name
+	}
+    }
+    verbose -log "info_threads: highest_thread=$highest_thread"
+    verbose -log "info_threads: exit_thread_threads=$exit_thread_threads"
+    verbose -log "info_threads: other_threads=$other_threads"
+    verbose -log "info_threads: exit_process_thread=$exit_process_thread"
+
+    return [list \
+		$highest_thread \
+		$exit_process_thread \
+		$exit_thread_threads \
+		$other_threads]
+}
+
+# If EXIT-THREADS-FIRST is true, continues all threads which have a
+# pending exit-thread event first, before continuing the thread with
+# the pending exit-process event.
+proc test {target-non-stop exit-threads-first schedlock} {
+    save_vars ::GDBFLAGS {
+	append ::GDBFLAGS " -ex \"maintenance set target-non-stop ${target-non-stop}\""
+	clean_restart $::testfile
+    }
+
+    set is_windows [expr {[istarget *-*-mingw*] || [istarget *-*-cygwin*]}]
+    set is_linux [istarget *-*-linux*]
+
+    if {!$is_windows && ${exit-threads-first}} {
+	# No point in exercising this combination because we will
+	# return before we reach the point where it is tested.
+	return
+    }
+
+    if {![runto_main]} {
+	return
+    }
+
+    gdb_breakpoint [gdb_get_line_number "break-here"]
+    gdb_continue_to_breakpoint "break-here" ".* break-here .*"
+
+    gdb_test_no_output "set scheduler-locking $schedlock"
+
+    # Continuing the main thread on Linux makes the whole process
+    # exit.  This makes GDB report all threads exits immediately, and
+    # then the inferior exit.  The thread exits don't stay pending
+    # because Linux supports per-thread thread-exit control, while
+    # Windows is per-target.
+    if {!$is_windows || $schedlock == off} {
+	gdb_test_multiple "c" "continue exit-process thread to exit" {
+	    -re -wrap "Inferior.*exited normally.*" {
+		pass $gdb_test_name
+	    }
+	    -re -wrap "No unwaited-for children left.*" {
+		# On Linux, GDB may briefly see the main thread turn
+		# zombie before seeing its exit event.
+		gdb_assert $is_linux $gdb_test_name
+	    }
+	}
+
+	return
+    }
+
+    # On Windows, continuing the thread that calls TerminateProcess
+    # (the main thread when it returns from main in our case) with
+    # scheduler-locking enabled exits the whole process, but core of
+    # GDB won't see the exit process event right away.  Windows only
+    # reports it to the last thread that exits, whichever that is.
+    # Due to scheduler locking, that won't happen until we resume all
+    # other threads.  The TerminateProcess-caller thread gets a plain
+    # thread exit event.
+    gdb_test "c" "No unwaited-for children left\\." "continue main thread"
+
+    if {${target-non-stop} == "on"} {
+	# With non-stop. GDB issues ContinueDebugEvent as soon as it
+	# seens a debug event, so after a bit, the windows backend
+	# will have seen all the thread and process exit events, even
+	# while the user has the prompt.  Give it a bit of time for
+	# that to happen, so we can tell which threads have exited by
+	# looking for (exiting) and "(exiting process) in "info
+	# threads" output.
+	sleep 2
+    }
+
+    with_test_prefix "initial threads info" {
+	lassign [info_threads] \
+	    highest_thread \
+	    exit_process_thread \
+	    exit_thread_threads \
+	    other_threads
+
+	gdb_assert {$highest_thread > 0}
+    }
+
+    # Continue one thread at a time, collecting the exit status.
+    set thread_count $highest_thread
+    for {set i 2} {$i <= $thread_count} {incr i} {
+	with_test_prefix "thread $i" {
+	    lassign [info_threads] \
+		highest_thread \
+		exit_process_thread \
+		exit_thread_threads \
+		other_threads
+
+	    # Default to a value that forces FAILs below.
+	    set thr 0
+	    # Whether we expect to find a thread with "(exiting process)":
+	    #   0 - not expected - it's a failure if we see one.
+	    #   1 - possible - we may or may not see one.
+	    #   2 - required - it's a failure if we don't see one.
+	    set process_exit_expected 0
+
+	    if {$i == $thread_count} {
+		set thr $highest_thread
+		set process_exit_expected 2
+		gdb_test "p/d \$_inferior_thread_count == 1" " = 1" "one thread left"
+	    } else {
+		if {${exit-threads-first} && [llength $exit_thread_threads] != 0} {
+		    set thr [lindex $exit_thread_threads 0]
+		} elseif {$exit_process_thread > 0} {
+		    set thr $exit_process_thread
+		    set process_exit_expected 2
+		} elseif {[llength $other_threads] != 0} {
+		    set thr [lindex $other_threads 0]
+		    set process_exit_expected 1
+		}
+	    }
+
+	    gdb_test "thread $thr" \
+		"Switching to .*" \
+		"switch to thread"
+	    gdb_test_multiple "c" "continue thread to exit" {
+		-re -wrap "No unwaited-for children left\\." {
+		    gdb_assert {$process_exit_expected != 2} $gdb_test_name
+		}
+		-re -wrap "Inferior.*exited normally.*" {
+		    gdb_assert {$process_exit_expected != 0} $gdb_test_name
+		    return
+		}
+	    }
+	}
+    }
+}
+
+foreach_with_prefix target-non-stop {off on} {
+    foreach_with_prefix exit-threads-first {0 1} {
+	foreach_with_prefix schedlock {off on} {
+	    test ${target-non-stop} ${exit-threads-first} $schedlock
+	}
+    }
+}

--- a/gdb/testsuite/gdb.threads/schedlock.exp
+++ b/gdb/testsuite/gdb.threads/schedlock.exp
@@ -232,8 +232,12 @@ proc check_result { cmd before_thread before_args locked } {
 	    }
 	} else {
 	    if {$i == $before_thread} {
-		if {$cmd == "continue"
-		    || [lindex $before_args $i] == [lindex $after_args $i] - 10} {
+		if {$cmd == "continue"} {
+		    pass "$test"
+		} elseif {[llength $after_args] <= $i} {
+		    fail "$test (no arg #$i)"
+		} elseif {[lindex $before_args $i] \
+			  == [lindex $after_args $i] - 10} {
 		    pass "$test"
 		} else {
 		    fail "$test (wrong amount)"

--- a/gdb/testsuite/gdb.threads/step-over-process-exit.c
+++ b/gdb/testsuite/gdb.threads/step-over-process-exit.c
@@ -1,0 +1,49 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright 2025-2026 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+volatile int other_thread_exits = 0;
+
+static void *
+thread_function (void *arg)
+{
+  if (other_thread_exits)
+    exit (0); /* break here other */
+
+  while (1)
+    sleep (1);
+}
+
+int
+main ()
+{
+  pthread_t thread;
+
+  alarm (30);
+
+  pthread_create (&thread, NULL, thread_function, NULL);
+
+  if (!other_thread_exits)
+    exit (0); /* break here main */
+
+  while (1)
+    sleep (1);
+  return 0;
+}

--- a/gdb/testsuite/gdb.threads/step-over-process-exit.exp
+++ b/gdb/testsuite/gdb.threads/step-over-process-exit.exp
@@ -1,0 +1,66 @@
+# This testcase is part of GDB, the GNU debugger.
+
+# Copyright 2025-2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test stepping over an exit syscall from both the main thread, and a
+# non-main thread.
+
+if { [target_info exists exit_is_reliable] } {
+    set exit_is_reliable [target_info exit_is_reliable]
+} else {
+    set exit_is_reliable [expr {![target_info exists use_gdb_stub]}]
+}
+require {expr {$exit_is_reliable}}
+
+standard_testfile
+
+if { [prepare_for_testing "failed to prepare" $testfile $srcfile {debug pthread}] } {
+    return -1
+}
+
+# WHICH is which thread exits the process.  Can be "main" for main
+# thread, or "other" for the non-main thread.
+
+proc test {which} {
+    if {![runto_main]} {
+	return -1
+    }
+
+    set other [expr {$which == "other"}]
+    gdb_test "p other_thread_exits = $other" " = $other"
+
+    set break_line [gdb_get_line_number "break here $which"]
+    gdb_breakpoint $break_line
+    gdb_continue_to_breakpoint "exit syscall"
+
+    set target_non_stop [is_target_non_stop]
+
+    gdb_test_multiple "next" "" {
+	-re -wrap "$::inferior_exited_re normally\\\]" {
+	    pass $gdb_test_name
+	}
+	-re -wrap "Further execution is probably impossible\\." {
+	    # With a target in all-stop, this is the best we can do.
+	    # We should not see this with a target backend in non-stop
+	    # mode, however.
+	    gdb_assert !$target_non_stop $gdb_test_name
+	}
+    }
+}
+
+foreach_with_prefix which {main other} {
+    test $which
+}

--- a/gdb/tui/tui.c
+++ b/gdb/tui/tui.c
@@ -429,7 +429,8 @@ tui_enable (void)
 	 again.  */
       error (_("Cannot enable the TUI"));
     }
-  else if (tui_finish_init == TRIBOOL_TRUE)
+
+  if (tui_finish_init == TRIBOOL_TRUE)
     {
       WINDOW *w;
       SCREEN *s;

--- a/gdb/tui/tui.c
+++ b/gdb/tui/tui.c
@@ -491,22 +491,31 @@ tui_enable (void)
 	 rely on this flag being true in order to know that the window
 	 they are creating is currently valid.  */
       tui_active = true;
+      try
+	{
+	  cbreak ();
+	  noecho ();
+	  /* timeout (1); */
+	  nodelay (w, FALSE);
+	  nl ();
+	  keypad (w, TRUE);
+	  tui_set_term_height_to (LINES);
+	  tui_set_term_width_to (COLS);
+	  def_prog_mode ();
+	  tui_show_frame_info (deprecated_safe_get_selected_frame ());
+	  tui_set_initial_layout ();
+	  tui_set_win_focus_to (tui_src_win ());
+	  keypad (tui_cmd_win ()->handle.get (), TRUE);
+	  wrefresh (tui_cmd_win ()->handle.get ());
+	}
+      catch (const gdb_exception &)
+	{
+	  endwin ();
+	  delscreen (s);
+	  tui_active = false;
+	  throw;
+	}
 
-      cbreak ();
-      noecho ();
-      /* timeout (1); */
-      nodelay(w, FALSE);
-      nl();
-      keypad (w, TRUE);
-      tui_set_term_height_to (LINES);
-      tui_set_term_width_to (COLS);
-      def_prog_mode ();
-
-      tui_show_frame_info (deprecated_safe_get_selected_frame ());
-      tui_set_initial_layout ();
-      tui_set_win_focus_to (tui_src_win ());
-      keypad (tui_cmd_win ()->handle.get (), TRUE);
-      wrefresh (tui_cmd_win ()->handle.get ());
       tui_finish_init = TRIBOOL_FALSE;
     }
   else

--- a/gdb/tui/tui.c
+++ b/gdb/tui/tui.c
@@ -429,7 +429,8 @@ tui_enable (void)
 	 again.  */
       error (_("Cannot enable the TUI"));
     }
-  else if (tui_finish_init == TRIBOOL_TRUE)
+
+  if (tui_finish_init == TRIBOOL_TRUE)
     {
       WINDOW *w;
       SCREEN *s;
@@ -491,22 +492,31 @@ tui_enable (void)
 	 rely on this flag being true in order to know that the window
 	 they are creating is currently valid.  */
       tui_active = true;
+      try
+	{
+	  cbreak ();
+	  noecho ();
+	  /* timeout (1); */
+	  nodelay (w, FALSE);
+	  nl ();
+	  keypad (w, TRUE);
+	  tui_set_term_height_to (LINES);
+	  tui_set_term_width_to (COLS);
+	  def_prog_mode ();
+	  tui_show_frame_info (deprecated_safe_get_selected_frame ());
+	  tui_set_initial_layout ();
+	  tui_set_win_focus_to (tui_src_win ());
+	  keypad (tui_cmd_win ()->handle.get (), TRUE);
+	  wrefresh (tui_cmd_win ()->handle.get ());
+	}
+      catch (const gdb_exception &)
+	{
+	  endwin ();
+	  delscreen (s);
+	  tui_active = false;
+	  throw;
+	}
 
-      cbreak ();
-      noecho ();
-      /* timeout (1); */
-      nodelay(w, FALSE);
-      nl();
-      keypad (w, TRUE);
-      tui_set_term_height_to (LINES);
-      tui_set_term_width_to (COLS);
-      def_prog_mode ();
-
-      tui_show_frame_info (deprecated_safe_get_selected_frame ());
-      tui_set_initial_layout ();
-      tui_set_win_focus_to (tui_src_win ());
-      keypad (tui_cmd_win ()->handle.get (), TRUE);
-      wrefresh (tui_cmd_win ()->handle.get ());
       tui_finish_init = TRIBOOL_FALSE;
     }
   else

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -3376,6 +3376,15 @@ windows_nat_target::supports_non_stop ()
   return dbg_reply_later_available ();
 }
 
+/* Implementation of the target_ops::always_non_stop_p method.  */
+
+bool
+windows_nat_target::always_non_stop_p ()
+{
+  /* If we can do non-stop, prefer it.  */
+  return supports_non_stop ();
+}
+
 INIT_GDB_FILE (windows_nat)
 {
 #ifdef __CYGWIN__

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -272,15 +272,23 @@ windows_nat_target::continue_last_debug_event_main_thread
   m_continued = !last_call;
 }
 
+/* Return a pointer to the windows-nat target instance.  */
+
+static windows_nat_target *
+get_windows_nat_target ()
+{
+  return gdb::checked_static_cast<windows_nat_target *> (get_native_target ());
+}
+
 /* See nat/windows-nat.h.  */
 
 windows_thread_info *
 windows_per_inferior::find_thread (ptid_t ptid)
 {
-  for (auto &th : thread_list)
-    if (th->tid == ptid.lwp ())
-      return th.get ();
-  return nullptr;
+  thread_info *thr = get_windows_nat_target ()->find_thread (ptid);
+  if (thr == nullptr)
+    return nullptr;
+  return as_windows_thread_info (thr);
 }
 
 /* See nat/windows-nat.h.  */
@@ -297,12 +305,11 @@ windows_thread_info *
 windows_nat_target::add_thread (ptid_t ptid, HANDLE h, void *tlb,
 				bool main_thread_p)
 {
-  windows_thread_info *th;
-
   gdb_assert (ptid.lwp () != 0);
 
-  if ((th = windows_process->find_thread (ptid)))
-    return th;
+  windows_thread_info *existing = windows_process->find_thread (ptid);
+  if (existing != nullptr)
+    return existing;
 
   CORE_ADDR base = (CORE_ADDR) (uintptr_t) tlb;
 #ifdef __x86_64__
@@ -311,33 +318,24 @@ windows_nat_target::add_thread (ptid_t ptid, HANDLE h, void *tlb,
   if (windows_process->wow64_process)
     base += 0x2000;
 #endif
-  th = new windows_thread_info (windows_process, ptid.lwp (), h, base);
-  windows_process->thread_list.emplace_back (th);
+  windows_private_thread_info *th
+    = new windows_private_thread_info (windows_process, ptid.lwp (), h, base);
 
   /* Add this new thread to the list of threads.
 
      To be consistent with what's done on other platforms, we add
      the main thread silently (in reality, this thread is really
      more of a process to the user than a thread).  */
-  if (main_thread_p)
-    add_thread_silent (this, ptid);
-  else
-    ::add_thread (this, ptid);
+  thread_info *gth = (main_thread_p
+		      ? ::add_thread_silent (this, ptid)
+		      : ::add_thread (this, ptid));
+  gth->priv.reset (th);
 
   /* It's simplest to always set this and update the debug
      registers.  */
   th->debug_registers_changed = true;
 
   return th;
-}
-
-/* Clear out any old thread list and reinitialize it to a
-   pristine state.  */
-static void
-windows_init_thread_list (void)
-{
-  DEBUG_EVENTS ("called");
-  windows_process->thread_list.clear ();
 }
 
 /* Delete a thread from the list of threads.
@@ -351,12 +349,6 @@ void
 windows_nat_target::delete_thread (ptid_t ptid, DWORD exit_code,
 				   bool main_thread_p)
 {
-  DWORD id;
-
-  gdb_assert (ptid.lwp () != 0);
-
-  id = ptid.lwp ();
-
   /* Note that no notification was printed when the main thread was
      created, and thus, unless in verbose mode, we should be symmetrical,
      and avoid an exit notification for the main thread here as well.  */
@@ -364,16 +356,6 @@ windows_nat_target::delete_thread (ptid_t ptid, DWORD exit_code,
   bool silent = (main_thread_p && !info_verbose);
   thread_info *to_del = this->find_thread (ptid);
   delete_thread_with_exit_code (to_del, exit_code, silent);
-
-  auto iter = std::find_if (windows_process->thread_list.begin (),
-			    windows_process->thread_list.end (),
-			    [=] (std::unique_ptr<windows_thread_info> &th)
-			    {
-			      return th->tid == id;
-			    });
-
-  if (iter != windows_process->thread_list.end ())
-    windows_process->thread_list.erase (iter);
 }
 
 void
@@ -712,7 +694,7 @@ BOOL
 windows_nat_target::windows_continue (DWORD continue_status, int id,
 				      windows_continue_flags cont_flags)
 {
-  for (auto &th : windows_process->thread_list)
+  for (auto *th : all_windows_threads ())
     {
       if ((id == -1 || id == (int) th->tid)
 	  && !th->suspended
@@ -730,9 +712,9 @@ windows_nat_target::windows_continue (DWORD continue_status, int id,
 	}
     }
 
-  for (auto &th : windows_process->thread_list)
+  for (auto *th : all_windows_threads ())
     if (id == -1 || id == (int) th->tid)
-      continue_one_thread (th.get (), cont_flags);
+      continue_one_thread (th, cont_flags);
 
   continue_last_debug_event_main_thread
     (_("Failed to resume program execution"), continue_status,
@@ -914,7 +896,7 @@ windows_nat_target::get_windows_debug_event
   /* If there is a relevant pending stop, report it now.  See the
      comment by the definition of "windows_thread_info::pending_status"
      for details on why this is needed.  */
-  for (auto &th : windows_process->thread_list)
+  for (auto *th : all_windows_threads ())
     {
       if (!th->suspended
 	  && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
@@ -927,7 +909,7 @@ windows_nat_target::get_windows_debug_event
 	  *current_event = th->last_event;
 
 	  ptid_t ptid (windows_process->process_id, thread_id);
-	  windows_process->invalidate_thread_context (th.get ());
+	  windows_process->invalidate_thread_context (th);
 	  return ptid;
 	}
     }
@@ -1226,7 +1208,7 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 
 	      /* All-stop, suspend all threads until they are
 		 explicitly resumed.  */
-	      for (auto &thr : windows_process->thread_list)
+	      for (auto *thr : all_windows_threads ())
 		thr->suspend ();
 	    }
 
@@ -1382,7 +1364,6 @@ windows_nat_target::attach (const char *args, int from_tty)
     warning ("Failed to get SE_DEBUG_NAME privilege\n"
 	     "This can cause attach to fail on Windows NT/2K/XP");
 
-  windows_init_thread_list ();
   windows_process->saw_create = 0;
 
   std::optional<unsigned> err;
@@ -2142,7 +2123,6 @@ windows_nat_target::create_inferior (const char *exec_file,
 	}
     }
 
-  windows_init_thread_list ();
   do_synchronously ([&] ()
     {
       BOOL ok = create_process (nullptr, args, flags, w32_env,
@@ -2271,7 +2251,6 @@ windows_nat_target::create_inferior (const char *exec_file,
   /* Final nil string to terminate new env.  */
   *temp = 0;
 
-  windows_init_thread_list ();
   do_synchronously ([&] ()
     {
       BOOL ok = create_process (nullptr, /* image */

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -855,7 +855,7 @@ windows_per_inferior::handle_output_debug_string
 		 a pending event.  It will be picked up by
 		 windows_nat_target::wait.  */
 	      th->suspend ();
-	      th->stopping = true;
+	      th->stopping = SK_EXTERNAL;
 	      th->last_event = {};
 	      th->pending_status.set_stopped (gotasig);
 
@@ -923,7 +923,7 @@ windows_nat_target::continue_one_thread (windows_thread_info *th,
   thread_context_continue (th, killed);
 
   th->resume ();
-  th->stopping = false;
+  th->stopping = SK_NOT_STOPPING;
   th->last_sig = GDB_SIGNAL_0;
 }
 
@@ -997,8 +997,19 @@ windows_nat_target::windows_continue (DWORD continue_status, int id,
 #endif
       }
 
-  if (!target_is_non_stop_p ()
-      || (cont_flags & WCONT_CONTINUE_DEBUG_EVENT) != 0)
+  /* WCONT_DONT_CONTINUE_DEBUG_EVENT and WCONT_CONTINUE_DEBUG_EVENT
+     can't both be enabled at the same time.  */
+  gdb_assert ((cont_flags & WCONT_DONT_CONTINUE_DEBUG_EVENT) == 0
+	      || (cont_flags & WCONT_CONTINUE_DEBUG_EVENT) == 0);
+
+  bool continue_debug_event;
+  if ((cont_flags & WCONT_CONTINUE_DEBUG_EVENT) != 0)
+    continue_debug_event = true;
+  else if ((cont_flags & WCONT_DONT_CONTINUE_DEBUG_EVENT) != 0)
+    continue_debug_event = false;
+  else
+    continue_debug_event = !target_is_non_stop_p ();
+  if (continue_debug_event)
     {
       DEBUG_EVENTS ("windows_continue -> continue_last_debug_event");
       continue_last_debug_event_main_thread
@@ -1201,11 +1212,13 @@ windows_nat_target::interrupt ()
 	     "Press Ctrl-c in the program console."));
 }
 
-/* Stop thread TH.  This leaves a GDB_SIGNAL_0 pending in the thread,
-   which is later consumed by windows_nat_target::wait.  */
+/* Stop thread TH, for STOPPING_KIND reason.  This leaves a
+   GDB_SIGNAL_0 pending in the thread, which is later consumed by
+   windows_nat_target::wait.  */
 
 void
-windows_nat_target::stop_one_thread (windows_thread_info *th)
+windows_nat_target::stop_one_thread (windows_thread_info *th,
+				     enum stopping_kind stopping_kind)
 {
   ptid_t thr_ptid (windows_process->process_id, th->tid);
 
@@ -1221,12 +1234,18 @@ windows_nat_target::stop_one_thread (windows_thread_info *th)
 #ifdef __CYGWIN__
   else if (th->suspended
 	   && th->signaled_thread != nullptr
-	   && th->pending_status.kind () == TARGET_WAITKIND_IGNORE)
+	   && th->pending_status.kind () == TARGET_WAITKIND_IGNORE
+	   /* If doing an internal stop to update debug registers,
+	      then just leave the "sig" thread suspended.  Otherwise
+	      windows_nat_target::wait would incorrectly break the
+	      signaled_thread lock when it later processes the pending
+	      stop and calls windows_continue on this thread.  */
+	   && stopping_kind == SK_EXTERNAL)
     {
       DEBUG_EVENTS ("explict stop for \"sig\" thread %s held for signal",
 		    thr_ptid.to_string ().c_str ());
 
-      th->stopping = true;
+      th->stopping = stopping_kind;
       th->pending_status.set_stopped (GDB_SIGNAL_0);
       th->last_event = {};
       serial_event_set (m_wait_event);
@@ -1240,7 +1259,9 @@ windows_nat_target::stop_one_thread (windows_thread_info *th)
 		    thr_ptid.to_string ().c_str (),
 		    th->suspended, th->stopping);
 
-      th->stopping = true;
+      /* Upgrade stopping.  */
+      if (stopping_kind > th->stopping)
+	th->stopping = stopping_kind;
     }
   else
     {
@@ -1255,14 +1276,20 @@ windows_nat_target::stop_one_thread (windows_thread_info *th)
 	{
 	  DEBUG_EVENTS ("suspension of %s failed, expect thread exit event",
 			thr_ptid.to_string ().c_str ());
+	  if (stopping_kind > th->stopping)
+	    th->stopping = stopping_kind;
 	  return;
 	}
 
       gdb_assert (th->suspended == 1);
 
-      th->stopping = true;
-      th->pending_status.set_stopped (GDB_SIGNAL_0);
-      th->last_event = {};
+      if (stopping_kind > th->stopping)
+	{
+	  th->stopping = stopping_kind;
+	  th->pending_status.set_stopped (GDB_SIGNAL_0);
+	  th->last_event = {};
+	}
+
       serial_event_set (m_wait_event);
     }
 }
@@ -1275,7 +1302,7 @@ windows_nat_target::stop (ptid_t ptid)
   for (thread_info &thr : all_non_exited_threads (this))
     {
       if (thr.ptid.matches (ptid))
-	stop_one_thread (as_windows_thread_info (&thr));
+	stop_one_thread (as_windows_thread_info (&thr), SK_EXTERNAL);
     }
 }
 
@@ -1777,6 +1804,17 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 	    {
 	      windows_thread_info *th = windows_process->find_thread (result);
 
+	      /* If this thread was temporarily stopped just so we
+		 could update its debug registers on the next
+		 resumption, do it now.  */
+	      if (th->stopping == SK_INTERNAL)
+		{
+		  gdb_assert (fake);
+		  windows_continue (DBG_CONTINUE, th->tid,
+				    WCONT_DONT_CONTINUE_DEBUG_EVENT);
+		  continue;
+		}
+
 	      th->stopped_at_software_breakpoint = false;
 	      if (current_event.dwDebugEventCode
 		  == EXCEPTION_DEBUG_EVENT
@@ -1821,7 +1859,7 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 		for (auto *thr : all_windows_threads ())
 		  thr->suspend ();
 
-	      th->stopping = false;
+	      th->stopping = SK_NOT_STOPPING;
 	    }
 
 	  /* If something came out, assume there may be more.  This is
@@ -3402,6 +3440,40 @@ Use \"%ps\" or \"%ps\" command to load executable/libraries directly."),
 	      styled_string (command_style.style (), "file"),
 	      styled_string (command_style.style (), "dll"));
     }
+}
+
+/* For each thread, set the debug_registers_changed flag, and
+   temporarily stop it so we can update its debug registers.  */
+
+void
+windows_nat_target::debug_registers_changed_all_threads ()
+{
+  for (auto *th : all_windows_threads ())
+    {
+      th->debug_registers_changed = true;
+
+      /* Note we don't SuspendThread => update debug regs =>
+	 ResumeThread, because SuspendThread is actually asynchronous
+	 (and GetThreadContext blocks until the thread really
+	 suspends), and doing that for all threads may take a bit.
+	 Also, the core does one call per DR register update, so that
+	 would result in a lot of suspend-resumes.  So instead, we
+	 suspend the thread if it wasn't already suspended, and queue
+	 a pending stop to be handled by windows_nat_target::wait.
+	 This means we only stop each thread once, and, we don't block
+	 waiting for each individual thread stop.  */
+      stop_one_thread (th, SK_INTERNAL);
+    }
+}
+
+/* Trampoline helper to get at the
+   windows_nat_target::debug_registers_changed_all_threads method in
+   the native target.  */
+
+void
+windows_debug_registers_changed_all_threads ()
+{
+  get_windows_nat_target ()->debug_registers_changed_all_threads ();
 }
 
 /* Determine if the thread referenced by "ptid" is alive

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -66,6 +66,202 @@
 #include "gdbsupport/symbol.h"
 #include "inf-loop.h"
 
+/* This comment documents high-level logic of this file.
+
+all-stop
+========
+
+In all-stop mode ("maint set target-non-stop off"), there is only ever
+one Windows debug event in flight. When we receive an event from
+WaitForDebugEvent, the kernel has already implicitly suspended all the
+threads of the process.  We report the breaking event to the core.
+When the core decides to resume the inferior, it calls
+windows_nat_target:resume, which triggers a ContinueDebugEvent call.
+This call makes all unsuspended threads schedulable again, and we go
+back to waiting for the next event in WaitForDebugEvent.
+
+non-stop
+========
+
+For non-stop mode, we utilize the DBG_REPLY_LATER flag in the
+ContinueDebugEvent function.  According to Microsoft:
+
+ "This flag causes dwThreadId to replay the existing breaking event
+ after the target continues.  By calling the SuspendThread API against
+ dwThreadId, a debugger can resume other threads in the process and
+ later return to the breaking."
+
+To enable non-stop mode, windows_nat_target::wait suspends the thread,
+calls 'ContinueForDebugEvent(..., DBG_REPLY_LATER)', and sets the
+process_thread thread to wait for the next event using
+WaitForDebugEvent, all before returning the original breaking event to
+the core.
+
+When the user/core finally decides to resume the inferior thread that
+reported the event, we unsuspend it using ResumeThread.  Unlike in
+all-stop mode, we don't call ContinueDebugEvent then, as it has
+already been called when the event was first encountered.  By making
+the inferior thread schedulable again (by unsuspending it),
+WaitForDebugEvent re-reports the same event (due to the earlier
+DBG_REPLY_LATER).  In windows_nat_target::wait, we detect this delayed
+re-report and call ContinueDebugEvent on the thread, instructing the
+"process_thread" thread (the GDB thread responsible for calling
+WaitForDebugEvents) to continue waiting for the next event.
+
+During the initial thread resumption in windows_nat_target::resume, we
+recorded the dwContinueStatus argument to be passed to the last
+ContinueDebugEvent (called when the reply-later event is re-reported).
+See windows_thread_info::reply_later for details.
+
+Note that with this setup, in non-stop mode, every stopped thread has
+its own independent last-reported Windows debug event.  Therefore, we
+can decide on a per-thread basis whether to pass the thread's
+exception (DBG_EXCEPTION_NOT_HANDLED / DBG_CONTINUE) to the inferior.
+This per-thread decision is not possible in all-stop mode, where we
+only call ContinueDebugEvent for the thread that last reported a stop,
+at windows_nat_target::resume time.
+
+Thread and process exits
+========================
+
+When a process exits, Windows reports one EXIT_THREAD_DEBUG_EVENT
+event for each thread, except for the last thread that exits.  That
+last thread reports a EXIT_PROCESS_DEBUG_EVENT event instead.
+
+The last thread that exits is not guaranteed to be the main thread of
+the process.  In fact, it seldom is.  E.g., if the main thread calls
+ExitProcess (or returns from main, which ends up calling ExitProcess),
+then we typically see a EXIT_THREAD_DEBUG_EVENT event for the main
+thread first, followed by more EXIT_THREAD_DEBUG_EVENT events for
+other threads, and then finaly the EXIT_PROCESS_DEBUG_EVENT for
+whatever thread happened to be the last one to exit.
+
+When a thread reports EXIT_THREAD_DEBUG_EVENT /
+EXIT_PROCESS_DEBUG_EVENT, our handle to the thread is still valid, and
+we can still read its registers.  Windows only destroys the handle
+after ContinueDebugEvent.
+
+A thread that has exited CANNOT be suspended.  So if a thread was
+previously suspended, and then something kills the whole process
+(which force-kills all threads), that suspended thread will
+automatically "unsuspend", and report a EXIT_THREAD_DEBUG_EVENT event.
+However, if we had previously used DBG_REPLY_LATER on the thread,
+Windows will first re-report the kernel-side-queued "reply-later"
+event, and only after that one is ContinueDebugEvent'ed, will we see
+the EXIT_THREAD_DEBUG_EVENT event.
+
+Detaching and DBG_REPLY_LATER
+=============================
+
+After we detach from a process that has threads that we had previously
+used DBG_REPLY_LATER on, the kernel re-raises the "reply-later"
+exceptions for those threads.  This would most often kill the
+just-detached process, if we let it happen.  To prevent it, we flush
+all the "reply-later" events from the kernel before detaching.
+
+Cygwin signals
+==============
+
+The Cygwin runtime always spawns a "sig" thread, which is responsible
+for receiving signal delivery requests, and hijacking the signaled
+thread's execution to make it run the signal handler.  This is all
+explained here:
+
+  https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/DevDocs/how-signals-work.txt
+
+There's a custom debug api protocol between GDB and Cygwin to be able
+to intercept Cygwin signals before they're seen by the signaled
+thread, just like the debugger intercepts signals with ptrace on
+Linux.  This Cygwin debugger protocol isn't well documented, though.
+Here's what happens: when the special "sig" thread in the Cygwin
+runtime is about to deliver a signal to the target thread, it calls
+OutputDebugString with a special message:
+
+  https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1866
+
+OutputDebugString is a function that is part of the Windows debug API.
+It generates an OUTPUT_DEBUG_STRING_EVENT event out of
+WaitForDebugEvent in the debugger, which freezes the inferior, like
+any other event.
+
+GDB recognizes the special Cygwin signal marker string, and is able to
+report the intercepted Cygwin signal to the user.
+
+With the windows-nat backend in all-stop mode, if the user decides to
+single-step the signaled thread, GDB will set the trace flag in the
+signaled thread to force it to single-step, and then re-resume the
+program with ContinueDebugEvent.  This resumes both the signaled
+thread, and the special "sig" thread.  The special "sig" thread
+decides to make the signaled thread run the signal handler, so it
+suspends it with SuspendThread, does a read-modify-write operation
+with GetThreadContext/SetThreadContext, and then re-resumes it with
+ResumeThread.  This is all done here:
+
+   https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1011
+
+That resulting register context will still have its trace flag set, so
+the signaled thread ends up single-stepping the signal handler and
+reporting the trace stop to GDB, which reports the stop where the
+thread is now stopped, inside the signal handler.
+
+That is the intended behavior; stepping into a signal handler is a
+feature that works on other ports as well, including x86 GNU/Linux,
+for example.  This is exercised by the gdb.base/sigstep.exp testcase.
+
+Now, making that work with the backend in non-stop mode (the default
+on Windows 10 and above) is tricker.  In that case, when GDB sees the
+magic OUTPUT_DEBUG_STRING_EVENT event mentioned above, reported for
+the "sig" thread, GDB reports the signal stop for the target signaled
+thread to the user (leaving that thread stopped), but, unlike with an
+all-stop backend, in non-stop, only the evented/signaled thread should
+be stopped, so the backend would normally want to re-resume the Cygwin
+runtime's "sig" thread after handling the OUTPUT_DEBUG_STRING_EVENT
+event, like it does with any other event out of WaitForDebugEvent that
+is not reported to the core.  If it did that (resume the "sig" thread)
+however, at that point, the signaled thread would be stopped,
+suspended with SuspendThread by GDB (while the user is inspecting it),
+but, unlike in all-stop, the "sig" thread would be set running free.
+The "sig" thread would reach the code that wants to redirect the
+signaled thread's execution to the signal handler (by hacking the
+registers context, as described above), but unlike in the all-stop
+case, the "sig" thread would notice that the signaled thread is
+suspended, and so would decide to defer the signal handler until a
+later time.  It's the same code as described above for the all-stop
+case, except it would take the "then" branch:
+
+   https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1019
+
+   // Just set pending if thread is already suspended
+   if (res)
+     {
+       tls->unlock ();
+       ResumeThread (hth);
+       goto out;
+     }
+
+The result would be that when the GDB user later finally decides to
+step the signaled thread, the signaled thread would just single step
+the mainline code, instead of stepping into the signal handler.
+
+To avoid this difference of behavior in non-stop mode compared to
+all-stop mode, we use a trick -- whenever we see that magic
+OUTPUT_DEBUG_STRING_EVENT event reported for the "sig" thread, we
+report a stop for the target signaled thread, _and_ leave the "sig"
+thread suspended as well, for as long as the target signaled thread is
+suspended.  I.e., we don't let the "sig" thread run before the user
+decides what to do with the signaled thread's signal.  Only when the
+user re-resumes the signaled thread, will we resume the "sig" thread
+as well.  The trick is that all this is done here in the Windows
+backend, while providing the illusion to the core of GDB (and the
+user) that the "sig" thread is "running", for as long as the core
+wants the "sig" thread to be running.
+
+This isn't ideal, since this means that with user-visible non-stop,
+the inferior will only be able to process and report one signal at a
+time (as the "sig" thread is responsible for that), but that seems
+like an acceptible compromise, better than not being able to have the
+target work in non-stop by default on Cygwin.  */
+
 using namespace windows_nat;
 
 /* The current process.  */
@@ -335,6 +531,13 @@ windows_nat_target::add_thread (ptid_t ptid, HANDLE h, void *tlb,
      registers.  */
   th->debug_registers_changed = true;
 
+  /* Even if we're stopping the thread for some reason internal to
+     this module, from the perspective of infrun and the
+     user/frontend, this new thread is running until it next reports a
+     stop.  */
+  set_state (this, ptid, THREAD_RUNNING);
+  set_internal_state (this, ptid, THREAD_INT_RUNNING);
+
   return th;
 }
 
@@ -589,12 +792,17 @@ signal_event_command (const char *args, int from_tty)
 
 /* See nat/windows-nat.h.  */
 
-DWORD
+bool
 windows_per_inferior::handle_output_debug_string
   (const DEBUG_EVENT &current_event,
    struct target_waitstatus *ourstatus)
 {
-  DWORD thread_id = 0;
+  windows_thread_info *event_thr
+    = windows_process->find_thread (ptid_t (current_event.dwProcessId,
+					    current_event.dwThreadId));
+  if (event_thr->reply_later != 0)
+    internal_error ("OutputDebugString thread 0x%x has reply-later set",
+		    event_thr->tid);
 
   gdb::unique_xmalloc_ptr<char> s
     = (target_read_string
@@ -631,15 +839,37 @@ windows_per_inferior::handle_output_debug_string
       int sig = strtol (s.get () + sizeof (_CYGWIN_SIGNAL_STRING) - 1, &p, 0);
       gdb_signal gotasig = gdb_signal_from_host (sig);
       LPCVOID x = 0;
+      DWORD thread_id = 0;
 
-      if (gotasig)
+      if (gotasig != GDB_SIGNAL_0)
 	{
-	  ourstatus->set_stopped (gotasig);
 	  thread_id = strtoul (p, &p, 0);
-	  if (thread_id == 0)
-	    thread_id = current_event.dwThreadId;
-	  else
-	    x = (LPCVOID) (uintptr_t) strtoull (p, NULL, 0);
+	  if (thread_id != 0)
+	    {
+	      x = (LPCVOID) (uintptr_t) strtoull (p, NULL, 0);
+
+	      ptid_t ptid (current_event.dwProcessId, thread_id, 0);
+	      windows_thread_info *th = find_thread (ptid);
+
+	      /* Suspend the signaled thread, and leave the signal as
+		 a pending event.  It will be picked up by
+		 windows_nat_target::wait.  */
+	      th->suspend ();
+	      th->stopping = true;
+	      th->last_event = {};
+	      th->pending_status.set_stopped (gotasig);
+
+	      /* Link the "sig" thread and the signaled threads, so we
+		 can keep the "sig" thread suspended until we resume
+		 the signaled thread.  See "Cygwin signals" at the
+		 top.  */
+	      event_thr->signaled_thread = th;
+	      th->cygwin_sig_thread = event_thr;
+
+	      /* Leave the "sig" thread suspended.  */
+	      event_thr->suspend ();
+	      return true;
+	    }
 	}
 
       DEBUG_EVENTS ("gdb: cygwin signal %d, thread 0x%x, CONTEXT @ %p",
@@ -647,7 +877,7 @@ windows_per_inferior::handle_output_debug_string
     }
 #endif
 
-  return thread_id;
+  return false;
 }
 
 /* See nat/windows-nat.h.  */
@@ -680,9 +910,20 @@ void
 windows_nat_target::continue_one_thread (windows_thread_info *th,
 					 windows_continue_flags cont_flags)
 {
+  /* If this thread is already gone, but the core doesn't know about
+     it yet, there's really nothing to resume.  Such a thread will
+     have a pending exit status, so we won't try to resume it in the
+     normal resume path.  But, we can still end up here in the
+     kill/detach/mourn paths, trying to resume the whole process to
+     collect the last debug event.  */
+  if (th->h == nullptr)
+    return;
+
   bool killed = (cont_flags & WCONT_KILLED) != 0;
   thread_context_continue (th, killed);
+
   th->resume ();
+  th->stopping = false;
   th->last_sig = GDB_SIGNAL_0;
 }
 
@@ -694,31 +935,76 @@ BOOL
 windows_nat_target::windows_continue (DWORD continue_status, int id,
 				      windows_continue_flags cont_flags)
 {
+  if ((cont_flags & (WCONT_LAST_CALL | WCONT_KILLED)) == 0)
+    for (auto *th : all_windows_threads ())
+      {
+	if ((id == -1 || id == (int) th->tid)
+	    && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
+	  {
+	    DEBUG_EVENTS ("got matching pending stop event "
+			  "for 0x%x, not resuming",
+			  th->tid);
+
+	    /* There's no need to really continue, because there's already
+	       another event pending.  However, we do need to inform the
+	       event loop of this.  */
+	    serial_event_set (m_wait_event);
+	    return TRUE;
+	  }
+      }
+
+  /* Resume any suspended thread whose ID matches "ID".  Skip the
+     Cygwin "sig" thread in the main iteration, though.  That one is
+     only resumed when the target signaled thread is resumed.  See
+     "Cygwin signals" in the intro section.  */
   for (auto *th : all_windows_threads ())
+    if (th->suspended
+#ifdef __CYGWIN__
+	&& th->signaled_thread == nullptr
+#endif
+	&& (id == -1 || id == (int) th->tid))
+      {
+	continue_one_thread (th, cont_flags);
+
+#ifdef __CYGWIN__
+	/* See if we're resuming a thread that caught a Cygwin signal.
+	   If so, also resume the Cygwin runtime's "sig" thread.  */
+	if (th->cygwin_sig_thread != nullptr)
+	  {
+	    DEBUG_EVENTS ("\"sig\" thread %d (0x%x) blocked by "
+			  "just-resumed thread %d (0x%x)",
+			  th->cygwin_sig_thread->tid,
+			  th->cygwin_sig_thread->tid,
+			  th->tid, th->tid);
+
+	    inferior *inf = find_inferior_pid (this,
+					       windows_process->process_id);
+	    thread_info *sig_thr
+	      = inf->find_thread (ptid_t (windows_process->process_id,
+					  th->cygwin_sig_thread->tid));
+	    if (sig_thr->internal_state () == THREAD_INT_RUNNING)
+	      {
+		DEBUG_EVENTS ("\"sig\" thread %d (0x%x) meant to be running, "
+			      "continuing it now",
+			      th->cygwin_sig_thread->tid,
+			      th->cygwin_sig_thread->tid);
+		continue_one_thread (th->cygwin_sig_thread, cont_flags);
+	      }
+	    /* Break the chain.  */
+	    th->cygwin_sig_thread->signaled_thread = nullptr;
+	    th->cygwin_sig_thread = nullptr;
+	  }
+#endif
+      }
+
+  if (!target_is_non_stop_p ()
+      || (cont_flags & WCONT_CONTINUE_DEBUG_EVENT) != 0)
     {
-      if ((id == -1 || id == (int) th->tid)
-	  && !th->suspended
-	  && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
-	{
-	  DEBUG_EVENTS ("got matching pending stop event "
-			"for 0x%x, not resuming",
-			th->tid);
-
-	  /* There's no need to really continue, because there's already
-	     another event pending.  However, we do need to inform the
-	     event loop of this.  */
-	  serial_event_set (m_wait_event);
-	  return TRUE;
-	}
+      DEBUG_EVENTS ("windows_continue -> continue_last_debug_event");
+      continue_last_debug_event_main_thread
+	(_("Failed to resume program execution"), continue_status,
+	 cont_flags & WCONT_LAST_CALL);
     }
-
-  for (auto *th : all_windows_threads ())
-    if (id == -1 || id == (int) th->tid)
-      continue_one_thread (th, cont_flags);
-
-  continue_last_debug_event_main_thread
-    (_("Failed to resume program execution"), continue_status,
-     cont_flags & WCONT_LAST_CALL);
 
   return TRUE;
 }
@@ -746,36 +1032,46 @@ windows_nat_target::fake_create_process (const DEBUG_EVENT &current_event)
   return current_event.dwThreadId;
 }
 
-void
-windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
+/* Prepare TH to be resumed.  TH and TP must point at the same thread.
+   Records the right dwContinueStatus for SIG in th->reply_later if we
+   used DBG_REPLY_LATER before on this thread, and sets of clears the
+   trace flag according to STEP.  Also returns the dwContinueStatus
+   argument to pass to ContinueDebugEvent.  The thread is still left
+   suspended -- a subsequent windows_continue/continue_one_thread call
+   is needed to flush the thread's register context and unsuspend.  */
+
+DWORD
+windows_nat_target::prepare_resume (windows_thread_info *th,
+				    thread_info *tp,
+				    int step, gdb_signal sig)
 {
-  windows_thread_info *th;
+  gdb_assert (th->tid == tp->ptid.lwp ());
+
   DWORD continue_status = DBG_CONTINUE;
-
-  /* A specific PTID means `step only this thread id'.  */
-  int resume_all = ptid == minus_one_ptid;
-
-  /* If we're continuing all threads, it's the current inferior that
-     should be handled specially.  */
-  if (resume_all)
-    ptid = inferior_ptid;
-
-  DEBUG_EXEC ("pid=%d, tid=0x%x, step=%d, sig=%d",
-	      ptid.pid (), (unsigned) ptid.lwp (), step, sig);
-
-  /* Get currently selected thread.  */
-  th = windows_process->find_thread (inferior_ptid);
-  gdb_assert (th != nullptr);
 
   if (sig != GDB_SIGNAL_0)
     {
+      /* Allow continuing with the same signal that interrupted us.
+	 Otherwise complain.  */
+
       /* Note it is OK to call get_last_debug_event_ptid() from the
-	 main thread here, because we know the process_thread thread
-	 isn't waiting for an event at this point, so there's no data
-	 race.  */
-      if (inferior_ptid != get_last_debug_event_ptid ())
+	 main thread here in all-stop, because we know the
+	 process_thread thread is not waiting for an event at this
+	 point, so there is no data race.  We cannot call it in
+	 non-stop mode, as the process_thread thread _is_ waiting for
+	 events right now in that case.  However, the restriction does
+	 not exist in non-stop mode, so we don't even call it in that
+	 mode.  */
+      if (!target_is_non_stop_p ()
+	  && tp->ptid != get_last_debug_event_ptid ())
 	{
-	  /* ContinueDebugEvent will be for a different thread.  */
+	  /* In all-stop, ContinueDebugEvent will be for a different
+	     thread.  For non-stop, we've called ContinueDebugEvent
+	     with DBG_REPLY_LATER for this thread, so we just set the
+	     intended continue status in 'reply_later', which is later
+	     passed to ContinueDebugEvent in windows_nat_target::wait
+	     after we resume the thread and we get the replied-later
+	     (repeated) event out of WaitForDebugEvent.  */
 	  DEBUG_EXCEPT ("Cannot continue with signal %d here.  "
 			"Not last-event thread", sig);
 	}
@@ -811,18 +1107,52 @@ windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
 		    th->last_sig);
     }
 
-  /* Get context for currently selected thread.  */
-  if (step)
-    {
-      /* Single step by setting t bit.  */
-      regcache *regcache = get_thread_regcache (inferior_thread ());
-      struct gdbarch *gdbarch = regcache->arch ();
-      fetch_registers (regcache, gdbarch_ps_regnum (gdbarch));
-      thread_context_step (th);
-    }
+  /* If DBG_REPLY_LATER was used on the thread, we override the
+     continue status that will be passed to ContinueDebugEvent later
+     with the continue status we've just determined fulfils the
+     caller's resumption request.  Note that DBG_REPLY_LATER is only
+     used in non-stop mode, and in that mode, windows_continue (called
+     below) does not call ContinueDebugEvent.  */
+  if (th->reply_later != 0)
+    th->reply_later = continue_status;
 
-  /* Allow continuing with the same signal that interrupted us.
-     Otherwise complain.  */
+  /* Single step by setting t bit (trap flag).  The trap flag is
+     automatically reset as soon as the single-step exception arrives,
+     however, it's possible to suspend/stop a thread before it
+     executes any instruction, leaving the trace flag set.  If we
+     subsequently decide to continue such a thread instead of stepping
+     it, and we didn't clear the trap flag, the thread would step, and
+     we'd end up reporting a SIGTRAP to the core which the core
+     couldn't explain (because the thread wasn't supposed to be
+     stepping), and end up reporting a spurious SIGTRAP to the
+     user.  */
+  regcache *regcache = get_thread_regcache (inferior_thread ());
+  struct gdbarch *gdbarch = regcache->arch ();
+  fetch_registers (regcache, gdbarch_ps_regnum (gdbarch));
+  thread_context_step (th, step);
+
+  return continue_status;
+}
+
+void
+windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
+{
+  /* A specific PTID means `step only this thread id'.  */
+  int resume_all = ptid == minus_one_ptid;
+
+  /* If we're continuing all threads, it's the current inferior that
+     should be handled specially.  */
+  if (resume_all)
+    ptid = inferior_ptid;
+
+  DEBUG_EXEC ("pid=%d, tid=0x%x, step=%d, sig=%d",
+	      ptid.pid (), (unsigned) ptid.lwp (), step, sig);
+
+  /* Get currently selected thread.  */
+  windows_thread_info *th = windows_process->find_thread (inferior_ptid);
+  gdb_assert (th != nullptr);
+
+  DWORD continue_status = prepare_resume (th, inferior_thread (), step, sig);
 
   if (resume_all)
     windows_continue (continue_status, -1);
@@ -871,16 +1201,132 @@ windows_nat_target::interrupt ()
 	     "Press Ctrl-c in the program console."));
 }
 
+/* Stop thread TH.  This leaves a GDB_SIGNAL_0 pending in the thread,
+   which is later consumed by windows_nat_target::wait.  */
+
+void
+windows_nat_target::stop_one_thread (windows_thread_info *th)
+{
+  ptid_t thr_ptid (windows_process->process_id, th->tid);
+
+  if (th->suspended == -1)
+    {
+      /* Already known to be stopped; and suspension failed, most
+	 probably because the thread is exiting.  Do nothing, and let
+	 the thread exit event be reported.  */
+      DEBUG_EVENTS ("already suspended %s: suspended=%d, stopping=%d",
+		    thr_ptid.to_string ().c_str (),
+		    th->suspended, th->stopping);
+    }
+#ifdef __CYGWIN__
+  else if (th->suspended
+	   && th->signaled_thread != nullptr
+	   && th->pending_status.kind () == TARGET_WAITKIND_IGNORE)
+    {
+      DEBUG_EVENTS ("explict stop for \"sig\" thread %s held for signal",
+		    thr_ptid.to_string ().c_str ());
+
+      th->stopping = true;
+      th->pending_status.set_stopped (GDB_SIGNAL_0);
+      th->last_event = {};
+      serial_event_set (m_wait_event);
+    }
+#endif
+  else if (th->suspended)
+    {
+      /* Already known to be stopped; do nothing.  */
+
+      DEBUG_EVENTS ("already suspended %s: suspended=%d, stopping=%d",
+		    thr_ptid.to_string ().c_str (),
+		    th->suspended, th->stopping);
+
+      th->stopping = true;
+    }
+  else
+    {
+      DEBUG_EVENTS ("stop request for %s", thr_ptid.to_string ().c_str ());
+
+      th->suspend ();
+
+      /* If suspension failed, it means the thread is exiting.  Let
+	 the thread exit event be reported instead of faking our own
+	 stop.  */
+      if (th->suspended == -1)
+	{
+	  DEBUG_EVENTS ("suspension of %s failed, expect thread exit event",
+			thr_ptid.to_string ().c_str ());
+	  return;
+	}
+
+      gdb_assert (th->suspended == 1);
+
+      th->stopping = true;
+      th->pending_status.set_stopped (GDB_SIGNAL_0);
+      th->last_event = {};
+      serial_event_set (m_wait_event);
+    }
+}
+
+/* Implementation of target_ops::stop.  */
+
+void
+windows_nat_target::stop (ptid_t ptid)
+{
+  for (thread_info &thr : all_non_exited_threads (this))
+    {
+      if (thr.ptid.matches (ptid))
+	stop_one_thread (as_windows_thread_info (&thr));
+    }
+}
+
 void
 windows_nat_target::pass_ctrlc ()
 {
   interrupt ();
 }
 
+/* Implementation of the target_ops::thread_events method.  */
+
 void
-windows_nat_target::stop (ptid_t ptid)
+windows_nat_target::thread_events (bool enable)
 {
-  interrupt ();
+  DEBUG_EVENTS ("windows_nat_target::thread_events(%d)", enable);
+  m_report_thread_events = enable;
+}
+
+/* True if there is any resumed thread.  */
+
+bool
+windows_nat_target::any_resumed_thread ()
+{
+  for (thread_info &thread : all_non_exited_threads (this))
+    if (thread.internal_state () == THREAD_INT_RUNNING)
+      return true;
+  return false;
+}
+
+/* Called for both EXIT_THREAD_DEBUG_EVENT and
+   EXIT_PROCESS_DEBUG_EVENT to handle the fact that the event thread
+   has exited.  */
+
+static void
+handle_thread_exit (const DEBUG_EVENT &current_event)
+{
+  ptid_t ptid (current_event.dwProcessId, current_event.dwThreadId);
+  windows_thread_info *th = windows_process->find_thread (ptid);
+  gdb_assert (th != nullptr);
+
+  /* The handle is still valid, but it is going to be automatically
+     closed by Windows when we next call ContinueDebugEvent.  Fetch
+     the thread's registers while we still can.  For EXIT_PROCESS,
+     ContinueDebugEvent only happens at target_mourn_inferior time,
+     but do this not too, for consistency with EXIT_THREAD time.  */
+  windows_process->fill_thread_context (th);
+  th->h = nullptr;
+
+  /* The thread is gone, so no longer suspended from Windows's
+     perspective.  */
+  th->suspended = -1;
 }
 
 /* Get the next event from the child.  Returns the thread ptid.  */
@@ -896,22 +1342,30 @@ windows_nat_target::get_windows_debug_event
   /* If there is a relevant pending stop, report it now.  See the
      comment by the definition of "windows_thread_info::pending_status"
      for details on why this is needed.  */
-  for (auto *th : all_windows_threads ())
+  for (thread_info &thread : all_threads_safe ())
     {
-      if (!th->suspended
+      if (thread.inf->process_target () != this)
+	continue;
+
+      auto *th = as_windows_thread_info (&thread);
+      if (thread.internal_state () == THREAD_INT_RUNNING
+	  && th->suspended
 	  && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
 	{
-	  DEBUG_EVENTS ("reporting pending event for 0x%x", th->tid);
-
-	  thread_id = th->tid;
 	  *ourstatus = th->pending_status;
 	  th->pending_status.set_ignore ();
 	  *current_event = th->last_event;
-
-	  ptid_t ptid (windows_process->process_id, thread_id);
-	  windows_process->invalidate_thread_context (th);
-	  return ptid;
+	  DEBUG_EVENTS ("reporting pending event for 0x%x", th->tid);
+	  return thread.ptid;
 	}
+    }
+
+  /* If there are no resumed threads left, bail.  */
+  if (windows_process->windows_initialization_done
+      && !any_resumed_thread ())
+    {
+      ourstatus->set_no_resumed ();
+      return minus_one_ptid;
     }
 
   if ((options & TARGET_WNOHANG) != 0 && !m_debug_event_pending)
@@ -926,6 +1380,78 @@ windows_nat_target::get_windows_debug_event
 
   event_code = current_event->dwDebugEventCode;
   ourstatus->set_spurious ();
+
+  ptid_t result_ptid (current_event->dwProcessId,
+		      current_event->dwThreadId, 0);
+  windows_thread_info *result_th = windows_process->find_thread (result_ptid);
+
+  /* If we previously used DBG_REPLY_LATER on this thread, and we're
+     seeing an event for it, it means we've already processed the
+     event, and then subsequently resumed the thread [1], intending to
+     pass REPLY_LATER to ContinueDebugEvent.  Do that now, before the
+     switch table below, which may have side effects that don't make
+     sense for a delayed event.
+
+     [1] - with the caveat that sometimes Windows reports an event for
+     a suspended thread.  Also handled below.  */
+  if (result_th != nullptr && result_th->reply_later != 0)
+    {
+      DEBUG_EVENTS ("reply-later thread 0x%x, suspended=%d, dwDebugEventCode=%s",
+		    result_th->tid, result_th->suspended,
+		    event_code_to_string (event_code).c_str ());
+
+      gdb_assert (dbg_reply_later_available ());
+
+      /* We never ask to DBG_REPLY_LATER these two, so we shouldn't
+	 see them here.  If a thread is forced-exited when a
+	 DBG_REPLY_LATER is in effect, then we will still see the
+	 DBG_REPLY_LATER-ed event before the thread/process exit
+	 event.  */
+      gdb_assert (event_code != EXIT_THREAD_DEBUG_EVENT
+		  && event_code != EXIT_PROCESS_DEBUG_EVENT);
+
+      if (result_th->suspended == 1)
+	{
+	  /* Pending stop.  See the comment by the definition of
+	     "pending_status" for details on why this is needed.  */
+	  DEBUG_EVENTS ("unexpected reply-later stop in suspended thread 0x%x",
+			result_th->tid);
+
+	  /* Put the event back in the kernel queue.  We haven't yet
+	     decided which reply to use.  */
+	  continue_status = DBG_REPLY_LATER;
+	}
+      else if (result_th->suspended == -1)
+	{
+	  /* We resumed the thread expecting to get back a reply-later
+	     event.  Before we saw that event, we tried to suspend the
+	     thread, but that failed, because the thread exited
+	     (likely because the whole process has been killed).  We
+	     should get back an EXIT_THREAD_DEBUG_EVENT for this
+	     thread, but only after getting past this reply-later
+	     event.  */
+	  DEBUG_EVENTS ("reply-later stop in suspend-failed "
+			"thread 0x%x, ignoring",
+			result_th->tid);
+
+	  /* Continue normally, and expect a
+	     EXIT_THREAD_DEBUG_EVENT.  */
+	  continue_status = DBG_CONTINUE;
+	  result_th->reply_later = 0;
+	}
+      else
+	{
+	  continue_status = result_th->reply_later;
+	  result_th->reply_later = 0;
+	}
+
+      /* Go back to waiting for the next event.  */
+      continue_last_debug_event_main_thread
+	(_("Failed to continue reply-later event"), continue_status);
+
+      ourstatus->set_ignore ();
+      return null_ptid;
+    }
 
   DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
 		(unsigned) current_event->dwProcessId,
@@ -960,17 +1486,29 @@ windows_nat_target::get_windows_debug_event
 	      current_event->u.CreateThread.lpThreadLocalBase,
 	      false /* main_thread_p */));
 
-	/* This updates debug registers if necessary.  */
-	continue_one_thread (th, 0);
+	/* Update the debug registers if we're not reporting the stop.
+	   If we are (reporting the stop), the debug registers will be
+	   updated when the thread is eventually re-resumed.  */
+	if (m_report_thread_events)
+	  ourstatus->set_thread_created ();
+	else
+	  continue_one_thread (th, 0);
       }
       break;
 
     case EXIT_THREAD_DEBUG_EVENT:
-      delete_thread (ptid_t (current_event->dwProcessId,
-			     current_event->dwThreadId, 0),
-		     current_event->u.ExitThread.dwExitCode,
-		     false /* main_thread_p */);
-      thread_id = 0;
+      {
+	ourstatus->set_thread_exited
+	  (current_event->u.ExitThread.dwExitCode);
+	thread_id = current_event->dwThreadId;
+
+	handle_thread_exit (*current_event);
+
+	/* Don't decide yet whether to report the event, or delete the
+	   thread immediately, because we still need to check whether
+	   the event should be left pending, depending on whether the
+	   thread was running or not from the core's perspective.  */
+      }
       break;
 
     case CREATE_PROCESS_DEBUG_EVENT:
@@ -999,9 +1537,6 @@ windows_nat_target::get_windows_debug_event
 	}
       else if (windows_process->saw_create == 1)
 	{
-	  delete_thread (ptid_t (current_event->dwProcessId,
-				 current_event->dwThreadId, 0),
-			 0, true /* main_thread_p */);
 	  DWORD exit_status = current_event->u.ExitProcess.dwExitCode;
 	  /* If the exit status looks like a fatal exception, but we
 	     don't recognize the exception's code, make the original
@@ -1013,7 +1548,10 @@ windows_nat_target::get_windows_debug_event
 	    ourstatus->set_exited (exit_status);
 	  else
 	    ourstatus->set_signalled (gdb_signal_from_host (exit_signal));
-	  return ptid_t (current_event->dwProcessId);
+
+	  thread_id = current_event->dwThreadId;
+
+	  handle_thread_exit (*current_event);
 	}
       break;
 
@@ -1072,8 +1610,24 @@ windows_nat_target::get_windows_debug_event
     case OUTPUT_DEBUG_STRING_EVENT:	/* Message from the kernel.  */
       if (windows_process->saw_create != 1)
 	break;
-      thread_id = windows_process->handle_output_debug_string (*current_event,
-							       ourstatus);
+      if (windows_process->handle_output_debug_string (*current_event,
+						       ourstatus))
+	{
+	  /* We caught a Cygwin signal for a thread.  That thread now
+	     has a pending event, and the "sig" thread is
+	     suspended.  */
+	  serial_event_set (m_wait_event);
+
+	  /* In all-stop, return now to avoid reaching
+	     ContinueDebugEvent further below.  In all-stop, it's
+	     always windows_nat_target::resume that does the
+	     ContinueDebugEvent call.  */
+	  if (!target_is_non_stop_p ())
+	    {
+	      ourstatus->set_ignore ();
+	      return null_ptid;
+	    }
+	}
       break;
 
     default:
@@ -1095,32 +1649,76 @@ windows_nat_target::get_windows_debug_event
       return null_ptid;
     }
 
-  const ptid_t ptid = ptid_t (current_event->dwProcessId, thread_id, 0);
-  windows_thread_info *th = windows_process->find_thread (ptid);
+  const ptid_t ptid = ptid_t (current_event->dwProcessId, thread_id);
+  thread_info *thread = this->find_thread (ptid);
+  auto *th = as_windows_thread_info (thread);
 
   th->last_event = *current_event;
 
-  if (th->suspended)
+  if (thread->internal_state () == THREAD_INT_STOPPED)
     {
+      gdb_assert (th->suspended != 0);
+
       /* Pending stop.  See the comment by the definition of
 	 "pending_status" for details on why this is needed.  */
       DEBUG_EVENTS ("get_windows_debug_event - "
 		    "unexpected stop in suspended thread 0x%x",
 		    thread_id);
 
-      if (current_event->dwDebugEventCode == EXCEPTION_DEBUG_EVENT
-	  && is_sw_breakpoint (&current_event->u.Exception.ExceptionRecord)
-	  && windows_process->windows_initialization_done)
+      /* Use DBG_REPLY_LATER to put the event back in the kernel queue
+	 if possible.  Don't do that with exit-thread or exit-process
+	 events, because when a thread is dead, it can't be suspended
+	 anymore, so the kernel would immediately re-report the
+	 event.  */
+      if (event_code != EXIT_THREAD_DEBUG_EVENT
+	  && event_code != EXIT_PROCESS_DEBUG_EVENT
+	  && dbg_reply_later_available ())
 	{
-	  th->stopped_at_software_breakpoint = true;
-	  th->pc_adjusted = false;
+	  /* Thankfully, the Windows kernel doesn't immediately
+	     re-report the unexpected event for a suspended thread
+	     when we defer it with DBG_REPLY_LATER, otherwise this
+	     would get us stuck in an infinite loop re-processing the
+	     same unexpected event over and over.  (Which is what
+	     would happen if we used DBG_REPLY_LATER on an exit-thread
+	     or exit-process event.  See comment above.)  */
+	  continue_status = DBG_REPLY_LATER;
+	}
+      else
+	{
+	  if (current_event->dwDebugEventCode == EXCEPTION_DEBUG_EVENT
+	      && is_sw_breakpoint (&current_event->u.Exception.ExceptionRecord)
+	      && windows_process->windows_initialization_done)
+	    {
+	      th->stopped_at_software_breakpoint = true;
+	      th->pc_adjusted = false;
+	    }
+
+	  th->pending_status = *ourstatus;
+	  th->last_event = {};
 	}
 
-      th->pending_status = *ourstatus;
+      /* For exit-process, the debug event is continued later, at
+	 mourn time.  */
+      if (event_code != EXIT_PROCESS_DEBUG_EVENT)
+	{
+	  continue_last_debug_event_main_thread
+	    (_("Failed to resume program execution"), continue_status);
+	}
       ourstatus->set_ignore ();
+      return null_ptid;
+    }
 
-      continue_last_debug_event_main_thread
-	(_("Failed to resume program execution"), continue_status);
+  gdb_assert (thread->internal_state () == THREAD_INT_RUNNING);
+
+  /* Now that we've handled exit events for suspended threads (above),
+     we can finally decide whether to report the thread exit event or
+     just delete the thread without bothering the core.  */
+  if (ourstatus->kind () == TARGET_WAITKIND_THREAD_EXITED
+      && !m_report_thread_events)
+    {
+      delete_thread (ptid, ourstatus->exit_status (),
+		     false /* main_thread_p */);
+      ourstatus->set_spurious ();
       return null_ptid;
     }
 
@@ -1147,13 +1745,24 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 
   while (1)
     {
-      DEBUG_EVENT current_event;
+      DEBUG_EVENT current_event {};
 
       ptid_t result = get_windows_debug_event (pid, ourstatus, options,
 					       &current_event);
+      /* True if this is a pending event that we injected ourselves,
+	 instead of a real event out of WaitForDebugEvent.  */
+      bool fake = current_event.dwDebugEventCode == 0;
+
+      DEBUG_EVENTS ("get_windows_debug_event returned [%s : %s, fake=%d]",
+		    result.to_string ().c_str (),
+		    ourstatus->to_string ().c_str(),
+		    fake);
 
       if ((options & TARGET_WNOHANG) != 0
 	  && ourstatus->kind () == TARGET_WAITKIND_IGNORE)
+	return result;
+
+      if (ourstatus->kind () == TARGET_WAITKIND_NO_RESUMED)
 	return result;
 
       if (ourstatus->kind () == TARGET_WAITKIND_SPURIOUS)
@@ -1179,10 +1788,40 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 		  th->pc_adjusted = false;
 		}
 
+	      /* If non-stop, suspend the event thread, and continue
+		 it with DBG_REPLY_LATER, so the other threads go back
+		 to running as soon as possible.  Don't do this if
+		 stopping the thread, as in that case the thread was
+		 already suspended, and also there's no real Windows
+		 debug event to continue in that case.  */
+	      if (windows_process->windows_initialization_done
+		  && target_is_non_stop_p ()
+		  && !fake)
+		{
+		  if (ourstatus->kind () == TARGET_WAITKIND_THREAD_EXITED)
+		    {
+		      gdb_assert (th->suspended == -1);
+		      continue_last_debug_event_main_thread
+			(_("Init: Failed to DBG_CONTINUE after thread exit"),
+			 DBG_CONTINUE);
+		    }
+		  else
+		    {
+		      th->suspend ();
+		      th->reply_later = DBG_CONTINUE;
+		      continue_last_debug_event_main_thread
+			(_("Init: Failed to defer event with DBG_REPLY_LATER"),
+			 DBG_REPLY_LATER);
+		    }
+		}
+
 	      /* All-stop, suspend all threads until they are
 		 explicitly resumed.  */
-	      for (auto *thr : all_windows_threads ())
-		thr->suspend ();
+	      if (!target_is_non_stop_p ())
+		for (auto *thr : all_windows_threads ())
+		  thr->suspend ();
+
+	      th->stopping = false;
 	    }
 
 	  /* If something came out, assume there may be more.  This is
@@ -1234,22 +1873,31 @@ windows_nat_target::do_initial_windows_stuff (DWORD pid, bool attaching)
 
   ptid_t last_ptid;
 
+  /* Keep fetching events until we see the initial breakpoint (which
+     is planted by Windows itself) being reported.  */
+
   while (1)
     {
       struct target_waitstatus status;
 
       last_ptid = this->wait (minus_one_ptid, &status, 0);
 
-      /* Note windows_wait returns TARGET_WAITKIND_SPURIOUS for thread
-	 events.  */
-      if (status.kind () != TARGET_WAITKIND_LOADED
-	  && status.kind () != TARGET_WAITKIND_SPURIOUS)
+      /* These result in an error being thrown before we get here.  */
+      gdb_assert (status.kind () != TARGET_WAITKIND_EXITED
+		  && status.kind () != TARGET_WAITKIND_SIGNALLED);
+
+      /* We may also see TARGET_WAITKIND_THREAD_EXITED if
+	 target_thread_events is active (because another thread was
+	 stepping earlier, for example).  Ignore such events until we
+	 see the initial breakpoint.  */
+
+      if (status.kind () == TARGET_WAITKIND_STOPPED)
 	break;
 
       /* Don't use windows_nat_target::resume here because that
 	 assumes that inferior_ptid points at a valid thread, and we
 	 haven't switched to any thread yet.  */
-      windows_continue (DBG_CONTINUE, -1);
+      windows_continue (DBG_CONTINUE, -1, WCONT_CONTINUE_DEBUG_EVENT);
     }
 
   switch_to_thread (this->find_thread (last_ptid));
@@ -1400,7 +2048,21 @@ windows_nat_target::attach (const char *args, int from_tty)
      is normally more useful to the user than the injected thread.  */
   switch_to_thread (first_thread_of_inferior (current_inferior ()));
 
-  target_terminal::ours ();
+  if (target_is_non_stop_p ())
+    {
+      /* Leave all threads running.  */
+
+      continue_last_debug_event_main_thread
+	(_("Failed to DBG_CONTINUE after attach"),
+	 DBG_CONTINUE);
+    }
+  else
+    {
+      set_state (this, minus_one_ptid, THREAD_STOPPED);
+      set_internal_state (this, minus_one_ptid, THREAD_INT_STOPPED);
+
+      target_terminal::ours ();
+    }
 }
 
 void
@@ -1501,16 +2163,77 @@ windows_nat_target::break_out_process_thread (bool &process_alive)
 
       DEBUG_EVENTS ("got unrelated event, code %u",
 		    current_event.dwDebugEventCode);
-      windows_continue (DBG_CONTINUE, -1, 0);
+
+      DWORD continue_status
+	= continue_status_for_event_detaching (current_event);
+      windows_continue (continue_status, -1, WCONT_CONTINUE_DEBUG_EVENT);
     }
 
   if (injected_thread_handle != NULL)
     CHECK (CloseHandle (injected_thread_handle));
 }
 
+
+/* Used while detaching.  Decide whether to pass the exception or not.
+   Returns the dwContinueStatus argument to pass to
+   ContinueDebugEvent.  */
+
+DWORD
+windows_nat_target::continue_status_for_event_detaching
+  (const DEBUG_EVENT &event, size_t *reply_later_events_left)
+{
+  ptid_t ptid (event.dwProcessId, event.dwThreadId, 0);
+  windows_thread_info *th = windows_process->find_thread (ptid);
+
+  /* This can be a thread that we don't know about, as we're not
+     tracking thread creation events at this point.  */
+  if (th != nullptr && th->reply_later != 0)
+    {
+      DWORD res = th->reply_later;
+      th->reply_later = 0;
+      if (reply_later_events_left != nullptr)
+	(*reply_later_events_left)--;
+      return res;
+    }
+  else if (event.dwDebugEventCode == EXCEPTION_DEBUG_EVENT)
+    {
+      /* As the user asked to detach already, any new exception not
+	 seen by infrun before, is passed down to the inferior without
+	 considering "handle SIG pass/nopass".  We can just pretend
+	 the exception was raised after the inferior was detached.  */
+      return DBG_EXCEPTION_NOT_HANDLED;
+    }
+  else
+    return DBG_CONTINUE;
+}
+
 void
 windows_nat_target::detach (inferior *inf, int from_tty)
 {
+  DWORD continue_status = DBG_CONTINUE;
+
+  /* For any thread the core hasn't resumed, call prepare_resume with
+     the signal that the thread would be resumed with, so that we set
+     the right reply_later value, and also, so that we clear the trace
+     flag.  */
+  for (thread_info &thr : inf->non_exited_threads ())
+    {
+      if (thr.internal_state () != THREAD_INT_RUNNING)
+	{
+	  windows_thread_info *wth = windows_process->find_thread (thr.ptid);
+	  gdb_signal signo = get_detach_signal (this, thr.ptid);
+
+	  if (signo != wth->last_sig
+	      || (signo != GDB_SIGNAL_0 && !signal_pass_state (signo)))
+	    signo = GDB_SIGNAL_0;
+
+	  DWORD cstatus = prepare_resume (wth, &thr, 0, signo);
+
+	  if (!m_continued && thr.ptid == get_last_debug_event_ptid ())
+	    continue_status = cstatus;
+	}
+    }
+
   /* If we see the process exit while unblocking the process_thread
      helper thread, then we should skip the actual
      DebugActiveProcessStop call.  But don't report an error.  Just
@@ -1518,20 +2241,76 @@ windows_nat_target::detach (inferior *inf, int from_tty)
   bool process_alive = true;
 
   /* The process_thread helper thread will be blocked in
-     WaitForDebugEvent waiting for events if we've resumed the target
-     before we get here, e.g., with "attach&" or "c&".  We need to
-     unblock it so that we can have it call DebugActiveProcessStop
-     below, in the do_synchronously block.  */
+     WaitForDebugEvent waiting for events if we're in non-stop mode,
+     or if in all-stop and we've resumed the target before we get
+     here, e.g., with "attach&" or "c&".  We need to unblock it so
+     that we can have it call DebugActiveProcessStop below, in the
+     do_synchronously block.  */
   if (m_continued)
-    break_out_process_thread (process_alive);
+    {
+      break_out_process_thread (process_alive);
 
-  windows_continue (DBG_CONTINUE, -1, WCONT_LAST_CALL);
+      /* We're now either stopped at a thread exit event, or a process
+	 exit event.  */
+      continue_status = DBG_CONTINUE;
+    }
+
+  windows_continue (continue_status, -1,
+		    WCONT_LAST_CALL | WCONT_CONTINUE_DEBUG_EVENT);
 
   std::optional<unsigned> err;
   if (process_alive)
     do_synchronously ([&] ()
       {
-	if (!DebugActiveProcessStop (windows_process->process_id))
+	/* The kernel re-raises any exception previously intercepted
+	   and deferred with DBG_REPLY_LATER in the inferior after we
+	   detach.  We need to flush those, and suppress those which
+	   aren't meant to be seen by the inferior (e.g., breakpoints,
+	   single-steps, any with matching "handle SIG nopass", etc.),
+	   otherwise the inferior dies immediately after the detach,
+	   due to an unhandled exception.  */
+	DEBUG_EVENT event;
+
+	/* Count how many threads have pending reply-later events.  */
+	size_t reply_later_events_left = 0;
+	for (auto *th : all_windows_threads ())
+	  if (th->reply_later != 0)
+	    reply_later_events_left++;
+
+	DEBUG_EVENTS ("flushing %zu reply-later events",
+		      reply_later_events_left);
+
+	/* Note we have to use a blocking wait (hence the need for the
+	   counter).  Just polling (timeout=0) until WaitForDebugEvent
+	   returns false would be racy -- the kernel may take a little
+	   bit to put the events in the pending queue.  That has been
+	   observed on Windows 11, where detaching would still very
+	   occasionally result in the inferior dying after the detach
+	   due to a reply-later event.  */
+	while (reply_later_events_left > 0
+	       && wait_for_debug_event (&event, INFINITE))
+	  {
+	    DEBUG_EVENTS ("flushed kernel event code %u",
+			  event.dwDebugEventCode);
+
+	    DWORD cstatus = (continue_status_for_event_detaching
+			     (event, &reply_later_events_left));
+	    if (!continue_last_debug_event (cstatus, debug_events))
+	      {
+		err = (unsigned) GetLastError ();
+		return false;
+	      }
+
+	    if (event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
+	      {
+		DEBUG_EVENTS ("got EXIT_PROCESS_DEBUG_EVENT, skipping detach");
+		process_alive = false;
+		break;
+	      }
+	  }
+
+	if (process_alive
+	    && !DebugActiveProcessStop (windows_process->process_id))
 	  err = (unsigned) GetLastError ();
 	else
 	  DebugSetProcessKillOnExit (FALSE);
@@ -2271,13 +3050,32 @@ windows_nat_target::create_inferior (const char *exec_file,
 
   do_initial_windows_stuff (pi.dwProcessId, 0);
 
-  /* windows_continue (DBG_CONTINUE, -1); */
+  /* Present the initial thread as stopped to the core.  */
+  windows_thread_info *th = windows_process->find_thread (inferior_ptid);
+
+  th->suspend ();
+  set_state (this, inferior_ptid, THREAD_STOPPED);
+  set_internal_state (this, inferior_ptid, THREAD_INT_STOPPED);
+
+  if (target_is_non_stop_p ())
+    {
+      /* In non-stop mode, we always immediately use DBG_REPLY_LATER
+	 on threads as soon as they report an event.  However, during
+	 the initial startup, windows_nat_target::wait does not do
+	 this, so we need to handle it here for the initial
+	 thread.  */
+      th->reply_later = DBG_CONTINUE;
+      continue_last_debug_event_main_thread
+	(_("Failed to defer event with DBG_REPLY_LATER"),
+	 DBG_REPLY_LATER);
+    }
 }
 
 void
 windows_nat_target::mourn_inferior ()
 {
-  windows_continue (DBG_CONTINUE, -1, WCONT_LAST_CALL);
+  windows_continue (DBG_CONTINUE, -1,
+		    WCONT_LAST_CALL | WCONT_CONTINUE_DEBUG_EVENT);
   cleanup_windows_arch ();
   if (windows_process->open_process_used)
     {
@@ -2327,19 +3125,55 @@ windows_xfer_memory (gdb_byte *readbuf, const gdb_byte *writebuf,
     return success ? TARGET_XFER_OK : TARGET_XFER_E_IO;
 }
 
+/* Return true if all the threads of the process have already
+   exited.  */
+
+static bool
+already_dead ()
+{
+  for (windows_thread_info *th : all_windows_threads ())
+    if (th->h != nullptr)
+      return false;
+  return true;
+}
+
 void
 windows_nat_target::kill ()
 {
+  /* If all the threads of the process have already exited, there is
+     really nothing to kill.  This can happen with e.g., scheduler
+     locking, where the thread exit events for all threads are still
+     pending to be processed by the core.  */
+  if (already_dead ())
+    {
+      target_mourn_inferior (inferior_ptid);
+      return;
+    }
+
   CHECK (TerminateProcess (windows_process->handle, 137));
+
+  /* In non-stop mode, windows_continue does not call
+     ContinueDebugEvent by default.  This behavior is appropriate for
+     the first call to windows_continue because any thread that is
+     stopped has already been ContinueDebugEvent'ed with
+     DBG_REPLY_LATER.  However, after the first
+     wait_for_debug_event_main_thread call in the loop, this will no
+     longer be true.
+
+     In all-stop mode, the WCONT_CONTINUE_DEBUG_EVENT flag has no
+     effect, so writing the code in this way ensures that the code is
+     the same for both modes.  */
+  windows_continue_flags flags = WCONT_KILLED;
 
   for (;;)
     {
-      if (!windows_continue (DBG_CONTINUE, -1, WCONT_KILLED))
+      if (!windows_continue (DBG_CONTINUE, -1, flags))
 	break;
       DEBUG_EVENT current_event;
       wait_for_debug_event_main_thread (&current_event);
       if (current_event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
 	break;
+      flags |= WCONT_CONTINUE_DEBUG_EVENT;
     }
 
   target_mourn_inferior (inferior_ptid);	/* Or just windows_mourn_inferior?  */
@@ -2473,6 +3307,15 @@ windows_nat_target::thread_name (struct thread_info *thr)
   return th->thread_name ();
 }
 
+/* Implementation of the target_ops::supports_non_stop method.  */
+
+bool
+windows_nat_target::supports_non_stop ()
+{
+  /* Non-stop support requires DBG_REPLY_LATER, which only exists on
+     Windows 10 and later.  */
+  return dbg_reply_later_available ();
+}
 
 INIT_GDB_FILE (windows_nat)
 {

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -3345,6 +3345,27 @@ windows_nat_target::thread_name (struct thread_info *thr)
   return th->thread_name ();
 }
 
+/* Implementation of the target_ops::extra_thread_info method.  */
+
+const char *
+windows_nat_target::extra_thread_info (thread_info *info)
+{
+  windows_thread_info *th = windows_process->find_thread (info->ptid);
+
+  if (!th->suspended)
+    return nullptr;
+
+  if (th->pending_status.kind () == TARGET_WAITKIND_THREAD_EXITED
+      || th->last_event.dwDebugEventCode == EXIT_THREAD_DEBUG_EVENT)
+    return "exiting";
+  else if (th->pending_status.kind () == TARGET_WAITKIND_EXITED
+	   || th->pending_status.kind () == TARGET_WAITKIND_SIGNALLED
+	   || th->last_event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
+    return "exiting process";
+
+  return nullptr;
+}
+
 /* Implementation of the target_ops::supports_non_stop method.  */
 
 bool

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -927,13 +927,14 @@ windows_nat_target::get_windows_debug_event
   event_code = current_event->dwDebugEventCode;
   ourstatus->set_spurious ();
 
+  DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
+		(unsigned) current_event->dwProcessId,
+		(unsigned) current_event->dwThreadId,
+		event_code_to_string (event_code).c_str ());
+
   switch (event_code)
     {
     case CREATE_THREAD_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "CREATE_THREAD_DEBUG_EVENT");
       if (windows_process->saw_create != 1)
 	{
 	  inferior *inf = find_inferior_pid (this, current_event->dwProcessId);
@@ -965,10 +966,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case EXIT_THREAD_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXIT_THREAD_DEBUG_EVENT");
       delete_thread (ptid_t (current_event->dwProcessId,
 			     current_event->dwThreadId, 0),
 		     current_event->u.ExitThread.dwExitCode,
@@ -977,10 +974,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case CREATE_PROCESS_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "CREATE_PROCESS_DEBUG_EVENT");
       CloseHandle (current_event->u.CreateProcessInfo.hFile);
       if (++windows_process->saw_create != 1)
 	break;
@@ -997,10 +990,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case EXIT_PROCESS_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXIT_PROCESS_DEBUG_EVENT");
       if (!windows_process->windows_initialization_done)
 	{
 	  target_terminal::ours ();
@@ -1029,10 +1018,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case LOAD_DLL_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "LOAD_DLL_DEBUG_EVENT");
       CloseHandle (current_event->u.LoadDll.hFile);
       if (windows_process->saw_create != 1
 	  || ! windows_process->windows_initialization_done)
@@ -1050,10 +1035,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case UNLOAD_DLL_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "UNLOAD_DLL_DEBUG_EVENT");
       if (windows_process->saw_create != 1
 	  || ! windows_process->windows_initialization_done)
 	break;
@@ -1070,10 +1051,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case EXCEPTION_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXCEPTION_DEBUG_EVENT");
       if (windows_process->saw_create != 1)
 	break;
       switch (windows_process->handle_exception (*current_event,
@@ -1093,10 +1070,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case OUTPUT_DEBUG_STRING_EVENT:	/* Message from the kernel.  */
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "OUTPUT_DEBUG_STRING_EVENT");
       if (windows_process->saw_create != 1)
 	break;
       thread_id = windows_process->handle_output_debug_string (*current_event,

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -66,6 +66,202 @@
 #include "gdbsupport/symbol.h"
 #include "inf-loop.h"
 
+/* This comment documents high-level logic of this file.
+
+all-stop
+========
+
+In all-stop mode ("maint set target-non-stop off"), there is only ever
+one Windows debug event in flight. When we receive an event from
+WaitForDebugEvent, the kernel has already implicitly suspended all the
+threads of the process.  We report the breaking event to the core.
+When the core decides to resume the inferior, it calls
+windows_nat_target:resume, which triggers a ContinueDebugEvent call.
+This call makes all unsuspended threads schedulable again, and we go
+back to waiting for the next event in WaitForDebugEvent.
+
+non-stop
+========
+
+For non-stop mode, we utilize the DBG_REPLY_LATER flag in the
+ContinueDebugEvent function.  According to Microsoft:
+
+ "This flag causes dwThreadId to replay the existing breaking event
+ after the target continues.  By calling the SuspendThread API against
+ dwThreadId, a debugger can resume other threads in the process and
+ later return to the breaking."
+
+To enable non-stop mode, windows_nat_target::wait suspends the thread,
+calls 'ContinueForDebugEvent(..., DBG_REPLY_LATER)', and sets the
+process_thread thread to wait for the next event using
+WaitForDebugEvent, all before returning the original breaking event to
+the core.
+
+When the user/core finally decides to resume the inferior thread that
+reported the event, we unsuspend it using ResumeThread.  Unlike in
+all-stop mode, we don't call ContinueDebugEvent then, as it has
+already been called when the event was first encountered.  By making
+the inferior thread schedulable again (by unsuspending it),
+WaitForDebugEvent re-reports the same event (due to the earlier
+DBG_REPLY_LATER).  In windows_nat_target::wait, we detect this delayed
+re-report and call ContinueDebugEvent on the thread, instructing the
+"process_thread" thread (the GDB thread responsible for calling
+WaitForDebugEvents) to continue waiting for the next event.
+
+During the initial thread resumption in windows_nat_target::resume, we
+recorded the dwContinueStatus argument to be passed to the last
+ContinueDebugEvent (called when the reply-later event is re-reported).
+See windows_thread_info::reply_later for details.
+
+Note that with this setup, in non-stop mode, every stopped thread has
+its own independent last-reported Windows debug event.  Therefore, we
+can decide on a per-thread basis whether to pass the thread's
+exception (DBG_EXCEPTION_NOT_HANDLED / DBG_CONTINUE) to the inferior.
+This per-thread decision is not possible in all-stop mode, where we
+only call ContinueDebugEvent for the thread that last reported a stop,
+at windows_nat_target::resume time.
+
+Thread and process exits
+========================
+
+When a process exits, Windows reports one EXIT_THREAD_DEBUG_EVENT
+event for each thread, except for the last thread that exits.  That
+last thread reports a EXIT_PROCESS_DEBUG_EVENT event instead.
+
+The last thread that exits is not guaranteed to be the main thread of
+the process.  In fact, it seldom is.  E.g., if the main thread calls
+ExitProcess (or returns from main, which ends up calling ExitProcess),
+then we typically see a EXIT_THREAD_DEBUG_EVENT event for the main
+thread first, followed by more EXIT_THREAD_DEBUG_EVENT events for
+other threads, and then finaly the EXIT_PROCESS_DEBUG_EVENT for
+whatever thread happened to be the last one to exit.
+
+When a thread reports EXIT_THREAD_DEBUG_EVENT /
+EXIT_PROCESS_DEBUG_EVENT, our handle to the thread is still valid, and
+we can still read its registers.  Windows only destroys the handle
+after ContinueDebugEvent.
+
+A thread that has exited CANNOT be suspended.  So if a thread was
+previously suspended, and then something kills the whole process
+(which force-kills all threads), that suspended thread will
+automatically "unsuspend", and report a EXIT_THREAD_DEBUG_EVENT event.
+However, if we had previously used DBG_REPLY_LATER on the thread,
+Windows will first re-report the kernel-side-queued "reply-later"
+event, and only after that one is ContinueDebugEvent'ed, will we see
+the EXIT_THREAD_DEBUG_EVENT event.
+
+Detaching and DBG_REPLY_LATER
+=============================
+
+After we detach from a process that has threads that we had previously
+used DBG_REPLY_LATER on, the kernel re-raises the "reply-later"
+exceptions for those threads.  This would most often kill the
+just-detached process, if we let it happen.  To prevent it, we flush
+all the "reply-later" events from the kernel before detaching.
+
+Cygwin signals
+==============
+
+The Cygwin runtime always spawns a "sig" thread, which is responsible
+for receiving signal delivery requests, and hijacking the signaled
+thread's execution to make it run the signal handler.  This is all
+explained here:
+
+  https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/DevDocs/how-signals-work.txt
+
+There's a custom debug api protocol between GDB and Cygwin to be able
+to intercept Cygwin signals before they're seen by the signaled
+thread, just like the debugger intercepts signals with ptrace on
+Linux.  This Cygwin debugger protocol isn't well documented, though.
+Here's what happens: when the special "sig" thread in the Cygwin
+runtime is about to deliver a signal to the target thread, it calls
+OutputDebugString with a special message:
+
+  https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1866
+
+OutputDebugString is a function that is part of the Windows debug API.
+It generates an OUTPUT_DEBUG_STRING_EVENT event out of
+WaitForDebugEvent in the debugger, which freezes the inferior, like
+any other event.
+
+GDB recognizes the special Cygwin signal marker string, and is able to
+report the intercepted Cygwin signal to the user.
+
+With the windows-nat backend in all-stop mode, if the user decides to
+single-step the signaled thread, GDB will set the trace flag in the
+signaled thread to force it to single-step, and then re-resume the
+program with ContinueDebugEvent.  This resumes both the signaled
+thread, and the special "sig" thread.  The special "sig" thread
+decides to make the signaled thread run the signal handler, so it
+suspends it with SuspendThread, does a read-modify-write operation
+with GetThreadContext/SetThreadContext, and then re-resumes it with
+ResumeThread.  This is all done here:
+
+   https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1011
+
+That resulting register context will still have its trace flag set, so
+the signaled thread ends up single-stepping the signal handler and
+reporting the trace stop to GDB, which reports the stop where the
+thread is now stopped, inside the signal handler.
+
+That is the intended behavior; stepping into a signal handler is a
+feature that works on other ports as well, including x86 GNU/Linux,
+for example.  This is exercised by the gdb.base/sigstep.exp testcase.
+
+Now, making that work with the backend in non-stop mode (the default
+on Windows 10 and above) is tricker.  In that case, when GDB sees the
+magic OUTPUT_DEBUG_STRING_EVENT event mentioned above, reported for
+the "sig" thread, GDB reports the signal stop for the target signaled
+thread to the user (leaving that thread stopped), but, unlike with an
+all-stop backend, in non-stop, only the evented/signaled thread should
+be stopped, so the backend would normally want to re-resume the Cygwin
+runtime's "sig" thread after handling the OUTPUT_DEBUG_STRING_EVENT
+event, like it does with any other event out of WaitForDebugEvent that
+is not reported to the core.  If it did that (resume the "sig" thread)
+however, at that point, the signaled thread would be stopped,
+suspended with SuspendThread by GDB (while the user is inspecting it),
+but, unlike in all-stop, the "sig" thread would be set running free.
+The "sig" thread would reach the code that wants to redirect the
+signaled thread's execution to the signal handler (by hacking the
+registers context, as described above), but unlike in the all-stop
+case, the "sig" thread would notice that the signaled thread is
+suspended, and so would decide to defer the signal handler until a
+later time.  It's the same code as described above for the all-stop
+case, except it would take the "then" branch:
+
+   https://sourceware.org/cgit/newlib-cygwin/tree/winsup/cygwin/exceptions.cc?id=4becae7bd833e183c789821a477f25898ed0db1f#n1019
+
+   // Just set pending if thread is already suspended
+   if (res)
+     {
+       tls->unlock ();
+       ResumeThread (hth);
+       goto out;
+     }
+
+The result would be that when the GDB user later finally decides to
+step the signaled thread, the signaled thread would just single step
+the mainline code, instead of stepping into the signal handler.
+
+To avoid this difference of behavior in non-stop mode compared to
+all-stop mode, we use a trick -- whenever we see that magic
+OUTPUT_DEBUG_STRING_EVENT event reported for the "sig" thread, we
+report a stop for the target signaled thread, _and_ leave the "sig"
+thread suspended as well, for as long as the target signaled thread is
+suspended.  I.e., we don't let the "sig" thread run before the user
+decides what to do with the signaled thread's signal.  Only when the
+user re-resumes the signaled thread, will we resume the "sig" thread
+as well.  The trick is that all this is done here in the Windows
+backend, while providing the illusion to the core of GDB (and the
+user) that the "sig" thread is "running", for as long as the core
+wants the "sig" thread to be running.
+
+This isn't ideal, since this means that with user-visible non-stop,
+the inferior will only be able to process and report one signal at a
+time (as the "sig" thread is responsible for that), but that seems
+like an acceptible compromise, better than not being able to have the
+target work in non-stop by default on Cygwin.  */
+
 using namespace windows_nat;
 
 /* The current process.  */
@@ -272,15 +468,23 @@ windows_nat_target::continue_last_debug_event_main_thread
   m_continued = !last_call;
 }
 
+/* Return a pointer to the windows-nat target instance.  */
+
+static windows_nat_target *
+get_windows_nat_target ()
+{
+  return gdb::checked_static_cast<windows_nat_target *> (get_native_target ());
+}
+
 /* See nat/windows-nat.h.  */
 
 windows_thread_info *
 windows_per_inferior::find_thread (ptid_t ptid)
 {
-  for (auto &th : thread_list)
-    if (th->tid == ptid.lwp ())
-      return th.get ();
-  return nullptr;
+  thread_info *thr = get_windows_nat_target ()->find_thread (ptid);
+  if (thr == nullptr)
+    return nullptr;
+  return as_windows_thread_info (thr);
 }
 
 /* See nat/windows-nat.h.  */
@@ -297,12 +501,11 @@ windows_thread_info *
 windows_nat_target::add_thread (ptid_t ptid, HANDLE h, void *tlb,
 				bool main_thread_p)
 {
-  windows_thread_info *th;
-
   gdb_assert (ptid.lwp () != 0);
 
-  if ((th = windows_process->find_thread (ptid)))
-    return th;
+  windows_thread_info *existing = windows_process->find_thread (ptid);
+  if (existing != nullptr)
+    return existing;
 
   CORE_ADDR base = (CORE_ADDR) (uintptr_t) tlb;
 #ifdef __x86_64__
@@ -311,33 +514,31 @@ windows_nat_target::add_thread (ptid_t ptid, HANDLE h, void *tlb,
   if (windows_process->wow64_process)
     base += 0x2000;
 #endif
-  th = new windows_thread_info (windows_process, ptid.lwp (), h, base);
-  windows_process->thread_list.emplace_back (th);
+  windows_private_thread_info *th
+    = new windows_private_thread_info (windows_process, ptid.lwp (), h, base);
 
   /* Add this new thread to the list of threads.
 
      To be consistent with what's done on other platforms, we add
      the main thread silently (in reality, this thread is really
      more of a process to the user than a thread).  */
-  if (main_thread_p)
-    add_thread_silent (this, ptid);
-  else
-    ::add_thread (this, ptid);
+  thread_info *gth = (main_thread_p
+		      ? ::add_thread_silent (this, ptid)
+		      : ::add_thread (this, ptid));
+  gth->priv.reset (th);
 
   /* It's simplest to always set this and update the debug
      registers.  */
   th->debug_registers_changed = true;
 
-  return th;
-}
+  /* Even if we're stopping the thread for some reason internal to
+     this module, from the perspective of infrun and the
+     user/frontend, this new thread is running until it next reports a
+     stop.  */
+  set_state (this, ptid, THREAD_RUNNING);
+  set_internal_state (this, ptid, THREAD_INT_RUNNING);
 
-/* Clear out any old thread list and reinitialize it to a
-   pristine state.  */
-static void
-windows_init_thread_list (void)
-{
-  DEBUG_EVENTS ("called");
-  windows_process->thread_list.clear ();
+  return th;
 }
 
 /* Delete a thread from the list of threads.
@@ -351,12 +552,6 @@ void
 windows_nat_target::delete_thread (ptid_t ptid, DWORD exit_code,
 				   bool main_thread_p)
 {
-  DWORD id;
-
-  gdb_assert (ptid.lwp () != 0);
-
-  id = ptid.lwp ();
-
   /* Note that no notification was printed when the main thread was
      created, and thus, unless in verbose mode, we should be symmetrical,
      and avoid an exit notification for the main thread here as well.  */
@@ -364,16 +559,6 @@ windows_nat_target::delete_thread (ptid_t ptid, DWORD exit_code,
   bool silent = (main_thread_p && !info_verbose);
   thread_info *to_del = this->find_thread (ptid);
   delete_thread_with_exit_code (to_del, exit_code, silent);
-
-  auto iter = std::find_if (windows_process->thread_list.begin (),
-			    windows_process->thread_list.end (),
-			    [=] (std::unique_ptr<windows_thread_info> &th)
-			    {
-			      return th->tid == id;
-			    });
-
-  if (iter != windows_process->thread_list.end ())
-    windows_process->thread_list.erase (iter);
 }
 
 void
@@ -607,12 +792,17 @@ signal_event_command (const char *args, int from_tty)
 
 /* See nat/windows-nat.h.  */
 
-DWORD
+bool
 windows_per_inferior::handle_output_debug_string
   (const DEBUG_EVENT &current_event,
    struct target_waitstatus *ourstatus)
 {
-  DWORD thread_id = 0;
+  windows_thread_info *event_thr
+    = windows_process->find_thread (ptid_t (current_event.dwProcessId,
+					    current_event.dwThreadId));
+  if (event_thr->reply_later != 0)
+    internal_error ("OutputDebugString thread 0x%x has reply-later set",
+		    event_thr->tid);
 
   gdb::unique_xmalloc_ptr<char> s
     = (target_read_string
@@ -649,15 +839,37 @@ windows_per_inferior::handle_output_debug_string
       int sig = strtol (s.get () + sizeof (_CYGWIN_SIGNAL_STRING) - 1, &p, 0);
       gdb_signal gotasig = gdb_signal_from_host (sig);
       LPCVOID x = 0;
+      DWORD thread_id = 0;
 
-      if (gotasig)
+      if (gotasig != GDB_SIGNAL_0)
 	{
-	  ourstatus->set_stopped (gotasig);
 	  thread_id = strtoul (p, &p, 0);
-	  if (thread_id == 0)
-	    thread_id = current_event.dwThreadId;
-	  else
-	    x = (LPCVOID) (uintptr_t) strtoull (p, NULL, 0);
+	  if (thread_id != 0)
+	    {
+	      x = (LPCVOID) (uintptr_t) strtoull (p, NULL, 0);
+
+	      ptid_t ptid (current_event.dwProcessId, thread_id, 0);
+	      windows_thread_info *th = find_thread (ptid);
+
+	      /* Suspend the signaled thread, and leave the signal as
+		 a pending event.  It will be picked up by
+		 windows_nat_target::wait.  */
+	      th->suspend ();
+	      th->stopping = SK_EXTERNAL;
+	      th->last_event = {};
+	      th->pending_status.set_stopped (gotasig);
+
+	      /* Link the "sig" thread and the signaled threads, so we
+		 can keep the "sig" thread suspended until we resume
+		 the signaled thread.  See "Cygwin signals" at the
+		 top.  */
+	      event_thr->signaled_thread = th;
+	      th->cygwin_sig_thread = event_thr;
+
+	      /* Leave the "sig" thread suspended.  */
+	      event_thr->suspend ();
+	      return true;
+	    }
 	}
 
       DEBUG_EVENTS ("gdb: cygwin signal %d, thread 0x%x, CONTEXT @ %p",
@@ -665,7 +877,7 @@ windows_per_inferior::handle_output_debug_string
     }
 #endif
 
-  return thread_id;
+  return false;
 }
 
 /* See nat/windows-nat.h.  */
@@ -698,9 +910,20 @@ void
 windows_nat_target::continue_one_thread (windows_thread_info *th,
 					 windows_continue_flags cont_flags)
 {
+  /* If this thread is already gone, but the core doesn't know about
+     it yet, there's really nothing to resume.  Such a thread will
+     have a pending exit status, so we won't try to resume it in the
+     normal resume path.  But, we can still end up here in the
+     kill/detach/mourn paths, trying to resume the whole process to
+     collect the last debug event.  */
+  if (th->h == nullptr)
+    return;
+
   bool killed = (cont_flags & WCONT_KILLED) != 0;
   thread_context_continue (th, killed);
+
   th->resume ();
+  th->stopping = SK_NOT_STOPPING;
   th->last_sig = GDB_SIGNAL_0;
 }
 
@@ -712,31 +935,87 @@ BOOL
 windows_nat_target::windows_continue (DWORD continue_status, int id,
 				      windows_continue_flags cont_flags)
 {
-  for (auto &th : windows_process->thread_list)
+  if ((cont_flags & (WCONT_LAST_CALL | WCONT_KILLED)) == 0)
+    for (auto *th : all_windows_threads ())
+      {
+	if ((id == -1 || id == (int) th->tid)
+	    && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
+	  {
+	    DEBUG_EVENTS ("got matching pending stop event "
+			  "for 0x%x, not resuming",
+			  th->tid);
+
+	    /* There's no need to really continue, because there's already
+	       another event pending.  However, we do need to inform the
+	       event loop of this.  */
+	    serial_event_set (m_wait_event);
+	    return TRUE;
+	  }
+      }
+
+  /* Resume any suspended thread whose ID matches "ID".  Skip the
+     Cygwin "sig" thread in the main iteration, though.  That one is
+     only resumed when the target signaled thread is resumed.  See
+     "Cygwin signals" in the intro section.  */
+  for (auto *th : all_windows_threads ())
+    if (th->suspended
+#ifdef __CYGWIN__
+	&& th->signaled_thread == nullptr
+#endif
+	&& (id == -1 || id == (int) th->tid))
+      {
+	continue_one_thread (th, cont_flags);
+
+#ifdef __CYGWIN__
+	/* See if we're resuming a thread that caught a Cygwin signal.
+	   If so, also resume the Cygwin runtime's "sig" thread.  */
+	if (th->cygwin_sig_thread != nullptr)
+	  {
+	    DEBUG_EVENTS ("\"sig\" thread %d (0x%x) blocked by "
+			  "just-resumed thread %d (0x%x)",
+			  th->cygwin_sig_thread->tid,
+			  th->cygwin_sig_thread->tid,
+			  th->tid, th->tid);
+
+	    inferior *inf = find_inferior_pid (this,
+					       windows_process->process_id);
+	    thread_info *sig_thr
+	      = inf->find_thread (ptid_t (windows_process->process_id,
+					  th->cygwin_sig_thread->tid));
+	    if (sig_thr->internal_state () == THREAD_INT_RUNNING)
+	      {
+		DEBUG_EVENTS ("\"sig\" thread %d (0x%x) meant to be running, "
+			      "continuing it now",
+			      th->cygwin_sig_thread->tid,
+			      th->cygwin_sig_thread->tid);
+		continue_one_thread (th->cygwin_sig_thread, cont_flags);
+	      }
+	    /* Break the chain.  */
+	    th->cygwin_sig_thread->signaled_thread = nullptr;
+	    th->cygwin_sig_thread = nullptr;
+	  }
+#endif
+      }
+
+  /* WCONT_DONT_CONTINUE_DEBUG_EVENT and WCONT_CONTINUE_DEBUG_EVENT
+     can't both be enabled at the same time.  */
+  gdb_assert ((cont_flags & WCONT_DONT_CONTINUE_DEBUG_EVENT) == 0
+	      || (cont_flags & WCONT_CONTINUE_DEBUG_EVENT) == 0);
+
+  bool continue_debug_event;
+  if ((cont_flags & WCONT_CONTINUE_DEBUG_EVENT) != 0)
+    continue_debug_event = true;
+  else if ((cont_flags & WCONT_DONT_CONTINUE_DEBUG_EVENT) != 0)
+    continue_debug_event = false;
+  else
+    continue_debug_event = !target_is_non_stop_p ();
+  if (continue_debug_event)
     {
-      if ((id == -1 || id == (int) th->tid)
-	  && !th->suspended
-	  && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
-	{
-	  DEBUG_EVENTS ("got matching pending stop event "
-			"for 0x%x, not resuming",
-			th->tid);
-
-	  /* There's no need to really continue, because there's already
-	     another event pending.  However, we do need to inform the
-	     event loop of this.  */
-	  serial_event_set (m_wait_event);
-	  return TRUE;
-	}
+      DEBUG_EVENTS ("windows_continue -> continue_last_debug_event");
+      continue_last_debug_event_main_thread
+	(_("Failed to resume program execution"), continue_status,
+	 cont_flags & WCONT_LAST_CALL);
     }
-
-  for (auto &th : windows_process->thread_list)
-    if (id == -1 || id == (int) th->tid)
-      continue_one_thread (th.get (), cont_flags);
-
-  continue_last_debug_event_main_thread
-    (_("Failed to resume program execution"), continue_status,
-     cont_flags & WCONT_LAST_CALL);
 
   return TRUE;
 }
@@ -764,36 +1043,46 @@ windows_nat_target::fake_create_process (const DEBUG_EVENT &current_event)
   return current_event.dwThreadId;
 }
 
-void
-windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
+/* Prepare TH to be resumed.  TH and TP must point at the same thread.
+   Records the right dwContinueStatus for SIG in th->reply_later if we
+   used DBG_REPLY_LATER before on this thread, and sets of clears the
+   trace flag according to STEP.  Also returns the dwContinueStatus
+   argument to pass to ContinueDebugEvent.  The thread is still left
+   suspended -- a subsequent windows_continue/continue_one_thread call
+   is needed to flush the thread's register context and unsuspend.  */
+
+DWORD
+windows_nat_target::prepare_resume (windows_thread_info *th,
+				    thread_info *tp,
+				    int step, gdb_signal sig)
 {
-  windows_thread_info *th;
+  gdb_assert (th->tid == tp->ptid.lwp ());
+
   DWORD continue_status = DBG_CONTINUE;
-
-  /* A specific PTID means `step only this thread id'.  */
-  int resume_all = ptid == minus_one_ptid;
-
-  /* If we're continuing all threads, it's the current inferior that
-     should be handled specially.  */
-  if (resume_all)
-    ptid = inferior_ptid;
-
-  DEBUG_EXEC ("pid=%d, tid=0x%x, step=%d, sig=%d",
-	      ptid.pid (), (unsigned) ptid.lwp (), step, sig);
-
-  /* Get currently selected thread.  */
-  th = windows_process->find_thread (inferior_ptid);
-  gdb_assert (th != nullptr);
 
   if (sig != GDB_SIGNAL_0)
     {
+      /* Allow continuing with the same signal that interrupted us.
+	 Otherwise complain.  */
+
       /* Note it is OK to call get_last_debug_event_ptid() from the
-	 main thread here, because we know the process_thread thread
-	 isn't waiting for an event at this point, so there's no data
-	 race.  */
-      if (inferior_ptid != get_last_debug_event_ptid ())
+	 main thread here in all-stop, because we know the
+	 process_thread thread is not waiting for an event at this
+	 point, so there is no data race.  We cannot call it in
+	 non-stop mode, as the process_thread thread _is_ waiting for
+	 events right now in that case.  However, the restriction does
+	 not exist in non-stop mode, so we don't even call it in that
+	 mode.  */
+      if (!target_is_non_stop_p ()
+	  && tp->ptid != get_last_debug_event_ptid ())
 	{
-	  /* ContinueDebugEvent will be for a different thread.  */
+	  /* In all-stop, ContinueDebugEvent will be for a different
+	     thread.  For non-stop, we've called ContinueDebugEvent
+	     with DBG_REPLY_LATER for this thread, so we just set the
+	     intended continue status in 'reply_later', which is later
+	     passed to ContinueDebugEvent in windows_nat_target::wait
+	     after we resume the thread and we get the replied-later
+	     (repeated) event out of WaitForDebugEvent.  */
 	  DEBUG_EXCEPT ("Cannot continue with signal %d here.  "
 			"Not last-event thread", sig);
 	}
@@ -829,18 +1118,52 @@ windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
 		    th->last_sig);
     }
 
-  /* Get context for currently selected thread.  */
-  if (step)
-    {
-      /* Single step by setting t bit.  */
-      regcache *regcache = get_thread_regcache (inferior_thread ());
-      struct gdbarch *gdbarch = regcache->arch ();
-      fetch_registers (regcache, gdbarch_ps_regnum (gdbarch));
-      thread_context_step (th);
-    }
+  /* If DBG_REPLY_LATER was used on the thread, we override the
+     continue status that will be passed to ContinueDebugEvent later
+     with the continue status we've just determined fulfils the
+     caller's resumption request.  Note that DBG_REPLY_LATER is only
+     used in non-stop mode, and in that mode, windows_continue (called
+     below) does not call ContinueDebugEvent.  */
+  if (th->reply_later != 0)
+    th->reply_later = continue_status;
 
-  /* Allow continuing with the same signal that interrupted us.
-     Otherwise complain.  */
+  /* Single step by setting t bit (trap flag).  The trap flag is
+     automatically reset as soon as the single-step exception arrives,
+     however, it's possible to suspend/stop a thread before it
+     executes any instruction, leaving the trace flag set.  If we
+     subsequently decide to continue such a thread instead of stepping
+     it, and we didn't clear the trap flag, the thread would step, and
+     we'd end up reporting a SIGTRAP to the core which the core
+     couldn't explain (because the thread wasn't supposed to be
+     stepping), and end up reporting a spurious SIGTRAP to the
+     user.  */
+  regcache *regcache = get_thread_regcache (inferior_thread ());
+  struct gdbarch *gdbarch = regcache->arch ();
+  fetch_registers (regcache, gdbarch_ps_regnum (gdbarch));
+  thread_context_step (th, step);
+
+  return continue_status;
+}
+
+void
+windows_nat_target::resume (ptid_t ptid, int step, enum gdb_signal sig)
+{
+  /* A specific PTID means `step only this thread id'.  */
+  int resume_all = ptid == minus_one_ptid;
+
+  /* If we're continuing all threads, it's the current inferior that
+     should be handled specially.  */
+  if (resume_all)
+    ptid = inferior_ptid;
+
+  DEBUG_EXEC ("pid=%d, tid=0x%x, step=%d, sig=%d",
+	      ptid.pid (), (unsigned) ptid.lwp (), step, sig);
+
+  /* Get currently selected thread.  */
+  windows_thread_info *th = windows_process->find_thread (inferior_ptid);
+  gdb_assert (th != nullptr);
+
+  DWORD continue_status = prepare_resume (th, inferior_thread (), step, sig);
 
   if (resume_all)
     windows_continue (continue_status, -1);
@@ -889,16 +1212,148 @@ windows_nat_target::interrupt ()
 	     "Press Ctrl-c in the program console."));
 }
 
+/* Stop thread TH, for STOPPING_KIND reason.  This leaves a
+   GDB_SIGNAL_0 pending in the thread, which is later consumed by
+   windows_nat_target::wait.  */
+
+void
+windows_nat_target::stop_one_thread (windows_thread_info *th,
+				     enum stopping_kind stopping_kind)
+{
+  ptid_t thr_ptid (windows_process->process_id, th->tid);
+
+  if (th->suspended == -1)
+    {
+      /* Already known to be stopped; and suspension failed, most
+	 probably because the thread is exiting.  Do nothing, and let
+	 the thread exit event be reported.  */
+      DEBUG_EVENTS ("already suspended %s: suspended=%d, stopping=%d",
+		    thr_ptid.to_string ().c_str (),
+		    th->suspended, th->stopping);
+    }
+#ifdef __CYGWIN__
+  else if (th->suspended
+	   && th->signaled_thread != nullptr
+	   && th->pending_status.kind () == TARGET_WAITKIND_IGNORE
+	   /* If doing an internal stop to update debug registers,
+	      then just leave the "sig" thread suspended.  Otherwise
+	      windows_nat_target::wait would incorrectly break the
+	      signaled_thread lock when it later processes the pending
+	      stop and calls windows_continue on this thread.  */
+	   && stopping_kind == SK_EXTERNAL)
+    {
+      DEBUG_EVENTS ("explict stop for \"sig\" thread %s held for signal",
+		    thr_ptid.to_string ().c_str ());
+
+      th->stopping = stopping_kind;
+      th->pending_status.set_stopped (GDB_SIGNAL_0);
+      th->last_event = {};
+      serial_event_set (m_wait_event);
+    }
+#endif
+  else if (th->suspended)
+    {
+      /* Already known to be stopped; do nothing.  */
+
+      DEBUG_EVENTS ("already suspended %s: suspended=%d, stopping=%d",
+		    thr_ptid.to_string ().c_str (),
+		    th->suspended, th->stopping);
+
+      /* Upgrade stopping.  */
+      if (stopping_kind > th->stopping)
+	th->stopping = stopping_kind;
+    }
+  else
+    {
+      DEBUG_EVENTS ("stop request for %s", thr_ptid.to_string ().c_str ());
+
+      th->suspend ();
+
+      /* If suspension failed, it means the thread is exiting.  Let
+	 the thread exit event be reported instead of faking our own
+	 stop.  */
+      if (th->suspended == -1)
+	{
+	  DEBUG_EVENTS ("suspension of %s failed, expect thread exit event",
+			thr_ptid.to_string ().c_str ());
+	  if (stopping_kind > th->stopping)
+	    th->stopping = stopping_kind;
+	  return;
+	}
+
+      gdb_assert (th->suspended == 1);
+
+      if (stopping_kind > th->stopping)
+	{
+	  th->stopping = stopping_kind;
+	  th->pending_status.set_stopped (GDB_SIGNAL_0);
+	  th->last_event = {};
+	}
+
+      serial_event_set (m_wait_event);
+    }
+}
+
+/* Implementation of target_ops::stop.  */
+
+void
+windows_nat_target::stop (ptid_t ptid)
+{
+  for (thread_info &thr : all_non_exited_threads (this))
+    {
+      if (thr.ptid.matches (ptid))
+	stop_one_thread (as_windows_thread_info (&thr), SK_EXTERNAL);
+    }
+}
+
 void
 windows_nat_target::pass_ctrlc ()
 {
   interrupt ();
 }
 
+/* Implementation of the target_ops::thread_events method.  */
+
 void
-windows_nat_target::stop (ptid_t ptid)
+windows_nat_target::thread_events (bool enable)
 {
-  interrupt ();
+  DEBUG_EVENTS ("windows_nat_target::thread_events(%d)", enable);
+  m_report_thread_events = enable;
+}
+
+/* True if there is any resumed thread.  */
+
+bool
+windows_nat_target::any_resumed_thread ()
+{
+  for (thread_info &thread : all_non_exited_threads (this))
+    if (thread.internal_state () == THREAD_INT_RUNNING)
+      return true;
+  return false;
+}
+
+/* Called for both EXIT_THREAD_DEBUG_EVENT and
+   EXIT_PROCESS_DEBUG_EVENT to handle the fact that the event thread
+   has exited.  */
+
+static void
+handle_thread_exit (const DEBUG_EVENT &current_event)
+{
+  ptid_t ptid (current_event.dwProcessId, current_event.dwThreadId);
+  windows_thread_info *th = windows_process->find_thread (ptid);
+  gdb_assert (th != nullptr);
+
+  /* The handle is still valid, but it is going to be automatically
+     closed by Windows when we next call ContinueDebugEvent.  Fetch
+     the thread's registers while we still can.  For EXIT_PROCESS,
+     ContinueDebugEvent only happens at target_mourn_inferior time,
+     but do this not too, for consistency with EXIT_THREAD time.  */
+  windows_process->fill_thread_context (th);
+  th->h = nullptr;
+
+  /* The thread is gone, so no longer suspended from Windows's
+     perspective.  */
+  th->suspended = -1;
 }
 
 /* Get the next event from the child.  Returns the thread ptid.  */
@@ -914,22 +1369,30 @@ windows_nat_target::get_windows_debug_event
   /* If there is a relevant pending stop, report it now.  See the
      comment by the definition of "windows_thread_info::pending_status"
      for details on why this is needed.  */
-  for (auto &th : windows_process->thread_list)
+  for (thread_info &thread : all_threads_safe ())
     {
-      if (!th->suspended
+      if (thread.inf->process_target () != this)
+	continue;
+
+      auto *th = as_windows_thread_info (&thread);
+      if (thread.internal_state () == THREAD_INT_RUNNING
+	  && th->suspended
 	  && th->pending_status.kind () != TARGET_WAITKIND_IGNORE)
 	{
-	  DEBUG_EVENTS ("reporting pending event for 0x%x", th->tid);
-
-	  thread_id = th->tid;
 	  *ourstatus = th->pending_status;
 	  th->pending_status.set_ignore ();
 	  *current_event = th->last_event;
-
-	  ptid_t ptid (windows_process->process_id, thread_id);
-	  windows_process->invalidate_thread_context (th.get ());
-	  return ptid;
+	  DEBUG_EVENTS ("reporting pending event for 0x%x", th->tid);
+	  return thread.ptid;
 	}
+    }
+
+  /* If there are no resumed threads left, bail.  */
+  if (windows_process->windows_initialization_done
+      && !any_resumed_thread ())
+    {
+      ourstatus->set_no_resumed ();
+      return minus_one_ptid;
     }
 
   if ((options & TARGET_WNOHANG) != 0 && !m_debug_event_pending)
@@ -945,13 +1408,86 @@ windows_nat_target::get_windows_debug_event
   event_code = current_event->dwDebugEventCode;
   ourstatus->set_spurious ();
 
+  ptid_t result_ptid (current_event->dwProcessId,
+		      current_event->dwThreadId, 0);
+  windows_thread_info *result_th = windows_process->find_thread (result_ptid);
+
+  /* If we previously used DBG_REPLY_LATER on this thread, and we're
+     seeing an event for it, it means we've already processed the
+     event, and then subsequently resumed the thread [1], intending to
+     pass REPLY_LATER to ContinueDebugEvent.  Do that now, before the
+     switch table below, which may have side effects that don't make
+     sense for a delayed event.
+
+     [1] - with the caveat that sometimes Windows reports an event for
+     a suspended thread.  Also handled below.  */
+  if (result_th != nullptr && result_th->reply_later != 0)
+    {
+      DEBUG_EVENTS ("reply-later thread 0x%x, suspended=%d, dwDebugEventCode=%s",
+		    result_th->tid, result_th->suspended,
+		    event_code_to_string (event_code).c_str ());
+
+      gdb_assert (dbg_reply_later_available ());
+
+      /* We never ask to DBG_REPLY_LATER these two, so we shouldn't
+	 see them here.  If a thread is forced-exited when a
+	 DBG_REPLY_LATER is in effect, then we will still see the
+	 DBG_REPLY_LATER-ed event before the thread/process exit
+	 event.  */
+      gdb_assert (event_code != EXIT_THREAD_DEBUG_EVENT
+		  && event_code != EXIT_PROCESS_DEBUG_EVENT);
+
+      if (result_th->suspended == 1)
+	{
+	  /* Pending stop.  See the comment by the definition of
+	     "pending_status" for details on why this is needed.  */
+	  DEBUG_EVENTS ("unexpected reply-later stop in suspended thread 0x%x",
+			result_th->tid);
+
+	  /* Put the event back in the kernel queue.  We haven't yet
+	     decided which reply to use.  */
+	  continue_status = DBG_REPLY_LATER;
+	}
+      else if (result_th->suspended == -1)
+	{
+	  /* We resumed the thread expecting to get back a reply-later
+	     event.  Before we saw that event, we tried to suspend the
+	     thread, but that failed, because the thread exited
+	     (likely because the whole process has been killed).  We
+	     should get back an EXIT_THREAD_DEBUG_EVENT for this
+	     thread, but only after getting past this reply-later
+	     event.  */
+	  DEBUG_EVENTS ("reply-later stop in suspend-failed "
+			"thread 0x%x, ignoring",
+			result_th->tid);
+
+	  /* Continue normally, and expect a
+	     EXIT_THREAD_DEBUG_EVENT.  */
+	  continue_status = DBG_CONTINUE;
+	  result_th->reply_later = 0;
+	}
+      else
+	{
+	  continue_status = result_th->reply_later;
+	  result_th->reply_later = 0;
+	}
+
+      /* Go back to waiting for the next event.  */
+      continue_last_debug_event_main_thread
+	(_("Failed to continue reply-later event"), continue_status);
+
+      ourstatus->set_ignore ();
+      return null_ptid;
+    }
+
+  DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
+		(unsigned) current_event->dwProcessId,
+		(unsigned) current_event->dwThreadId,
+		event_code_to_string (event_code).c_str ());
+
   switch (event_code)
     {
     case CREATE_THREAD_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "CREATE_THREAD_DEBUG_EVENT");
       if (windows_process->saw_create != 1)
 	{
 	  inferior *inf = find_inferior_pid (this, current_event->dwProcessId);
@@ -977,28 +1513,32 @@ windows_nat_target::get_windows_debug_event
 	      current_event->u.CreateThread.lpThreadLocalBase,
 	      false /* main_thread_p */));
 
-	/* This updates debug registers if necessary.  */
-	continue_one_thread (th, 0);
+	/* Update the debug registers if we're not reporting the stop.
+	   If we are (reporting the stop), the debug registers will be
+	   updated when the thread is eventually re-resumed.  */
+	if (m_report_thread_events)
+	  ourstatus->set_thread_created ();
+	else
+	  continue_one_thread (th, 0);
       }
       break;
 
     case EXIT_THREAD_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXIT_THREAD_DEBUG_EVENT");
-      delete_thread (ptid_t (current_event->dwProcessId,
-			     current_event->dwThreadId, 0),
-		     current_event->u.ExitThread.dwExitCode,
-		     false /* main_thread_p */);
-      thread_id = 0;
+      {
+	ourstatus->set_thread_exited
+	  (current_event->u.ExitThread.dwExitCode);
+	thread_id = current_event->dwThreadId;
+
+	handle_thread_exit (*current_event);
+
+	/* Don't decide yet whether to report the event, or delete the
+	   thread immediately, because we still need to check whether
+	   the event should be left pending, depending on whether the
+	   thread was running or not from the core's perspective.  */
+      }
       break;
 
     case CREATE_PROCESS_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "CREATE_PROCESS_DEBUG_EVENT");
       CloseHandle (current_event->u.CreateProcessInfo.hFile);
       if (++windows_process->saw_create != 1)
 	break;
@@ -1015,10 +1555,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case EXIT_PROCESS_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXIT_PROCESS_DEBUG_EVENT");
       if (!windows_process->windows_initialization_done)
 	{
 	  target_terminal::ours ();
@@ -1028,9 +1564,6 @@ windows_nat_target::get_windows_debug_event
 	}
       else if (windows_process->saw_create == 1)
 	{
-	  delete_thread (ptid_t (current_event->dwProcessId,
-				 current_event->dwThreadId, 0),
-			 0, true /* main_thread_p */);
 	  DWORD exit_status = current_event->u.ExitProcess.dwExitCode;
 	  /* If the exit status looks like a fatal exception, but we
 	     don't recognize the exception's code, make the original
@@ -1042,15 +1575,14 @@ windows_nat_target::get_windows_debug_event
 	    ourstatus->set_exited (exit_status);
 	  else
 	    ourstatus->set_signalled (gdb_signal_from_host (exit_signal));
-	  return ptid_t (current_event->dwProcessId);
+
+	  thread_id = current_event->dwThreadId;
+
+	  handle_thread_exit (*current_event);
 	}
       break;
 
     case LOAD_DLL_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "LOAD_DLL_DEBUG_EVENT");
       CloseHandle (current_event->u.LoadDll.hFile);
       if (windows_process->saw_create != 1
 	  || ! windows_process->windows_initialization_done)
@@ -1068,10 +1600,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case UNLOAD_DLL_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "UNLOAD_DLL_DEBUG_EVENT");
       if (windows_process->saw_create != 1
 	  || ! windows_process->windows_initialization_done)
 	break;
@@ -1088,10 +1616,6 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case EXCEPTION_DEBUG_EVENT:
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "EXCEPTION_DEBUG_EVENT");
       if (windows_process->saw_create != 1)
 	break;
       switch (windows_process->handle_exception (*current_event,
@@ -1111,14 +1635,26 @@ windows_nat_target::get_windows_debug_event
       break;
 
     case OUTPUT_DEBUG_STRING_EVENT:	/* Message from the kernel.  */
-      DEBUG_EVENTS ("kernel event for pid=%u tid=0x%x code=%s",
-		    (unsigned) current_event->dwProcessId,
-		    (unsigned) current_event->dwThreadId,
-		    "OUTPUT_DEBUG_STRING_EVENT");
       if (windows_process->saw_create != 1)
 	break;
-      thread_id = windows_process->handle_output_debug_string (*current_event,
-							       ourstatus);
+      if (windows_process->handle_output_debug_string (*current_event,
+						       ourstatus))
+	{
+	  /* We caught a Cygwin signal for a thread.  That thread now
+	     has a pending event, and the "sig" thread is
+	     suspended.  */
+	  serial_event_set (m_wait_event);
+
+	  /* In all-stop, return now to avoid reaching
+	     ContinueDebugEvent further below.  In all-stop, it's
+	     always windows_nat_target::resume that does the
+	     ContinueDebugEvent call.  */
+	  if (!target_is_non_stop_p ())
+	    {
+	      ourstatus->set_ignore ();
+	      return null_ptid;
+	    }
+	}
       break;
 
     default:
@@ -1140,32 +1676,76 @@ windows_nat_target::get_windows_debug_event
       return null_ptid;
     }
 
-  const ptid_t ptid = ptid_t (current_event->dwProcessId, thread_id, 0);
-  windows_thread_info *th = windows_process->find_thread (ptid);
+  const ptid_t ptid = ptid_t (current_event->dwProcessId, thread_id);
+  thread_info *thread = this->find_thread (ptid);
+  auto *th = as_windows_thread_info (thread);
 
   th->last_event = *current_event;
 
-  if (th->suspended)
+  if (thread->internal_state () == THREAD_INT_STOPPED)
     {
+      gdb_assert (th->suspended != 0);
+
       /* Pending stop.  See the comment by the definition of
 	 "pending_status" for details on why this is needed.  */
       DEBUG_EVENTS ("get_windows_debug_event - "
 		    "unexpected stop in suspended thread 0x%x",
 		    thread_id);
 
-      if (current_event->dwDebugEventCode == EXCEPTION_DEBUG_EVENT
-	  && is_sw_breakpoint (&current_event->u.Exception.ExceptionRecord)
-	  && windows_process->windows_initialization_done)
+      /* Use DBG_REPLY_LATER to put the event back in the kernel queue
+	 if possible.  Don't do that with exit-thread or exit-process
+	 events, because when a thread is dead, it can't be suspended
+	 anymore, so the kernel would immediately re-report the
+	 event.  */
+      if (event_code != EXIT_THREAD_DEBUG_EVENT
+	  && event_code != EXIT_PROCESS_DEBUG_EVENT
+	  && dbg_reply_later_available ())
 	{
-	  th->stopped_at_software_breakpoint = true;
-	  th->pc_adjusted = false;
+	  /* Thankfully, the Windows kernel doesn't immediately
+	     re-report the unexpected event for a suspended thread
+	     when we defer it with DBG_REPLY_LATER, otherwise this
+	     would get us stuck in an infinite loop re-processing the
+	     same unexpected event over and over.  (Which is what
+	     would happen if we used DBG_REPLY_LATER on an exit-thread
+	     or exit-process event.  See comment above.)  */
+	  continue_status = DBG_REPLY_LATER;
+	}
+      else
+	{
+	  if (current_event->dwDebugEventCode == EXCEPTION_DEBUG_EVENT
+	      && is_sw_breakpoint (&current_event->u.Exception.ExceptionRecord)
+	      && windows_process->windows_initialization_done)
+	    {
+	      th->stopped_at_software_breakpoint = true;
+	      th->pc_adjusted = false;
+	    }
+
+	  th->pending_status = *ourstatus;
+	  th->last_event = {};
 	}
 
-      th->pending_status = *ourstatus;
+      /* For exit-process, the debug event is continued later, at
+	 mourn time.  */
+      if (event_code != EXIT_PROCESS_DEBUG_EVENT)
+	{
+	  continue_last_debug_event_main_thread
+	    (_("Failed to resume program execution"), continue_status);
+	}
       ourstatus->set_ignore ();
+      return null_ptid;
+    }
 
-      continue_last_debug_event_main_thread
-	(_("Failed to resume program execution"), continue_status);
+  gdb_assert (thread->internal_state () == THREAD_INT_RUNNING);
+
+  /* Now that we've handled exit events for suspended threads (above),
+     we can finally decide whether to report the thread exit event or
+     just delete the thread without bothering the core.  */
+  if (ourstatus->kind () == TARGET_WAITKIND_THREAD_EXITED
+      && !m_report_thread_events)
+    {
+      delete_thread (ptid, ourstatus->exit_status (),
+		     false /* main_thread_p */);
+      ourstatus->set_spurious ();
       return null_ptid;
     }
 
@@ -1192,13 +1772,24 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 
   while (1)
     {
-      DEBUG_EVENT current_event;
+      DEBUG_EVENT current_event {};
 
       ptid_t result = get_windows_debug_event (pid, ourstatus, options,
 					       &current_event);
+      /* True if this is a pending event that we injected ourselves,
+	 instead of a real event out of WaitForDebugEvent.  */
+      bool fake = current_event.dwDebugEventCode == 0;
+
+      DEBUG_EVENTS ("get_windows_debug_event returned [%s : %s, fake=%d]",
+		    result.to_string ().c_str (),
+		    ourstatus->to_string ().c_str(),
+		    fake);
 
       if ((options & TARGET_WNOHANG) != 0
 	  && ourstatus->kind () == TARGET_WAITKIND_IGNORE)
+	return result;
+
+      if (ourstatus->kind () == TARGET_WAITKIND_NO_RESUMED)
 	return result;
 
       if (ourstatus->kind () == TARGET_WAITKIND_SPURIOUS)
@@ -1213,6 +1804,17 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 	    {
 	      windows_thread_info *th = windows_process->find_thread (result);
 
+	      /* If this thread was temporarily stopped just so we
+		 could update its debug registers on the next
+		 resumption, do it now.  */
+	      if (th->stopping == SK_INTERNAL)
+		{
+		  gdb_assert (fake);
+		  windows_continue (DBG_CONTINUE, th->tid,
+				    WCONT_DONT_CONTINUE_DEBUG_EVENT);
+		  continue;
+		}
+
 	      th->stopped_at_software_breakpoint = false;
 	      if (current_event.dwDebugEventCode
 		  == EXCEPTION_DEBUG_EVENT
@@ -1224,10 +1826,40 @@ windows_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,
 		  th->pc_adjusted = false;
 		}
 
+	      /* If non-stop, suspend the event thread, and continue
+		 it with DBG_REPLY_LATER, so the other threads go back
+		 to running as soon as possible.  Don't do this if
+		 stopping the thread, as in that case the thread was
+		 already suspended, and also there's no real Windows
+		 debug event to continue in that case.  */
+	      if (windows_process->windows_initialization_done
+		  && target_is_non_stop_p ()
+		  && !fake)
+		{
+		  if (ourstatus->kind () == TARGET_WAITKIND_THREAD_EXITED)
+		    {
+		      gdb_assert (th->suspended == -1);
+		      continue_last_debug_event_main_thread
+			(_("Init: Failed to DBG_CONTINUE after thread exit"),
+			 DBG_CONTINUE);
+		    }
+		  else
+		    {
+		      th->suspend ();
+		      th->reply_later = DBG_CONTINUE;
+		      continue_last_debug_event_main_thread
+			(_("Init: Failed to defer event with DBG_REPLY_LATER"),
+			 DBG_REPLY_LATER);
+		    }
+		}
+
 	      /* All-stop, suspend all threads until they are
 		 explicitly resumed.  */
-	      for (auto &thr : windows_process->thread_list)
-		thr->suspend ();
+	      if (!target_is_non_stop_p ())
+		for (auto *thr : all_windows_threads ())
+		  thr->suspend ();
+
+	      th->stopping = SK_NOT_STOPPING;
 	    }
 
 	  /* If something came out, assume there may be more.  This is
@@ -1279,22 +1911,31 @@ windows_nat_target::do_initial_windows_stuff (DWORD pid, bool attaching)
 
   ptid_t last_ptid;
 
+  /* Keep fetching events until we see the initial breakpoint (which
+     is planted by Windows itself) being reported.  */
+
   while (1)
     {
       struct target_waitstatus status;
 
       last_ptid = this->wait (minus_one_ptid, &status, 0);
 
-      /* Note windows_wait returns TARGET_WAITKIND_SPURIOUS for thread
-	 events.  */
-      if (status.kind () != TARGET_WAITKIND_LOADED
-	  && status.kind () != TARGET_WAITKIND_SPURIOUS)
+      /* These result in an error being thrown before we get here.  */
+      gdb_assert (status.kind () != TARGET_WAITKIND_EXITED
+		  && status.kind () != TARGET_WAITKIND_SIGNALLED);
+
+      /* We may also see TARGET_WAITKIND_THREAD_EXITED if
+	 target_thread_events is active (because another thread was
+	 stepping earlier, for example).  Ignore such events until we
+	 see the initial breakpoint.  */
+
+      if (status.kind () == TARGET_WAITKIND_STOPPED)
 	break;
 
       /* Don't use windows_nat_target::resume here because that
 	 assumes that inferior_ptid points at a valid thread, and we
 	 haven't switched to any thread yet.  */
-      windows_continue (DBG_CONTINUE, -1);
+      windows_continue (DBG_CONTINUE, -1, WCONT_CONTINUE_DEBUG_EVENT);
     }
 
   switch_to_thread (this->find_thread (last_ptid));
@@ -1382,7 +2023,6 @@ windows_nat_target::attach (const char *args, int from_tty)
     warning ("Failed to get SE_DEBUG_NAME privilege\n"
 	     "This can cause attach to fail on Windows NT/2K/XP");
 
-  windows_init_thread_list ();
   windows_process->saw_create = 0;
 
   std::optional<unsigned> err;
@@ -1446,7 +2086,21 @@ windows_nat_target::attach (const char *args, int from_tty)
      is normally more useful to the user than the injected thread.  */
   switch_to_thread (first_thread_of_inferior (current_inferior ()));
 
-  target_terminal::ours ();
+  if (target_is_non_stop_p ())
+    {
+      /* Leave all threads running.  */
+
+      continue_last_debug_event_main_thread
+	(_("Failed to DBG_CONTINUE after attach"),
+	 DBG_CONTINUE);
+    }
+  else
+    {
+      set_state (this, minus_one_ptid, THREAD_STOPPED);
+      set_internal_state (this, minus_one_ptid, THREAD_INT_STOPPED);
+
+      target_terminal::ours ();
+    }
 }
 
 void
@@ -1547,16 +2201,77 @@ windows_nat_target::break_out_process_thread (bool &process_alive)
 
       DEBUG_EVENTS ("got unrelated event, code %u",
 		    current_event.dwDebugEventCode);
-      windows_continue (DBG_CONTINUE, -1, 0);
+
+      DWORD continue_status
+	= continue_status_for_event_detaching (current_event);
+      windows_continue (continue_status, -1, WCONT_CONTINUE_DEBUG_EVENT);
     }
 
   if (injected_thread_handle != NULL)
     CHECK (CloseHandle (injected_thread_handle));
 }
 
+
+/* Used while detaching.  Decide whether to pass the exception or not.
+   Returns the dwContinueStatus argument to pass to
+   ContinueDebugEvent.  */
+
+DWORD
+windows_nat_target::continue_status_for_event_detaching
+  (const DEBUG_EVENT &event, size_t *reply_later_events_left)
+{
+  ptid_t ptid (event.dwProcessId, event.dwThreadId, 0);
+  windows_thread_info *th = windows_process->find_thread (ptid);
+
+  /* This can be a thread that we don't know about, as we're not
+     tracking thread creation events at this point.  */
+  if (th != nullptr && th->reply_later != 0)
+    {
+      DWORD res = th->reply_later;
+      th->reply_later = 0;
+      if (reply_later_events_left != nullptr)
+	(*reply_later_events_left)--;
+      return res;
+    }
+  else if (event.dwDebugEventCode == EXCEPTION_DEBUG_EVENT)
+    {
+      /* As the user asked to detach already, any new exception not
+	 seen by infrun before, is passed down to the inferior without
+	 considering "handle SIG pass/nopass".  We can just pretend
+	 the exception was raised after the inferior was detached.  */
+      return DBG_EXCEPTION_NOT_HANDLED;
+    }
+  else
+    return DBG_CONTINUE;
+}
+
 void
 windows_nat_target::detach (inferior *inf, int from_tty)
 {
+  DWORD continue_status = DBG_CONTINUE;
+
+  /* For any thread the core hasn't resumed, call prepare_resume with
+     the signal that the thread would be resumed with, so that we set
+     the right reply_later value, and also, so that we clear the trace
+     flag.  */
+  for (thread_info &thr : inf->non_exited_threads ())
+    {
+      if (thr.internal_state () != THREAD_INT_RUNNING)
+	{
+	  windows_thread_info *wth = windows_process->find_thread (thr.ptid);
+	  gdb_signal signo = get_detach_signal (this, thr.ptid);
+
+	  if (signo != wth->last_sig
+	      || (signo != GDB_SIGNAL_0 && !signal_pass_state (signo)))
+	    signo = GDB_SIGNAL_0;
+
+	  DWORD cstatus = prepare_resume (wth, &thr, 0, signo);
+
+	  if (!m_continued && thr.ptid == get_last_debug_event_ptid ())
+	    continue_status = cstatus;
+	}
+    }
+
   /* If we see the process exit while unblocking the process_thread
      helper thread, then we should skip the actual
      DebugActiveProcessStop call.  But don't report an error.  Just
@@ -1564,20 +2279,76 @@ windows_nat_target::detach (inferior *inf, int from_tty)
   bool process_alive = true;
 
   /* The process_thread helper thread will be blocked in
-     WaitForDebugEvent waiting for events if we've resumed the target
-     before we get here, e.g., with "attach&" or "c&".  We need to
-     unblock it so that we can have it call DebugActiveProcessStop
-     below, in the do_synchronously block.  */
+     WaitForDebugEvent waiting for events if we're in non-stop mode,
+     or if in all-stop and we've resumed the target before we get
+     here, e.g., with "attach&" or "c&".  We need to unblock it so
+     that we can have it call DebugActiveProcessStop below, in the
+     do_synchronously block.  */
   if (m_continued)
-    break_out_process_thread (process_alive);
+    {
+      break_out_process_thread (process_alive);
 
-  windows_continue (DBG_CONTINUE, -1, WCONT_LAST_CALL);
+      /* We're now either stopped at a thread exit event, or a process
+	 exit event.  */
+      continue_status = DBG_CONTINUE;
+    }
+
+  windows_continue (continue_status, -1,
+		    WCONT_LAST_CALL | WCONT_CONTINUE_DEBUG_EVENT);
 
   std::optional<unsigned> err;
   if (process_alive)
     do_synchronously ([&] ()
       {
-	if (!DebugActiveProcessStop (windows_process->process_id))
+	/* The kernel re-raises any exception previously intercepted
+	   and deferred with DBG_REPLY_LATER in the inferior after we
+	   detach.  We need to flush those, and suppress those which
+	   aren't meant to be seen by the inferior (e.g., breakpoints,
+	   single-steps, any with matching "handle SIG nopass", etc.),
+	   otherwise the inferior dies immediately after the detach,
+	   due to an unhandled exception.  */
+	DEBUG_EVENT event;
+
+	/* Count how many threads have pending reply-later events.  */
+	size_t reply_later_events_left = 0;
+	for (auto *th : all_windows_threads ())
+	  if (th->reply_later != 0)
+	    reply_later_events_left++;
+
+	DEBUG_EVENTS ("flushing %zu reply-later events",
+		      reply_later_events_left);
+
+	/* Note we have to use a blocking wait (hence the need for the
+	   counter).  Just polling (timeout=0) until WaitForDebugEvent
+	   returns false would be racy -- the kernel may take a little
+	   bit to put the events in the pending queue.  That has been
+	   observed on Windows 11, where detaching would still very
+	   occasionally result in the inferior dying after the detach
+	   due to a reply-later event.  */
+	while (reply_later_events_left > 0
+	       && wait_for_debug_event (&event, INFINITE))
+	  {
+	    DEBUG_EVENTS ("flushed kernel event code %u",
+			  event.dwDebugEventCode);
+
+	    DWORD cstatus = (continue_status_for_event_detaching
+			     (event, &reply_later_events_left));
+	    if (!continue_last_debug_event (cstatus, debug_events))
+	      {
+		err = (unsigned) GetLastError ();
+		return false;
+	      }
+
+	    if (event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
+	      {
+		DEBUG_EVENTS ("got EXIT_PROCESS_DEBUG_EVENT, skipping detach");
+		process_alive = false;
+		break;
+	      }
+	  }
+
+	if (process_alive
+	    && !DebugActiveProcessStop (windows_process->process_id))
 	  err = (unsigned) GetLastError ();
 	else
 	  DebugSetProcessKillOnExit (FALSE);
@@ -2142,7 +2913,6 @@ windows_nat_target::create_inferior (const char *exec_file,
 	}
     }
 
-  windows_init_thread_list ();
   do_synchronously ([&] ()
     {
       BOOL ok = create_process (nullptr, args, flags, w32_env,
@@ -2271,7 +3041,6 @@ windows_nat_target::create_inferior (const char *exec_file,
   /* Final nil string to terminate new env.  */
   *temp = 0;
 
-  windows_init_thread_list ();
   do_synchronously ([&] ()
     {
       BOOL ok = create_process (nullptr, /* image */
@@ -2319,13 +3088,32 @@ windows_nat_target::create_inferior (const char *exec_file,
 
   do_initial_windows_stuff (pi.dwProcessId, 0);
 
-  /* windows_continue (DBG_CONTINUE, -1); */
+  /* Present the initial thread as stopped to the core.  */
+  windows_thread_info *th = windows_process->find_thread (inferior_ptid);
+
+  th->suspend ();
+  set_state (this, inferior_ptid, THREAD_STOPPED);
+  set_internal_state (this, inferior_ptid, THREAD_INT_STOPPED);
+
+  if (target_is_non_stop_p ())
+    {
+      /* In non-stop mode, we always immediately use DBG_REPLY_LATER
+	 on threads as soon as they report an event.  However, during
+	 the initial startup, windows_nat_target::wait does not do
+	 this, so we need to handle it here for the initial
+	 thread.  */
+      th->reply_later = DBG_CONTINUE;
+      continue_last_debug_event_main_thread
+	(_("Failed to defer event with DBG_REPLY_LATER"),
+	 DBG_REPLY_LATER);
+    }
 }
 
 void
 windows_nat_target::mourn_inferior ()
 {
-  windows_continue (DBG_CONTINUE, -1, WCONT_LAST_CALL);
+  windows_continue (DBG_CONTINUE, -1,
+		    WCONT_LAST_CALL | WCONT_CONTINUE_DEBUG_EVENT);
   cleanup_windows_arch ();
   if (windows_process->open_process_used)
     {
@@ -2375,19 +3163,55 @@ windows_xfer_memory (gdb_byte *readbuf, const gdb_byte *writebuf,
     return success ? TARGET_XFER_OK : TARGET_XFER_E_IO;
 }
 
+/* Return true if all the threads of the process have already
+   exited.  */
+
+static bool
+already_dead ()
+{
+  for (windows_thread_info *th : all_windows_threads ())
+    if (th->h != nullptr)
+      return false;
+  return true;
+}
+
 void
 windows_nat_target::kill ()
 {
+  /* If all the threads of the process have already exited, there is
+     really nothing to kill.  This can happen with e.g., scheduler
+     locking, where the thread exit events for all threads are still
+     pending to be processed by the core.  */
+  if (already_dead ())
+    {
+      target_mourn_inferior (inferior_ptid);
+      return;
+    }
+
   CHECK (TerminateProcess (windows_process->handle, 137));
+
+  /* In non-stop mode, windows_continue does not call
+     ContinueDebugEvent by default.  This behavior is appropriate for
+     the first call to windows_continue because any thread that is
+     stopped has already been ContinueDebugEvent'ed with
+     DBG_REPLY_LATER.  However, after the first
+     wait_for_debug_event_main_thread call in the loop, this will no
+     longer be true.
+
+     In all-stop mode, the WCONT_CONTINUE_DEBUG_EVENT flag has no
+     effect, so writing the code in this way ensures that the code is
+     the same for both modes.  */
+  windows_continue_flags flags = WCONT_KILLED;
 
   for (;;)
     {
-      if (!windows_continue (DBG_CONTINUE, -1, WCONT_KILLED))
+      if (!windows_continue (DBG_CONTINUE, -1, flags))
 	break;
       DEBUG_EVENT current_event;
       wait_for_debug_event_main_thread (&current_event);
       if (current_event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
 	break;
+      flags |= WCONT_CONTINUE_DEBUG_EVENT;
     }
 
   target_mourn_inferior (inferior_ptid);	/* Or just windows_mourn_inferior?  */
@@ -2521,6 +3345,45 @@ windows_nat_target::thread_name (struct thread_info *thr)
   return th->thread_name ();
 }
 
+/* Implementation of the target_ops::extra_thread_info method.  */
+
+const char *
+windows_nat_target::extra_thread_info (thread_info *info)
+{
+  windows_thread_info *th = windows_process->find_thread (info->ptid);
+
+  if (!th->suspended)
+    return nullptr;
+
+  if (th->pending_status.kind () == TARGET_WAITKIND_THREAD_EXITED
+      || th->last_event.dwDebugEventCode == EXIT_THREAD_DEBUG_EVENT)
+    return "exiting";
+  else if (th->pending_status.kind () == TARGET_WAITKIND_EXITED
+	   || th->pending_status.kind () == TARGET_WAITKIND_SIGNALLED
+	   || th->last_event.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
+    return "exiting process";
+
+  return nullptr;
+}
+
+/* Implementation of the target_ops::supports_non_stop method.  */
+
+bool
+windows_nat_target::supports_non_stop ()
+{
+  /* Non-stop support requires DBG_REPLY_LATER, which only exists on
+     Windows 10 and later.  */
+  return dbg_reply_later_available ();
+}
+
+/* Implementation of the target_ops::always_non_stop_p method.  */
+
+bool
+windows_nat_target::always_non_stop_p ()
+{
+  /* If we can do non-stop, prefer it.  */
+  return supports_non_stop ();
+}
 
 INIT_GDB_FILE (windows_nat)
 {
@@ -2607,6 +3470,40 @@ Use \"%ps\" or \"%ps\" command to load executable/libraries directly."),
 	      styled_string (command_style.style (), "file"),
 	      styled_string (command_style.style (), "dll"));
     }
+}
+
+/* For each thread, set the debug_registers_changed flag, and
+   temporarily stop it so we can update its debug registers.  */
+
+void
+windows_nat_target::debug_registers_changed_all_threads ()
+{
+  for (auto *th : all_windows_threads ())
+    {
+      th->debug_registers_changed = true;
+
+      /* Note we don't SuspendThread => update debug regs =>
+	 ResumeThread, because SuspendThread is actually asynchronous
+	 (and GetThreadContext blocks until the thread really
+	 suspends), and doing that for all threads may take a bit.
+	 Also, the core does one call per DR register update, so that
+	 would result in a lot of suspend-resumes.  So instead, we
+	 suspend the thread if it wasn't already suspended, and queue
+	 a pending stop to be handled by windows_nat_target::wait.
+	 This means we only stop each thread once, and, we don't block
+	 waiting for each individual thread stop.  */
+      stop_one_thread (th, SK_INTERNAL);
+    }
+}
+
+/* Trampoline helper to get at the
+   windows_nat_target::debug_registers_changed_all_threads method in
+   the native target.  */
+
+void
+windows_debug_registers_changed_all_threads ()
+{
+  get_windows_nat_target ()->debug_registers_changed_all_threads ();
 }
 
 /* Determine if the thread referenced by "ptid" is alive

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -214,6 +214,8 @@ struct windows_nat_target : public inf_child_target
 
   bool thread_alive (ptid_t ptid) override;
 
+  const char *extra_thread_info (thread_info *info) override;
+
   std::string pid_to_str (ptid_t) override;
 
   void interrupt () override;

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -256,6 +256,7 @@ struct windows_nat_target : public inf_child_target
   }
 
   bool supports_non_stop () override;
+  bool always_non_stop_p () override;
 
   void async (bool enable) override;
 

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -77,6 +77,38 @@ enum windows_continue_flag
 
 DEF_ENUM_FLAGS_TYPE (windows_continue_flag, windows_continue_flags);
 
+/* We want to register windows_thread_info as struct thread_info
+   private data.  thread_info::priv must point to a class that
+   inherits from private_thread_info.  But we can't make
+   windows_thread_info inherit private_thread_info, because
+   windows_thread_info is shared with GDBserver.  So we make a new
+   class that inherits from both private_thread_info,
+   windows_thread_info, and register that one as thread_info::private.
+   This multiple inheritance is benign, because private_thread_info is
+   a java-style interface class with no data.  */
+struct windows_private_thread_info : private_thread_info, windows_thread_info
+{
+  windows_private_thread_info (windows_nat::windows_process_info *proc,
+			       DWORD tid, HANDLE h, CORE_ADDR tlb)
+    : windows_thread_info (proc, tid, h, tlb)
+  {}
+
+  ~windows_private_thread_info () override
+  {}
+};
+
+/* Get the windows_thread_info object associated with THR.  */
+
+static inline windows_thread_info *
+as_windows_thread_info (thread_info *thr)
+{
+  /* Cast to windows_private_thread_info, which inherits from
+     private_thread_info, and is implicitly convertible to
+     windows_thread_info, the return type.  */
+  private_thread_info *priv = thr->priv.get ();
+  return gdb::checked_static_cast<windows_private_thread_info *> (priv);
+}
+
 struct windows_per_inferior : public windows_nat::windows_process_info
 {
   windows_thread_info *find_thread (ptid_t ptid) override;
@@ -90,8 +122,6 @@ struct windows_per_inferior : public windows_nat::windows_process_info
   virtual void invalidate_thread_context (windows_thread_info *th) = 0;
 
   int windows_initialization_done = 0;
-
-  std::vector<std::unique_ptr<windows_thread_info>> thread_list;
 
   /* Counts of things.  */
   int saw_create = 0;
@@ -351,5 +381,70 @@ int amd64_windows_segment_register_p (int regnum);
 /* context register offsets for amd64.  */
 extern const int amd64_mappings[];
 #endif
+
+/* Creates an iterator that works like all_matching_threads_iterator,
+   but that returns windows_thread_info pointers instead of
+   thread_info.  This could be replaced with a std::range::transform
+   when we require C++20.  */
+class all_windows_threads_iterator
+{
+public:
+  typedef all_windows_threads_iterator self_type;
+  typedef windows_thread_info value_type;
+  typedef windows_thread_info *&reference;
+  typedef windows_thread_info **pointer;
+  typedef std::forward_iterator_tag iterator_category;
+  typedef int difference_type;
+
+  explicit all_windows_threads_iterator (all_non_exited_threads_iterator base_iter)
+    : m_base_iter (base_iter)
+  {}
+
+  windows_thread_info * operator* () const { return as_windows_thread_info (&*m_base_iter); }
+
+  all_windows_threads_iterator &operator++ ()
+  {
+    ++m_base_iter;
+    return *this;
+  }
+
+  bool operator== (const all_windows_threads_iterator &other) const
+  { return m_base_iter == other.m_base_iter; }
+
+  bool operator!= (const all_windows_threads_iterator &other) const
+  { return !(*this == other); }
+
+private:
+  all_non_exited_threads_iterator m_base_iter;
+};
+
+/* The range for all_windows_threads, below.  */
+
+class all_windows_threads_range : public all_non_exited_threads_range
+{
+public:
+  all_windows_threads_range (all_non_exited_threads_range base_range)
+    : m_base_range (base_range)
+  {}
+
+  all_windows_threads_iterator begin () const
+  { return all_windows_threads_iterator (m_base_range.begin ()); }
+  all_windows_threads_iterator end () const
+  { return all_windows_threads_iterator (m_base_range.end ()); }
+
+private:
+  all_non_exited_threads_range m_base_range;
+};
+
+/* Return a range that can be used to walk over all non-exited Windows
+   threads of all inferiors, with range-for.  */
+
+static inline all_windows_threads_range
+all_windows_threads ()
+{
+  auto *win_tgt = static_cast<windows_nat_target *> (get_native_target ());
+  return (all_windows_threads_range
+	  (all_non_exited_threads_range (win_tgt, minus_one_ptid)));
+}
 
 #endif /* GDB_WINDOWS_NAT_H */

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -73,6 +73,11 @@ enum windows_continue_flag
        call to continue the inferior -- we are either mourning it or
        detaching.  */
     WCONT_LAST_CALL = 2,
+
+    /* By default, windows_continue only calls ContinueDebugEvent in
+       all-stop mode.  This flag indicates that windows_continue
+       should call ContinueDebugEvent even in non-stop mode.  */
+    WCONT_CONTINUE_DEBUG_EVENT = 4,
   };
 
 DEF_ENUM_FLAGS_TYPE (windows_continue_flag, windows_continue_flags);
@@ -112,8 +117,8 @@ as_windows_thread_info (thread_info *thr)
 struct windows_per_inferior : public windows_nat::windows_process_info
 {
   windows_thread_info *find_thread (ptid_t ptid) override;
-  DWORD handle_output_debug_string (const DEBUG_EVENT &current_event,
-				    struct target_waitstatus *ourstatus) override;
+  bool handle_output_debug_string (const DEBUG_EVENT &current_event,
+				   struct target_waitstatus *ourstatus) override;
   void handle_load_dll (const char *dll_name, LPVOID base) override;
   void handle_unload_dll (const DEBUG_EVENT &current_event) override;
   bool handle_access_violation (const EXCEPTION_RECORD *rec) override;
@@ -211,6 +216,10 @@ struct windows_nat_target : public inf_child_target
   void pass_ctrlc () override;
   void stop (ptid_t ptid) override;
 
+  void thread_events (bool enable) override;
+
+  bool any_resumed_thread ();
+
   const char *pid_to_exec_file (int pid) override;
 
   ptid_t get_ada_task_ptid (long lwp, ULONGEST thread) override;
@@ -240,6 +249,8 @@ struct windows_nat_target : public inf_child_target
     return m_is_async;
   }
 
+  bool supports_non_stop () override;
+
   void async (bool enable) override;
 
   int async_wait_fd () override
@@ -259,8 +270,8 @@ protected:
   /* Prepare the thread context for continuing.  */
   virtual void thread_context_continue (windows_thread_info *th,
 					int killed) = 0;
-  /* Set the stepping bit in the thread context.  */
-  virtual void thread_context_step (windows_thread_info *th) = 0;
+  /* Set or clear the stepping bit in the thread context.  */
+  virtual void thread_context_step (windows_thread_info *th, bool enable) = 0;
 
   /* Fetches register number R from the given windows_thread_info,
      and supplies its value to the given regcache.
@@ -291,6 +302,15 @@ private:
 				   bool main_thread_p);
   void delete_thread (ptid_t ptid, DWORD exit_code, bool main_thread_p);
   DWORD fake_create_process (const DEBUG_EVENT &current_event);
+
+  void stop_one_thread (windows_thread_info *th);
+
+  DWORD continue_status_for_event_detaching
+    (const DEBUG_EVENT &event, size_t *reply_later_events_left = nullptr);
+
+  DWORD prepare_resume (windows_thread_info *wth,
+			thread_info *tp,
+			int step, gdb_signal sig);
 
   void continue_one_thread (windows_thread_info *th,
 			    windows_continue_flags cont_flags);
@@ -358,6 +378,9 @@ private:
      already returned an event, and we need to ContinueDebugEvent
      again to restart the inferior.  */
   bool m_continued = false;
+
+  /* Whether target_thread_events is in effect.  */
+  bool m_report_thread_events = false;
 };
 
 /* Check if Windows API call succeeds, and otherwise print error code

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -78,6 +78,10 @@ enum windows_continue_flag
        all-stop mode.  This flag indicates that windows_continue
        should call ContinueDebugEvent even in non-stop mode.  */
     WCONT_CONTINUE_DEBUG_EVENT = 4,
+
+    /* Skip calling ContinueDebugEvent even in all-stop mode.  This is
+       the default in non-stop mode.  */
+    WCONT_DONT_CONTINUE_DEBUG_EVENT = 8,
   };
 
 DEF_ENUM_FLAGS_TYPE (windows_continue_flag, windows_continue_flags);
@@ -258,6 +262,8 @@ struct windows_nat_target : public inf_child_target
     return serial_event_fd (m_wait_event);
   }
 
+  void debug_registers_changed_all_threads ();
+
 protected:
 
   /* Initialize arch-specific data for a new inferior (debug registers,
@@ -303,7 +309,8 @@ private:
   void delete_thread (ptid_t ptid, DWORD exit_code, bool main_thread_p);
   DWORD fake_create_process (const DEBUG_EVENT &current_event);
 
-  void stop_one_thread (windows_thread_info *th);
+  void stop_one_thread (windows_thread_info *th,
+			enum windows_nat::stopping_kind stopping_kind);
 
   DWORD continue_status_for_event_detaching
     (const DEBUG_EVENT &event, size_t *reply_later_events_left = nullptr);
@@ -469,5 +476,7 @@ all_windows_threads ()
   return (all_windows_threads_range
 	  (all_non_exited_threads_range (win_tgt, minus_one_ptid)));
 }
+
+extern void windows_debug_registers_changed_all_threads ();
 
 #endif /* GDB_WINDOWS_NAT_H */

--- a/gdb/windows-nat.h
+++ b/gdb/windows-nat.h
@@ -73,15 +73,56 @@ enum windows_continue_flag
        call to continue the inferior -- we are either mourning it or
        detaching.  */
     WCONT_LAST_CALL = 2,
+
+    /* By default, windows_continue only calls ContinueDebugEvent in
+       all-stop mode.  This flag indicates that windows_continue
+       should call ContinueDebugEvent even in non-stop mode.  */
+    WCONT_CONTINUE_DEBUG_EVENT = 4,
+
+    /* Skip calling ContinueDebugEvent even in all-stop mode.  This is
+       the default in non-stop mode.  */
+    WCONT_DONT_CONTINUE_DEBUG_EVENT = 8,
   };
 
 DEF_ENUM_FLAGS_TYPE (windows_continue_flag, windows_continue_flags);
 
+/* We want to register windows_thread_info as struct thread_info
+   private data.  thread_info::priv must point to a class that
+   inherits from private_thread_info.  But we can't make
+   windows_thread_info inherit private_thread_info, because
+   windows_thread_info is shared with GDBserver.  So we make a new
+   class that inherits from both private_thread_info,
+   windows_thread_info, and register that one as thread_info::private.
+   This multiple inheritance is benign, because private_thread_info is
+   a java-style interface class with no data.  */
+struct windows_private_thread_info : private_thread_info, windows_thread_info
+{
+  windows_private_thread_info (windows_nat::windows_process_info *proc,
+			       DWORD tid, HANDLE h, CORE_ADDR tlb)
+    : windows_thread_info (proc, tid, h, tlb)
+  {}
+
+  ~windows_private_thread_info () override
+  {}
+};
+
+/* Get the windows_thread_info object associated with THR.  */
+
+static inline windows_thread_info *
+as_windows_thread_info (thread_info *thr)
+{
+  /* Cast to windows_private_thread_info, which inherits from
+     private_thread_info, and is implicitly convertible to
+     windows_thread_info, the return type.  */
+  private_thread_info *priv = thr->priv.get ();
+  return gdb::checked_static_cast<windows_private_thread_info *> (priv);
+}
+
 struct windows_per_inferior : public windows_nat::windows_process_info
 {
   windows_thread_info *find_thread (ptid_t ptid) override;
-  DWORD handle_output_debug_string (const DEBUG_EVENT &current_event,
-				    struct target_waitstatus *ourstatus) override;
+  bool handle_output_debug_string (const DEBUG_EVENT &current_event,
+				   struct target_waitstatus *ourstatus) override;
   void handle_load_dll (const char *dll_name, LPVOID base) override;
   void handle_unload_dll (const DEBUG_EVENT &current_event) override;
   bool handle_access_violation (const EXCEPTION_RECORD *rec) override;
@@ -90,8 +131,6 @@ struct windows_per_inferior : public windows_nat::windows_process_info
   virtual void invalidate_thread_context (windows_thread_info *th) = 0;
 
   int windows_initialization_done = 0;
-
-  std::vector<std::unique_ptr<windows_thread_info>> thread_list;
 
   /* Counts of things.  */
   int saw_create = 0;
@@ -175,11 +214,17 @@ struct windows_nat_target : public inf_child_target
 
   bool thread_alive (ptid_t ptid) override;
 
+  const char *extra_thread_info (thread_info *info) override;
+
   std::string pid_to_str (ptid_t) override;
 
   void interrupt () override;
   void pass_ctrlc () override;
   void stop (ptid_t ptid) override;
+
+  void thread_events (bool enable) override;
+
+  bool any_resumed_thread ();
 
   const char *pid_to_exec_file (int pid) override;
 
@@ -210,12 +255,17 @@ struct windows_nat_target : public inf_child_target
     return m_is_async;
   }
 
+  bool supports_non_stop () override;
+  bool always_non_stop_p () override;
+
   void async (bool enable) override;
 
   int async_wait_fd () override
   {
     return serial_event_fd (m_wait_event);
   }
+
+  void debug_registers_changed_all_threads ();
 
 protected:
 
@@ -229,8 +279,8 @@ protected:
   /* Prepare the thread context for continuing.  */
   virtual void thread_context_continue (windows_thread_info *th,
 					int killed) = 0;
-  /* Set the stepping bit in the thread context.  */
-  virtual void thread_context_step (windows_thread_info *th) = 0;
+  /* Set or clear the stepping bit in the thread context.  */
+  virtual void thread_context_step (windows_thread_info *th, bool enable) = 0;
 
   /* Fetches register number R from the given windows_thread_info,
      and supplies its value to the given regcache.
@@ -261,6 +311,16 @@ private:
 				   bool main_thread_p);
   void delete_thread (ptid_t ptid, DWORD exit_code, bool main_thread_p);
   DWORD fake_create_process (const DEBUG_EVENT &current_event);
+
+  void stop_one_thread (windows_thread_info *th,
+			enum windows_nat::stopping_kind stopping_kind);
+
+  DWORD continue_status_for_event_detaching
+    (const DEBUG_EVENT &event, size_t *reply_later_events_left = nullptr);
+
+  DWORD prepare_resume (windows_thread_info *wth,
+			thread_info *tp,
+			int step, gdb_signal sig);
 
   void continue_one_thread (windows_thread_info *th,
 			    windows_continue_flags cont_flags);
@@ -328,6 +388,9 @@ private:
      already returned an event, and we need to ContinueDebugEvent
      again to restart the inferior.  */
   bool m_continued = false;
+
+  /* Whether target_thread_events is in effect.  */
+  bool m_report_thread_events = false;
 };
 
 /* Check if Windows API call succeeds, and otherwise print error code
@@ -351,5 +414,72 @@ int amd64_windows_segment_register_p (int regnum);
 /* context register offsets for amd64.  */
 extern const int amd64_mappings[];
 #endif
+
+/* Creates an iterator that works like all_matching_threads_iterator,
+   but that returns windows_thread_info pointers instead of
+   thread_info.  This could be replaced with a std::range::transform
+   when we require C++20.  */
+class all_windows_threads_iterator
+{
+public:
+  typedef all_windows_threads_iterator self_type;
+  typedef windows_thread_info value_type;
+  typedef windows_thread_info *&reference;
+  typedef windows_thread_info **pointer;
+  typedef std::forward_iterator_tag iterator_category;
+  typedef int difference_type;
+
+  explicit all_windows_threads_iterator (all_non_exited_threads_iterator base_iter)
+    : m_base_iter (base_iter)
+  {}
+
+  windows_thread_info * operator* () const { return as_windows_thread_info (&*m_base_iter); }
+
+  all_windows_threads_iterator &operator++ ()
+  {
+    ++m_base_iter;
+    return *this;
+  }
+
+  bool operator== (const all_windows_threads_iterator &other) const
+  { return m_base_iter == other.m_base_iter; }
+
+  bool operator!= (const all_windows_threads_iterator &other) const
+  { return !(*this == other); }
+
+private:
+  all_non_exited_threads_iterator m_base_iter;
+};
+
+/* The range for all_windows_threads, below.  */
+
+class all_windows_threads_range : public all_non_exited_threads_range
+{
+public:
+  all_windows_threads_range (all_non_exited_threads_range base_range)
+    : m_base_range (base_range)
+  {}
+
+  all_windows_threads_iterator begin () const
+  { return all_windows_threads_iterator (m_base_range.begin ()); }
+  all_windows_threads_iterator end () const
+  { return all_windows_threads_iterator (m_base_range.end ()); }
+
+private:
+  all_non_exited_threads_range m_base_range;
+};
+
+/* Return a range that can be used to walk over all non-exited Windows
+   threads of all inferiors, with range-for.  */
+
+static inline all_windows_threads_range
+all_windows_threads ()
+{
+  auto *win_tgt = static_cast<windows_nat_target *> (get_native_target ());
+  return (all_windows_threads_range
+	  (all_non_exited_threads_range (win_tgt, minus_one_ptid)));
+}
+
+extern void windows_debug_registers_changed_all_threads ();
 
 #endif /* GDB_WINDOWS_NAT_H */

--- a/gdb/x86-windows-nat.c
+++ b/gdb/x86-windows-nat.c
@@ -58,7 +58,7 @@ struct x86_windows_nat_target final : public x86_nat_target<windows_nat_target>
   void cleanup_windows_arch () override;
 
   void thread_context_continue (windows_thread_info *th, int killed) override;
-  void thread_context_step (windows_thread_info *th) override;
+  void thread_context_step (windows_thread_info *th, bool step) override;
 
   void fetch_one_register (struct regcache *regcache,
 			   windows_thread_info *th, int r) override;
@@ -213,11 +213,15 @@ x86_windows_nat_target::thread_context_continue (windows_thread_info *th,
 /* See windows-nat.h.  */
 
 void
-x86_windows_nat_target::thread_context_step (windows_thread_info *th)
+x86_windows_nat_target::thread_context_step (windows_thread_info *th,
+					     bool enable)
 {
   x86_windows_process.with_context (th, [&] (auto *context)
     {
-      context->EFlags |= FLAG_TRACE_BIT;
+      if (enable)
+	context->EFlags |= FLAG_TRACE_BIT;
+      else
+	context->EFlags &= ~FLAG_TRACE_BIT;
     });
 }
 

--- a/gdb/x86-windows-nat.c
+++ b/gdb/x86-windows-nat.c
@@ -350,8 +350,7 @@ windows_set_dr (int i, CORE_ADDR addr)
   if (i < 0 || i > 3)
     internal_error (_("Invalid register %d in windows_set_dr.\n"), i);
 
-  for (auto *th : all_windows_threads ())
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 /* Pass the value VAL to the inferior in the DR7 debug control
@@ -360,8 +359,7 @@ windows_set_dr (int i, CORE_ADDR addr)
 static void
 windows_set_dr7 (unsigned long val)
 {
-  for (auto *th : all_windows_threads ())
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 /* Get the value of debug register I from the inferior.  */

--- a/gdb/x86-windows-nat.c
+++ b/gdb/x86-windows-nat.c
@@ -346,7 +346,7 @@ windows_set_dr (int i, CORE_ADDR addr)
   if (i < 0 || i > 3)
     internal_error (_("Invalid register %d in windows_set_dr.\n"), i);
 
-  for (auto &th : x86_windows_process.thread_list)
+  for (auto *th : all_windows_threads ())
     th->debug_registers_changed = true;
 }
 
@@ -356,7 +356,7 @@ windows_set_dr (int i, CORE_ADDR addr)
 static void
 windows_set_dr7 (unsigned long val)
 {
-  for (auto &th : x86_windows_process.thread_list)
+  for (auto *th : all_windows_threads ())
     th->debug_registers_changed = true;
 }
 

--- a/gdb/x86-windows-nat.c
+++ b/gdb/x86-windows-nat.c
@@ -58,7 +58,7 @@ struct x86_windows_nat_target final : public x86_nat_target<windows_nat_target>
   void cleanup_windows_arch () override;
 
   void thread_context_continue (windows_thread_info *th, int killed) override;
-  void thread_context_step (windows_thread_info *th) override;
+  void thread_context_step (windows_thread_info *th, bool step) override;
 
   void fetch_one_register (struct regcache *regcache,
 			   windows_thread_info *th, int r) override;
@@ -213,11 +213,15 @@ x86_windows_nat_target::thread_context_continue (windows_thread_info *th,
 /* See windows-nat.h.  */
 
 void
-x86_windows_nat_target::thread_context_step (windows_thread_info *th)
+x86_windows_nat_target::thread_context_step (windows_thread_info *th,
+					     bool enable)
 {
   x86_windows_process.with_context (th, [&] (auto *context)
     {
-      context->EFlags |= FLAG_TRACE_BIT;
+      if (enable)
+	context->EFlags |= FLAG_TRACE_BIT;
+      else
+	context->EFlags &= ~FLAG_TRACE_BIT;
     });
 }
 
@@ -346,8 +350,7 @@ windows_set_dr (int i, CORE_ADDR addr)
   if (i < 0 || i > 3)
     internal_error (_("Invalid register %d in windows_set_dr.\n"), i);
 
-  for (auto &th : x86_windows_process.thread_list)
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 /* Pass the value VAL to the inferior in the DR7 debug control
@@ -356,8 +359,7 @@ windows_set_dr (int i, CORE_ADDR addr)
 static void
 windows_set_dr7 (unsigned long val)
 {
-  for (auto &th : x86_windows_process.thread_list)
-    th->debug_registers_changed = true;
+  windows_debug_registers_changed_all_threads ();
 }
 
 /* Get the value of debug register I from the inferior.  */

--- a/gdbserver/win32-low.cc
+++ b/gdbserver/win32-low.cc
@@ -333,8 +333,9 @@ do_initial_child_stuff (HANDLE proch, DWORD pid, int attached)
 
       the_target->wait (minus_one_ptid, &status, 0);
 
-      /* Note win32_wait doesn't return thread events.  */
-      if (status.kind () != TARGET_WAITKIND_LOADED)
+      if (status.kind () == TARGET_WAITKIND_EXITED
+	  || status.kind () == TARGET_WAITKIND_SIGNALLED
+	  || status.kind () == TARGET_WAITKIND_STOPPED)
 	{
 	  windows_process.cached_status = status;
 	  break;
@@ -593,7 +594,7 @@ win32_process_target::attach (unsigned long pid)
 
 /* See nat/windows-nat.h.  */
 
-DWORD
+bool
 gdbserver_windows_process::handle_output_debug_string
   (const DEBUG_EVENT &current_event,
    struct target_waitstatus *ourstatus)
@@ -604,7 +605,7 @@ gdbserver_windows_process::handle_output_debug_string
   DWORD nbytes = current_event.u.DebugString.nDebugStringLength;
 
   if (nbytes == 0)
-    return 0;
+    return false;
 
   if (nbytes > READ_BUFFER_LEN)
     nbytes = READ_BUFFER_LEN;
@@ -623,7 +624,7 @@ gdbserver_windows_process::handle_output_debug_string
   else
     {
       if (read_inferior_memory (addr, (unsigned char *) s, nbytes) != 0)
-	return 0;
+	return false;
     }
 
   if (!startswith (s, "cYg"))
@@ -631,14 +632,14 @@ gdbserver_windows_process::handle_output_debug_string
       if (!server_waiting)
 	{
 	  OUTMSG2(("%s", s));
-	  return 0;
+	  return false;
 	}
 
       monitor_output (s);
     }
 #undef READ_BUFFER_LEN
 
-  return 0;
+  return false;
 }
 
 static void

--- a/gdbserver/win32-low.cc
+++ b/gdbserver/win32-low.cc
@@ -997,13 +997,14 @@ get_child_debug_event (DWORD *continue_status,
       }
   }
 
+  OUTMSG2 (("gdbserver: kernel event %s for pid=%u tid=%x)\n",
+	    event_code_to_string (current_event->dwDebugEventCode).c_str (),
+	    (unsigned) current_event->dwProcessId,
+	    (unsigned) current_event->dwThreadId));
+
   switch (current_event->dwDebugEventCode)
     {
     case CREATE_THREAD_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event CREATE_THREAD_DEBUG_EVENT "
-		"for pid=%u tid=%x)\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
 
       /* Record the existence of this thread.  */
       child_add_thread (current_event->dwProcessId,
@@ -1013,10 +1014,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXIT_THREAD_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXIT_THREAD_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       child_delete_thread (current_event->dwProcessId,
 			   current_event->dwThreadId);
 
@@ -1024,10 +1021,6 @@ get_child_debug_event (DWORD *continue_status,
       return 1;
 
     case CREATE_PROCESS_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event CREATE_PROCESS_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       CloseHandle (current_event->u.CreateProcessInfo.hFile);
 
       if (windows_process.open_process_used)
@@ -1047,10 +1040,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXIT_PROCESS_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXIT_PROCESS_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       {
 	DWORD exit_status = current_event->u.ExitProcess.dwExitCode;
 	/* If the exit status looks like a fatal exception, but we
@@ -1067,10 +1056,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case LOAD_DLL_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event LOAD_DLL_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       CloseHandle (current_event->u.LoadDll.hFile);
       if (! windows_process.child_initialization_done)
 	break;
@@ -1080,10 +1065,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case UNLOAD_DLL_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event UNLOAD_DLL_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       if (! windows_process.child_initialization_done)
 	break;
       windows_process.handle_unload_dll (*current_event);
@@ -1091,10 +1072,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXCEPTION_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXCEPTION_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       if (windows_process.handle_exception (*current_event,
 					    ourstatus, debug_threads)
 	  == HANDLE_EXCEPTION_UNHANDLED)
@@ -1103,19 +1080,7 @@ get_child_debug_event (DWORD *continue_status,
 
     case OUTPUT_DEBUG_STRING_EVENT:
       /* A message from the kernel (or Cygwin).  */
-      OUTMSG2 (("gdbserver: kernel event OUTPUT_DEBUG_STRING_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       windows_process.handle_output_debug_string (*current_event, nullptr);
-      break;
-
-    default:
-      OUTMSG2 (("gdbserver: kernel event unknown "
-		"for pid=%u tid=%x code=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId,
-		(unsigned) current_event->dwDebugEventCode));
       break;
     }
 

--- a/gdbserver/win32-low.cc
+++ b/gdbserver/win32-low.cc
@@ -333,8 +333,9 @@ do_initial_child_stuff (HANDLE proch, DWORD pid, int attached)
 
       the_target->wait (minus_one_ptid, &status, 0);
 
-      /* Note win32_wait doesn't return thread events.  */
-      if (status.kind () != TARGET_WAITKIND_LOADED)
+      if (status.kind () == TARGET_WAITKIND_EXITED
+	  || status.kind () == TARGET_WAITKIND_SIGNALLED
+	  || status.kind () == TARGET_WAITKIND_STOPPED)
 	{
 	  windows_process.cached_status = status;
 	  break;
@@ -593,7 +594,7 @@ win32_process_target::attach (unsigned long pid)
 
 /* See nat/windows-nat.h.  */
 
-DWORD
+bool
 gdbserver_windows_process::handle_output_debug_string
   (const DEBUG_EVENT &current_event,
    struct target_waitstatus *ourstatus)
@@ -604,7 +605,7 @@ gdbserver_windows_process::handle_output_debug_string
   DWORD nbytes = current_event.u.DebugString.nDebugStringLength;
 
   if (nbytes == 0)
-    return 0;
+    return false;
 
   if (nbytes > READ_BUFFER_LEN)
     nbytes = READ_BUFFER_LEN;
@@ -623,7 +624,7 @@ gdbserver_windows_process::handle_output_debug_string
   else
     {
       if (read_inferior_memory (addr, (unsigned char *) s, nbytes) != 0)
-	return 0;
+	return false;
     }
 
   if (!startswith (s, "cYg"))
@@ -631,14 +632,14 @@ gdbserver_windows_process::handle_output_debug_string
       if (!server_waiting)
 	{
 	  OUTMSG2(("%s", s));
-	  return 0;
+	  return false;
 	}
 
       monitor_output (s);
     }
 #undef READ_BUFFER_LEN
 
-  return 0;
+  return false;
 }
 
 static void
@@ -997,13 +998,14 @@ get_child_debug_event (DWORD *continue_status,
       }
   }
 
+  OUTMSG2 (("gdbserver: kernel event %s for pid=%u tid=%x)\n",
+	    event_code_to_string (current_event->dwDebugEventCode).c_str (),
+	    (unsigned) current_event->dwProcessId,
+	    (unsigned) current_event->dwThreadId));
+
   switch (current_event->dwDebugEventCode)
     {
     case CREATE_THREAD_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event CREATE_THREAD_DEBUG_EVENT "
-		"for pid=%u tid=%x)\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
 
       /* Record the existence of this thread.  */
       child_add_thread (current_event->dwProcessId,
@@ -1013,10 +1015,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXIT_THREAD_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXIT_THREAD_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       child_delete_thread (current_event->dwProcessId,
 			   current_event->dwThreadId);
 
@@ -1024,10 +1022,6 @@ get_child_debug_event (DWORD *continue_status,
       return 1;
 
     case CREATE_PROCESS_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event CREATE_PROCESS_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       CloseHandle (current_event->u.CreateProcessInfo.hFile);
 
       if (windows_process.open_process_used)
@@ -1047,10 +1041,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXIT_PROCESS_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXIT_PROCESS_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       {
 	DWORD exit_status = current_event->u.ExitProcess.dwExitCode;
 	/* If the exit status looks like a fatal exception, but we
@@ -1067,10 +1057,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case LOAD_DLL_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event LOAD_DLL_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       CloseHandle (current_event->u.LoadDll.hFile);
       if (! windows_process.child_initialization_done)
 	break;
@@ -1080,10 +1066,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case UNLOAD_DLL_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event UNLOAD_DLL_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       if (! windows_process.child_initialization_done)
 	break;
       windows_process.handle_unload_dll (*current_event);
@@ -1091,10 +1073,6 @@ get_child_debug_event (DWORD *continue_status,
       break;
 
     case EXCEPTION_DEBUG_EVENT:
-      OUTMSG2 (("gdbserver: kernel event EXCEPTION_DEBUG_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       if (windows_process.handle_exception (*current_event,
 					    ourstatus, debug_threads)
 	  == HANDLE_EXCEPTION_UNHANDLED)
@@ -1103,19 +1081,7 @@ get_child_debug_event (DWORD *continue_status,
 
     case OUTPUT_DEBUG_STRING_EVENT:
       /* A message from the kernel (or Cygwin).  */
-      OUTMSG2 (("gdbserver: kernel event OUTPUT_DEBUG_STRING_EVENT "
-		"for pid=%u tid=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId));
       windows_process.handle_output_debug_string (*current_event, nullptr);
-      break;
-
-    default:
-      OUTMSG2 (("gdbserver: kernel event unknown "
-		"for pid=%u tid=%x code=%x\n",
-		(unsigned) current_event->dwProcessId,
-		(unsigned) current_event->dwThreadId,
-		(unsigned) current_event->dwDebugEventCode));
       break;
     }
 

--- a/gdbserver/win32-low.h
+++ b/gdbserver/win32-low.h
@@ -179,8 +179,8 @@ public:
 struct gdbserver_windows_process : public windows_nat::windows_process_info
 {
   windows_nat::windows_thread_info *find_thread (ptid_t ptid) override;
-  DWORD handle_output_debug_string (const DEBUG_EVENT &current_event,
-				    struct target_waitstatus *ourstatus) override;
+  bool handle_output_debug_string (const DEBUG_EVENT &current_event,
+				   struct target_waitstatus *ourstatus) override;
   void handle_load_dll (const char *dll_name, LPVOID base) override;
   void handle_unload_dll (const DEBUG_EVENT &current_event) override;
   bool handle_access_violation (const EXCEPTION_RECORD *rec) override;

--- a/gdbsupport/function-view.h
+++ b/gdbsupport/function-view.h
@@ -193,6 +193,8 @@
   unittests/function-view-selftests.c.  */
 
 #include <type_traits>
+#include "gdbsupport/traits.h"
+
 namespace gdb {
 
 namespace fv_detail {

--- a/gprof/corefile.c
+++ b/gprof/corefile.c
@@ -34,6 +34,7 @@
 bfd *core_bfd;
 static int core_num_syms;
 static asymbol **core_syms;
+static bfd *core_debug_bfd;	/* Separated debuginfo file, if any.  */
 asection *core_text_sect;
 void * core_text_space;
 
@@ -173,6 +174,59 @@ read_function_mappings (const char *filename)
   fclose (file);
 }
 
+/* Attempt to open separated debuginfo files (e.g., created with "strip -g").
+   This function tries to follow GNU debug links to locate external debug info
+   and opens them to make symbol and line information available.  */
+
+static void
+open_separated_debug_file (bfd *abfd)
+{
+  char *debug_filename = NULL;
+  bfd *debug_bfd;
+
+  /* Try to follow .gnu_debuglink first (standard separated debug file).  */
+  debug_filename = bfd_follow_gnu_debuglink (abfd, NULL);
+
+  if (!debug_filename)
+    {
+      /* Try alternate debug info (.gnu_debugaltlink).  */
+      debug_filename = bfd_follow_gnu_debugaltlink (abfd, NULL);
+    }
+
+  if (!debug_filename)
+    {
+      /* Try build-id based debug file location.  */
+      debug_filename = bfd_follow_build_id_debuglink (abfd, NULL);
+    }
+
+  if (debug_filename)
+    {
+      debug_bfd = bfd_openr (debug_filename, 0);
+
+      if (debug_bfd)
+	{
+	  if (bfd_check_format (debug_bfd, bfd_object))
+	    {
+	      /* Successfully opened the debug file.
+	         Enable decompression on the debug file.  */
+	      if ((debug_bfd->flags & BFD_DECOMPRESS) == 0)
+		debug_bfd->flags |= BFD_DECOMPRESS;
+
+	      /* Store the debug BFD for use during symbol reading.
+	         We'll use this for bfd_canonicalize_symtab and other symbol ops.  */
+	      core_debug_bfd = debug_bfd;
+	    }
+	  else
+	    {
+	      /* Debug file format check failed.  */
+	      bfd_close (debug_bfd);
+	    }
+	}
+
+      free (debug_filename);
+    }
+}
+
 void
 core_init (const char * aout_name)
 {
@@ -196,6 +250,11 @@ core_init (const char * aout_name)
       done (1);
     }
 
+  /* Attempt to open separated debuginfo files if available.
+     This handles binaries stripped with "strip -g" by locating and opening
+     the external debug information via .gnu_debuglink or build-id.  */
+  open_separated_debug_file (core_bfd);
+
   /* Get core's text section.  */
   core_text_sect = bfd_get_section_by_name (core_bfd, ".text");
   if (!core_text_sect)
@@ -212,7 +271,10 @@ core_init (const char * aout_name)
   /* Read core's symbol table.  */
 
   /* This will probably give us more than we need, but that's ok.  */
-  core_sym_bytes = bfd_get_symtab_upper_bound (core_bfd);
+  /* Use debug BFD for symbol info if we found a separated debuginfo file.  */
+  bfd *sym_bfd = core_debug_bfd ? core_debug_bfd : core_bfd;
+
+  core_sym_bytes = bfd_get_symtab_upper_bound (sym_bfd);
   if (core_sym_bytes < 0)
     {
       fprintf (stderr, "%s: %s: %s\n", whoami, aout_name,
@@ -221,7 +283,7 @@ core_init (const char * aout_name)
     }
 
   core_syms = (asymbol **) xmalloc (core_sym_bytes);
-  core_num_syms = bfd_canonicalize_symtab (core_bfd, core_syms);
+  core_num_syms = bfd_canonicalize_symtab (sym_bfd, core_syms);
 
   if (core_num_syms < 0)
     {
@@ -230,7 +292,7 @@ core_init (const char * aout_name)
       done (1);
     }
 
-  synth_count = bfd_get_synthetic_symtab (core_bfd, core_num_syms, core_syms,
+  synth_count = bfd_get_synthetic_symtab (sym_bfd, core_num_syms, core_syms,
 					  0, NULL, &synthsyms);
   if (synth_count > 0)
     {
@@ -468,8 +530,10 @@ get_src_info (bfd_vma addr, const char **filename, const char **name,
 {
   const char *fname = 0, *func_name = 0;
   int l = 0;
+  /* Use debug BFD for line info if we have a separated debuginfo file.  */
+  bfd *info_bfd = core_debug_bfd ? core_debug_bfd : core_bfd;
 
-  if (bfd_find_nearest_line (core_bfd, core_text_sect, core_syms,
+  if (bfd_find_nearest_line (info_bfd, core_text_sect, core_syms,
 			     addr - core_text_sect->vma,
 			     &fname, &func_name, (unsigned int *) &l)
       && fname && func_name && l)

--- a/gprof/corefile.c
+++ b/gprof/corefile.c
@@ -207,6 +207,10 @@ open_separated_debug_file (bfd *abfd)
 	{
 	  if (bfd_check_format (debug_bfd, bfd_object))
 	    {
+	      /* Successfully opened the debug file.
+	         Enable decompression on the debug file.  */
+              debug_bfd->flags |= BFD_DECOMPRESS;
+
 	      /* Store the debug BFD for use during symbol reading.
 	         We'll use this for bfd_canonicalize_symtab and other symbol ops.  */
 	      core_debug_bfd = debug_bfd;

--- a/gprof/corefile.c
+++ b/gprof/corefile.c
@@ -207,11 +207,6 @@ open_separated_debug_file (bfd *abfd)
 	{
 	  if (bfd_check_format (debug_bfd, bfd_object))
 	    {
-	      /* Successfully opened the debug file.
-	         Enable decompression on the debug file.  */
-	      if ((debug_bfd->flags & BFD_DECOMPRESS) == 0)
-		debug_bfd->flags |= BFD_DECOMPRESS;
-
 	      /* Store the debug BFD for use during symbol reading.
 	         We'll use this for bfd_canonicalize_symtab and other symbol ops.  */
 	      core_debug_bfd = debug_bfd;

--- a/gprof/corefile.c
+++ b/gprof/corefile.c
@@ -34,6 +34,7 @@
 bfd *core_bfd;
 static int core_num_syms;
 static asymbol **core_syms;
+static bfd *core_debug_bfd;	/* Separated debuginfo file, if any.  */
 asection *core_text_sect;
 void * core_text_space;
 
@@ -173,6 +174,58 @@ read_function_mappings (const char *filename)
   fclose (file);
 }
 
+/* Attempt to open separated debuginfo files (e.g., created with "strip -g").
+   This function tries to follow GNU debug links to locate external debug info
+   and opens them to make symbol and line information available.  */
+
+static void
+open_separated_debug_file (bfd *abfd)
+{
+  char *debug_filename = NULL;
+  bfd *debug_bfd;
+
+  /* Try to follow .gnu_debuglink first (standard separated debug file).  */
+  debug_filename = bfd_follow_gnu_debuglink (abfd, NULL);
+
+  if (!debug_filename)
+    {
+      /* Try alternate debug info (.gnu_debugaltlink).  */
+      debug_filename = bfd_follow_gnu_debugaltlink (abfd, NULL);
+    }
+
+  if (!debug_filename)
+    {
+      /* Try build-id based debug file location.  */
+      debug_filename = bfd_follow_build_id_debuglink (abfd, NULL);
+    }
+
+  if (debug_filename)
+    {
+      debug_bfd = bfd_openr (debug_filename, 0);
+
+      if (debug_bfd)
+	{
+	  if (bfd_check_format (debug_bfd, bfd_object))
+	    {
+	      /* Successfully opened the debug file.
+	         Enable decompression on the debug file.  */
+              debug_bfd->flags |= BFD_DECOMPRESS;
+
+	      /* Store the debug BFD for use during symbol reading.
+	         We'll use this for bfd_canonicalize_symtab and other symbol ops.  */
+	      core_debug_bfd = debug_bfd;
+	    }
+	  else
+	    {
+	      /* Debug file format check failed.  */
+	      bfd_close (debug_bfd);
+	    }
+	}
+
+      free (debug_filename);
+    }
+}
+
 void
 core_init (const char * aout_name)
 {
@@ -196,6 +249,11 @@ core_init (const char * aout_name)
       done (1);
     }
 
+  /* Attempt to open separated debuginfo files if available.
+     This handles binaries stripped with "strip -g" by locating and opening
+     the external debug information via .gnu_debuglink or build-id.  */
+  open_separated_debug_file (core_bfd);
+
   /* Get core's text section.  */
   core_text_sect = bfd_get_section_by_name (core_bfd, ".text");
   if (!core_text_sect)
@@ -212,7 +270,10 @@ core_init (const char * aout_name)
   /* Read core's symbol table.  */
 
   /* This will probably give us more than we need, but that's ok.  */
-  core_sym_bytes = bfd_get_symtab_upper_bound (core_bfd);
+  /* Use debug BFD for symbol info if we found a separated debuginfo file.  */
+  bfd *sym_bfd = core_debug_bfd ? core_debug_bfd : core_bfd;
+
+  core_sym_bytes = bfd_get_symtab_upper_bound (sym_bfd);
   if (core_sym_bytes < 0)
     {
       fprintf (stderr, "%s: %s: %s\n", whoami, aout_name,
@@ -221,7 +282,7 @@ core_init (const char * aout_name)
     }
 
   core_syms = (asymbol **) xmalloc (core_sym_bytes);
-  core_num_syms = bfd_canonicalize_symtab (core_bfd, core_syms);
+  core_num_syms = bfd_canonicalize_symtab (sym_bfd, core_syms);
 
   if (core_num_syms < 0)
     {
@@ -230,7 +291,7 @@ core_init (const char * aout_name)
       done (1);
     }
 
-  synth_count = bfd_get_synthetic_symtab (core_bfd, core_num_syms, core_syms,
+  synth_count = bfd_get_synthetic_symtab (sym_bfd, core_num_syms, core_syms,
 					  0, NULL, &synthsyms);
   if (synth_count > 0)
     {
@@ -468,8 +529,10 @@ get_src_info (bfd_vma addr, const char **filename, const char **name,
 {
   const char *fname = 0, *func_name = 0;
   int l = 0;
+  /* Use debug BFD for line info if we have a separated debuginfo file.  */
+  bfd *info_bfd = core_debug_bfd ? core_debug_bfd : core_bfd;
 
-  if (bfd_find_nearest_line (core_bfd, core_text_sect, core_syms,
+  if (bfd_find_nearest_line (info_bfd, core_text_sect, core_syms,
 			     addr - core_text_sect->vma,
 			     &fname, &func_name, (unsigned int *) &l)
       && fname && func_name && l)

--- a/gprof/source.c
+++ b/gprof/source.c
@@ -126,7 +126,7 @@ annotate_source (Source_File *sf, unsigned int max_width,
 	  name_only = strrchr (sf->name, '/');
 #ifdef HAVE_DOS_BASED_FILE_SYSTEM
 	  {
-	    char *bslash = strrchr (sf->name, '\\');
+	    const char *bslash = strrchr (sf->name, '\\');
 	    if (name_only == NULL || (bslash != NULL && bslash > name_only))
 	      name_only = bslash;
 	    if (name_only == NULL && sf->name[0] != '\0' && sf->name[1] == ':')
@@ -183,7 +183,7 @@ annotate_source (Source_File *sf, unsigned int max_width,
       filename = strrchr (sf->name, '/');
 #ifdef HAVE_DOS_BASED_FILE_SYSTEM
 	{
-	  char *bslash = strrchr (sf->name, '\\');
+	  const char *bslash = strrchr (sf->name, '\\');
 	  if (filename == NULL || (bslash != NULL && bslash > filename))
 	    filename = bslash;
 	  if (filename == NULL && sf->name[0] != '\0' && sf->name[1] == ':')

--- a/gprof/testsuite/Makefile.am
+++ b/gprof/testsuite/Makefile.am
@@ -37,9 +37,23 @@ tst-gmon-gprof.out: tst-gmon$(EXEEXT) $(GPROF)
 
 check_SCRIPTS += tst-gmon-gprof-l.sh
 check_DATA += tst-gmon-gprof-l.out
-# Run tst-gmon-gprof-l.sh after tst-gmon-gprof.sh to avoid the race
-# condition since they both generate gmon.out.
-tst-gmon-gprof-l.out: tst-gmon$(EXEEXT) $(GPROF) tst-gmon-gprof.out
+tst-gmon-gprof-l.out: tst-gmon$(EXEEXT) $(GPROF)
 	$(srcdir)/tst-gmon-gprof-l.sh $(GPROF) tst-gmon$(EXEEXT)
+
+# Create a separated-debuginfo version of the initial binary 
+check_SCRIPTS += tst-gmon-gprof-l2.sh
+tst-gmon2$(EXEEXT) tst-gmon2.debug: tst-gmon$(EXEEXT)
+	cp -p tst-gmon$(EXEEXT) tst-gmon2$(EXEEXT)
+	objcopy --only-keep-debug tst-gmon2$(EXEEXT) tst-gmon2.debug
+	strip --strip-debug tst-gmon2$(EXEEXT)
+	objcopy --add-gnu-debuglink=tst-gmon2.debug tst-gmon2$(EXEEXT)
+
+tst-gmon-gprof-l2.out: tst-gmon2$(EXEEXT) tst-gmon2.debug $(GPROF)
+	$(srcdir)/tst-gmon-gprof-l2.sh $(GPROF) tst-gmon2$(EXEEXT)
+check_DATA += tst-gmon-gprof-l2.out
+MOSTLYCLEANFILES += tst-gmon2$(EXEEXT) tst-gmon2.debug
+
+# Run all tests in series, so they don't fight over the gmon.out file
+.NOTPARALLEL:
 
 endif NATIVE

--- a/gprof/testsuite/Makefile.in
+++ b/gprof/testsuite/Makefile.in
@@ -90,9 +90,14 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-@NATIVE_TRUE@am__append_1 = tst-gmon-gprof.sh tst-gmon-gprof-l.sh
-@NATIVE_TRUE@am__append_2 = tst-gmon-gprof.out tst-gmon-gprof-l.out
-@NATIVE_TRUE@am__append_3 = tst-gmon.$(OBJEXT) tst-gmon$(EXEEXT) gmon.out
+
+# Create a separated-debuginfo version of the initial binary 
+@NATIVE_TRUE@am__append_1 = tst-gmon-gprof.sh tst-gmon-gprof-l.sh \
+@NATIVE_TRUE@	tst-gmon-gprof-l2.sh
+@NATIVE_TRUE@am__append_2 = tst-gmon-gprof.out tst-gmon-gprof-l.out \
+@NATIVE_TRUE@	tst-gmon-gprof-l2.out
+@NATIVE_TRUE@am__append_3 = tst-gmon.$(OBJEXT) tst-gmon$(EXEEXT) \
+@NATIVE_TRUE@	gmon.out tst-gmon2$(EXEEXT) tst-gmon2.debug
 subdir = testsuite
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/../bfd/warning.m4 \
@@ -713,6 +718,13 @@ tst-gmon-gprof-l.sh.log: tst-gmon-gprof-l.sh
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+tst-gmon-gprof-l2.sh.log: tst-gmon-gprof-l2.sh
+	@p='tst-gmon-gprof-l2.sh'; \
+	b='tst-gmon-gprof-l2.sh'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -887,10 +899,19 @@ uninstall-am:
 @NATIVE_TRUE@	$(LINK) tst-gmon.$(OBJEXT)
 @NATIVE_TRUE@tst-gmon-gprof.out: tst-gmon$(EXEEXT) $(GPROF)
 @NATIVE_TRUE@	$(srcdir)/tst-gmon-gprof.sh $(GPROF) tst-gmon$(EXEEXT)
-# Run tst-gmon-gprof-l.sh after tst-gmon-gprof.sh to avoid the race
-# condition since they both generate gmon.out.
-@NATIVE_TRUE@tst-gmon-gprof-l.out: tst-gmon$(EXEEXT) $(GPROF) tst-gmon-gprof.out
+@NATIVE_TRUE@tst-gmon-gprof-l.out: tst-gmon$(EXEEXT) $(GPROF)
 @NATIVE_TRUE@	$(srcdir)/tst-gmon-gprof-l.sh $(GPROF) tst-gmon$(EXEEXT)
+@NATIVE_TRUE@tst-gmon2$(EXEEXT) tst-gmon2.debug: tst-gmon$(EXEEXT)
+@NATIVE_TRUE@	cp -p tst-gmon$(EXEEXT) tst-gmon2$(EXEEXT)
+@NATIVE_TRUE@	objcopy --only-keep-debug tst-gmon2$(EXEEXT) tst-gmon2.debug
+@NATIVE_TRUE@	strip --strip-debug tst-gmon2$(EXEEXT)
+@NATIVE_TRUE@	objcopy --add-gnu-debuglink=tst-gmon2.debug tst-gmon2$(EXEEXT)
+
+@NATIVE_TRUE@tst-gmon-gprof-l2.out: tst-gmon2$(EXEEXT) tst-gmon2.debug $(GPROF)
+@NATIVE_TRUE@	$(srcdir)/tst-gmon-gprof-l2.sh $(GPROF) tst-gmon2$(EXEEXT)
+
+# Run all tests in series, so they don't fight over the gmon.out file
+@NATIVE_TRUE@.NOTPARALLEL:
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/gprof/testsuite/tst-gmon-gprof-l2.sh
+++ b/gprof/testsuite/tst-gmon-gprof-l2.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Check the output of gprof against a carfully crafted binary.
+# Copyright (C) 2017-2025 Free Software Foundation, Inc.
+# This file is part of the GNU C Library.
+
+# The GNU C Library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# The GNU C Library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with the GNU C Library; if not, see
+# <https://www.gnu.org/licenses/>.
+
+GPROF="$1"
+if test -z "$GPROF"; then
+  # Exit 0 for automake test script run.
+  exit 0
+fi
+
+program="$2"
+# Generate gmon.out
+data=gmon.out
+rm -f $data
+./$program
+if test ! -s $data; then
+    echo "FAIL"
+    exit 1
+fi
+
+LC_ALL=C
+export LC_ALL
+set -e
+exec 2>&1
+
+actual=${program}.actual-l
+expected=${program}.expected-l
+expected_dot=${program}.expected_dot-l
+cleanup () {
+    rm -f "$actual"
+    rm -f "$expected"
+    rm -f "$expected_dot"
+}
+trap cleanup 0
+
+cat > "$expected" <<EOF
+25 f1 2000
+31 f2 1000
+40 f3 1
+EOF
+
+# Special version for powerpc with function descriptors.
+cat > "$expected_dot" <<EOF
+25 .f1 2000
+31 .f2 1000
+40 .f3 1
+EOF
+
+"$GPROF" -l -C "$program" "$data" \
+    | awk -F  '[(): ]' '/executions/{print $2, $5, $8}' \
+    | sort > "$actual"
+
+if cmp -s "$actual" "$expected_dot" \
+   || diff -u --label expected "$expected" --label actual "$actual" ; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi

--- a/include/bfdlink.h
+++ b/include/bfdlink.h
@@ -572,10 +572,6 @@ struct bfd_link_info
   /* TRUE if program headers ought to be loaded.  */
   unsigned int load_phdrs: 1;
 
-  /* TRUE if we should check relocations after all input files have
-     been opened.  */
-  unsigned int check_relocs_after_open_input: 1;
-
   /* TRUE if generation of .interp/PT_INTERP should be suppressed.  */
   unsigned int nointerp: 1;
 

--- a/ld/emultempl/aarch64elf.em
+++ b/ld/emultempl/aarch64elf.em
@@ -59,7 +59,6 @@ gld${EMULATION_NAME}_before_parse (void)
   input_flags.dynamic = ${DYNAMIC_LINK-true};
   config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo true ; else echo false ; fi`;
   config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo true ; else echo false ; fi`;
-  link_info.check_relocs_after_open_input = true;
 EOF
 if test -n "$COMMONPAGESIZE"; then
 fragment <<EOF

--- a/ld/emultempl/armelf.em
+++ b/ld/emultempl/armelf.em
@@ -59,7 +59,6 @@ gld${EMULATION_NAME}_before_parse (void)
   input_flags.dynamic = ${DYNAMIC_LINK-true};
   config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo true ; else echo false ; fi`;
   config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo true ; else echo false ; fi`;
-  link_info.check_relocs_after_open_input = true;
 EOF
 if test -n "$COMMONPAGESIZE"; then
 fragment <<EOF

--- a/ld/emultempl/beos.em
+++ b/ld/emultempl/beos.em
@@ -554,7 +554,7 @@ sort_sections (lang_statement_union_type *s)
 		 the linker handle the rest).  */
 	      if (sec->spec.name != NULL)
 		{
-		  char *q = strchr (sec->spec.name, '\$');
+		  const char *q = strchr (sec->spec.name, '\$');
 
 		  if (q != NULL
 		      && (q[1] == '\0'

--- a/ld/emultempl/elf.em
+++ b/ld/emultempl/elf.em
@@ -84,7 +84,6 @@ gld${EMULATION_NAME}_before_parse (void)
   input_flags.dynamic = ${DYNAMIC_LINK-true};
   config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo true ; else echo false ; fi`;
   config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo true ; else echo false ; fi`;
-  link_info.check_relocs_after_open_input = true;
 EOF
 if test -n "$COMMONPAGESIZE"; then
 fragment <<EOF

--- a/ld/emultempl/mmix-elfnmmo.em
+++ b/ld/emultempl/mmix-elfnmmo.em
@@ -25,15 +25,6 @@
 fragment <<EOF
 #include "elf/mmix.h"
 
-static void gld${EMULATION_NAME}_before_parse (void);
-
-static void
-mmix_before_parse (void)
-{
-  link_info.check_relocs_after_open_input = true;
-  gld${EMULATION_NAME}_before_parse ();
-}
-
 /* Set up handling of linker-allocated global registers.  */
 
 static void
@@ -117,6 +108,5 @@ mmix_after_allocation (void)
 }
 EOF
 
-LDEMUL_BEFORE_PARSE=mmix_before_parse
 LDEMUL_AFTER_ALLOCATION=mmix_after_allocation
 LDEMUL_BEFORE_ALLOCATION=mmix_before_allocation

--- a/ld/emultempl/mmixelf.em
+++ b/ld/emultempl/mmixelf.em
@@ -29,7 +29,7 @@ fragment <<EOF
 static void
 elfmmix_before_parse (void)
 {
-  mmix_before_parse ();
+  gld${EMULATION_NAME}_before_parse ();
 
   /* Make sure we don't create a demand-paged executable.  Unfortunately
      this isn't changeable with a command-line option.  It makes no

--- a/ld/emultempl/pe.em
+++ b/ld/emultempl/pe.em
@@ -1149,7 +1149,7 @@ pe_fixup_stdcalls (void)
     if (undef->type == bfd_link_hash_undefined)
       {
 	const char * name = undef->root.string;
-	char * at;
+	const char * at;
 	int lead_at = (*name == '@');
 
 	if (lead_at)
@@ -1750,7 +1750,7 @@ gld${EMULATION_NAME}_after_open (void)
       {
 	if (is->the_bfd->my_archive)
 	  {
-	    char *pnt;
+	    const char *pnt;
 
 	    /* Microsoft import libraries may contain archive members for
 	       one or more DLLs, together with static object files.
@@ -2146,7 +2146,7 @@ gld${EMULATION_NAME}_place_orphan (asection *s,
 				   int constraint)
 {
   const char *orig_secname = secname;
-  char *dollar = NULL;
+  const char *dollar = NULL;
   lang_output_section_statement_type *os;
   lang_statement_list_type add_child;
   lang_output_section_statement_type *match_by_name = NULL;

--- a/ld/emultempl/pep.em
+++ b/ld/emultempl/pep.em
@@ -1089,7 +1089,7 @@ pep_fixup_stdcalls (void)
   for (undef = link_info.hash->undefs; undef; undef=undef->u.undef.next)
     if (undef->type == bfd_link_hash_undefined)
       {
-	char* at = strchr (undef->root.string, '@');
+	const char* at = strchr (undef->root.string, '@');
 	int lead_at = (*undef->root.string == '@');
 	if (lead_at)
 	  at = strchr (undef->root.string + 1, '@');
@@ -1098,12 +1098,13 @@ pep_fixup_stdcalls (void)
 	    /* The symbol is a stdcall symbol, so let's look for a
 	       cdecl symbol with the same name and resolve to that.  */
 	    char *cname = xstrdup (undef->root.string);
+	    char *at2;
 
 	    if (lead_at)
 	      *cname = '_';
-	    at = strchr (cname, '@');
-	    if (at)
-	      *at = 0;
+	    at2 = strchr (cname, '@');
+	    if (at2)
+	      *at2 = 0;
 	    sym = bfd_link_hash_lookup (link_info.hash, cname, 0, 0, 1);
 
 	    if (sym && sym->type == bfd_link_hash_defined)
@@ -1737,7 +1738,7 @@ gld${EMULATION_NAME}_after_open (void)
       {
 	if (is->the_bfd->my_archive)
 	  {
-	    char *pnt;
+	    const char *pnt;
 
 	    /* Microsoft import libraries may contain archive members for
 	       one or more DLLs, together with static object files.
@@ -1986,7 +1987,7 @@ gld${EMULATION_NAME}_place_orphan (asection *s,
 				    int constraint)
 {
   const char *orig_secname = secname;
-  char *dollar = NULL;
+  const char *dollar = NULL;
   lang_output_section_statement_type *os;
   lang_statement_list_type add_child;
   lang_output_section_statement_type *match_by_name = NULL;

--- a/ld/emultempl/scoreelf.em
+++ b/ld/emultempl/scoreelf.em
@@ -39,7 +39,6 @@ gld${EMULATION_NAME}_before_parse (void)
   input_flags.dynamic = ${DYNAMIC_LINK-true};
   config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo true ; else echo false ; fi`;
   config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo true ; else echo false ; fi`;
-  link_info.check_relocs_after_open_input = true;
 EOF
 if test -n "$COMMONPAGESIZE"; then
 fragment <<EOF

--- a/ld/emultempl/spuelf.em
+++ b/ld/emultempl/spuelf.em
@@ -235,14 +235,14 @@ spu_elf_load_ovl_mgr (void)
 		    if (!lang_output_section_find (oname))
 		      {
 			lang_output_section_statement_type *os = NULL;
-			char *p = strchr (oname + 1, '.');
+			const char *p = strchr (oname + 1, '.');
 			if (p != NULL)
 			  {
 			    size_t len = p - oname;
-			    p = memcpy (xmalloc (len + 1), oname, len);
-			    p[len] = '\0';
-			    os = lang_output_section_find (p);
-			    free (p);
+			    char *np = memcpy (xmalloc (len + 1), oname, len);
+			    np[len] = '\0';
+			    os = lang_output_section_find (np);
+			    free (np);
 			  }
 			if (os != NULL)
 			  oname = os->name;

--- a/ld/ldelf.c
+++ b/ld/ldelf.c
@@ -534,9 +534,9 @@ ldelf_search_needed (const char *path, struct dt_needed *n, int force,
 				  replacement, rep_len + 1);
 			}
 
-		      replacement = freeme;
-		      if ((slash = strrchr (replacement, '/')) != NULL)
+		      if ((slash = strrchr (freeme, '/')) != NULL)
 			* slash = 0;
+		      replacement = freeme;
 		    }
 		}
 	      break;
@@ -794,7 +794,7 @@ ldelf_parse_ld_so_conf_include (struct ldelf_ld_so_conf *info,
 
   if (pattern[0] != '/')
     {
-      char *p = strrchr (filename, '/');
+      const char *p = strrchr (filename, '/');
       size_t patlen = strlen (pattern) + 1;
 
       newp = xmalloc (p - filename + 1 + patlen);

--- a/ld/ldlang.c
+++ b/ld/ldlang.c
@@ -8463,21 +8463,15 @@ lang_add_gc_name (const char *name)
 static void
 lang_check_relocs (void)
 {
-  if (link_info.check_relocs_after_open_input)
-    {
-      bfd *abfd;
-
-      for (abfd = link_info.input_bfds;
-	   abfd != (bfd *) NULL; abfd = abfd->link.next)
-	if (!bfd_link_check_relocs (abfd, &link_info))
-	  {
-	    /* No object output, fail return.  */
-	    config.make_executable = false;
-	    /* Note: we do not abort the loop, but rather
-	       continue the scan in case there are other
-	       bad relocations to report.  */
-	  }
-    }
+  for (bfd *abfd = link_info.input_bfds; abfd != NULL; abfd = abfd->link.next)
+    if (!bfd_link_check_relocs (abfd, &link_info))
+      {
+	/* No object output, fail return.  */
+	config.make_executable = false;
+	/* Note: we do not abort the loop, but rather
+	   continue the scan in case there are other
+	   bad relocations to report.  */
+      }
 }
 
 /* Look through all output sections looking for places where we can

--- a/ld/ldlang.c
+++ b/ld/ldlang.c
@@ -337,10 +337,10 @@ stat_ldirname (const char *name)
 /* If PATTERN is of the form archive:file, return a pointer to the
    separator.  If not, return NULL.  */
 
-static char *
+static const char *
 archive_path (const char *pattern)
 {
-  char *p = NULL;
+  const char *p = NULL;
 
   if (link_info.path_separator == 0)
     return p;
@@ -362,7 +362,7 @@ archive_path (const char *pattern)
    return whether F matches FILE_SPEC.  */
 
 static bool
-input_statement_is_archive_path (const char *file_spec, char *sep,
+input_statement_is_archive_path (const char *file_spec, const char *sep,
 				 lang_input_statement_type *f)
 {
   bool match = false;
@@ -377,9 +377,10 @@ input_statement_is_archive_path (const char *file_spec, char *sep,
       if (sep != file_spec)
 	{
 	  const char *aname = bfd_get_filename (f->the_bfd->my_archive);
-	  *sep = 0;
+	  /* SEP which points into FILE_SPEC is in writable memory.  */
+	  *(char *) sep = 0;
 	  match = name_match (file_spec, aname) == 0;
-	  *sep = link_info.path_separator;
+	  *(char *) sep = link_info.path_separator;
 	}
     }
   return match;
@@ -421,7 +422,7 @@ walk_wild_file_in_exclude_list (struct name_list *exclude_list,
        list_tmp;
        list_tmp = list_tmp->next)
     {
-      char *p = archive_path (list_tmp->name);
+      const char *p = archive_path (list_tmp->name);
 
       if (p != NULL)
 	{
@@ -477,7 +478,7 @@ walk_wild_section_match (lang_wild_statement_type *ptr,
 {
   struct wildcard_list *sec;
   const char *file_spec = ptr->filename;
-  char *p;
+  const char *p;
 
   /* Check if filenames match.  */
   if (file_spec == NULL)
@@ -10946,7 +10947,7 @@ cmdline_fopen_temp (const char *path, const char *target,
 #ifdef HAVE_DOS_BASED_FILE_SYSTEM
   {
     /* We could have foo/bar\\baz, or foo\\bar, or d:bar.  */
-    char *bslash = strrchr (path, '\\');
+    const char *bslash = strrchr (path, '\\');
 
     if (slash == NULL || (bslash != NULL && bslash > slash))
       slash = bslash;

--- a/ld/ldlang.c
+++ b/ld/ldlang.c
@@ -337,10 +337,10 @@ stat_ldirname (const char *name)
 /* If PATTERN is of the form archive:file, return a pointer to the
    separator.  If not, return NULL.  */
 
-static char *
+static const char *
 archive_path (const char *pattern)
 {
-  char *p = NULL;
+  const char *p = NULL;
 
   if (link_info.path_separator == 0)
     return p;
@@ -362,7 +362,7 @@ archive_path (const char *pattern)
    return whether F matches FILE_SPEC.  */
 
 static bool
-input_statement_is_archive_path (const char *file_spec, char *sep,
+input_statement_is_archive_path (const char *file_spec, const char *sep,
 				 lang_input_statement_type *f)
 {
   bool match = false;
@@ -377,9 +377,10 @@ input_statement_is_archive_path (const char *file_spec, char *sep,
       if (sep != file_spec)
 	{
 	  const char *aname = bfd_get_filename (f->the_bfd->my_archive);
-	  *sep = 0;
+	  /* SEP which points into FILE_SPEC is in writable memory.  */
+	  *(char *) sep = 0;
 	  match = name_match (file_spec, aname) == 0;
-	  *sep = link_info.path_separator;
+	  *(char *) sep = link_info.path_separator;
 	}
     }
   return match;
@@ -421,7 +422,7 @@ walk_wild_file_in_exclude_list (struct name_list *exclude_list,
        list_tmp;
        list_tmp = list_tmp->next)
     {
-      char *p = archive_path (list_tmp->name);
+      const char *p = archive_path (list_tmp->name);
 
       if (p != NULL)
 	{
@@ -477,7 +478,7 @@ walk_wild_section_match (lang_wild_statement_type *ptr,
 {
   struct wildcard_list *sec;
   const char *file_spec = ptr->filename;
-  char *p;
+  const char *p;
 
   /* Check if filenames match.  */
   if (file_spec == NULL)
@@ -8463,21 +8464,15 @@ lang_add_gc_name (const char *name)
 static void
 lang_check_relocs (void)
 {
-  if (link_info.check_relocs_after_open_input)
-    {
-      bfd *abfd;
-
-      for (abfd = link_info.input_bfds;
-	   abfd != (bfd *) NULL; abfd = abfd->link.next)
-	if (!bfd_link_check_relocs (abfd, &link_info))
-	  {
-	    /* No object output, fail return.  */
-	    config.make_executable = false;
-	    /* Note: we do not abort the loop, but rather
-	       continue the scan in case there are other
-	       bad relocations to report.  */
-	  }
-    }
+  for (bfd *abfd = link_info.input_bfds; abfd != NULL; abfd = abfd->link.next)
+    if (!bfd_link_check_relocs (abfd, &link_info))
+      {
+	/* No object output, fail return.  */
+	config.make_executable = false;
+	/* Note: we do not abort the loop, but rather
+	   continue the scan in case there are other
+	   bad relocations to report.  */
+      }
 }
 
 /* Look through all output sections looking for places where we can
@@ -10952,7 +10947,7 @@ cmdline_fopen_temp (const char *path, const char *target,
 #ifdef HAVE_DOS_BASED_FILE_SYSTEM
   {
     /* We could have foo/bar\\baz, or foo\\bar, or d:bar.  */
-    char *bslash = strrchr (path, '\\');
+    const char *bslash = strrchr (path, '\\');
 
     if (slash == NULL || (bslash != NULL && bslash > slash))
       slash = bslash;

--- a/libctf/ctf-link.c
+++ b/libctf/ctf-link.c
@@ -1649,7 +1649,7 @@ ctf_link_shuffle_syms (ctf_dict_t *fp)
   ctf_in_flight_dynsym_t *did, *nid;
   ctf_next_t *i = NULL;
   int err = ENOMEM;
-  void *name_, *sym_;
+  void *sym_;
 
   if (fp->ctf_stypes > 0)
     return ctf_set_errno (fp, ECTF_RDONLY);
@@ -1733,9 +1733,8 @@ ctf_link_shuffle_syms (ctf_dict_t *fp)
 				   sizeof (ctf_link_sym_t *))) == NULL)
     goto err;
 
-  while ((err = ctf_dynhash_next (fp->ctf_dynsyms, &i, &name_, &sym_)) == 0)
+  while ((err = ctf_dynhash_next (fp->ctf_dynsyms, &i, NULL, &sym_)) == 0)
     {
-      const char *name = (const char *) name;
       ctf_link_sym_t *symp = (ctf_link_sym_t *) sym_;
 
       if (!ctf_assert (fp, symp->st_symidx <= fp->ctf_dynsymmax))


### PR DESCRIPTION
Handle conflicts introduced by the following upstream patches:

    commit https://github.com/ROCm/ROCgdb/commit/57cb42b69f90784bb57b8c5342765d7439dc693b
    Date:   Tue Apr 28 18:23:55 2026 +0200

        [gdb/symtab] Factor out new_symbol variant

This patch heavily reworks new_symbol in gdb/dwarf2/read.c.  In the end,
we did not have much changes downstream to this file, we only touched
code to treat HIP as a C++ dialect.  I took the code from upstream, and
made sure to have the HIP as a C++ dialect reinstated.

    commit https://github.com/ROCm/ROCgdb/commit/329a53a6d590e2e90f590c89473990040a86c8e0
    Date:   Sat Nov 22 11:03:57 2025 -0700

        Some cleanups to "pretend language" handling

Minor change which did not cause a conflict, but caused a build failure.
It turned a LANG variable into an optional, just adjust the place using
it.

    commit https://github.com/ROCm/ROCgdb/commit/5a3726062a2c50b28592551cadf20118fe603b29
    Date:   Tue Apr 28 20:55:42 2026 -0400

        gdb/dwarf2: pass around DWARF expressions as gdb::array_view

This upstream change caused most of the conflicts, but the resolution
was quite automatic.

Finally, starting with:

    commit https://github.com/ROCm/ROCgdb/commit/c76bd1b0f757cbb5f361ec5c994a17769a12825a
    Date:   Wed Apr 8 07:00:59 2026 -0600

        Remove symbol lookup of arguments

upstream GDB seems to change how argument pack are handled.

Consider the following code:

    template<typename... Args>
    void
    foo (Args... args)
    {
    }

    int
    main ()
    {
      foo<int, long, float> (1, 2, 3.14);
      return 0;
    }

Prior to this commit, stepping into FOO would have GDB show:

    (gdb) frame
    #0  foo<int, long, float> (args=3.1400001, args=3.1400001, args=3.1400001) at tmp.cpp:7
    7       }

This is wrong.  Even if all of the arguments of the pack have the same
name (args), the do not have the same type nor value.

With this upstream change, we now see:

    (gdb) frame
    #0  foo<int, long, float> (args=1, args=2, args=3.1400001) at tmp.cpp:7
    7       }

which is correct.

We had one test downstream exercising something like this, but expected
the "wrong" behaviour: gdb.rocm/names.exp.  This merge also adjusts it
to expect the new behaviour.