### PR TITLE
Add dejagnu tests for cooperative group GWS debugging

### DIFF
--- a/gdb/testsuite/gdb.rocm/coop-group-grid-sync.cpp
+++ b/gdb/testsuite/gdb.rocm/coop-group-grid-sync.cpp
@@ -1,0 +1,169 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* This program exercises a single-device cooperative kernel launch.
+   The kernel uses cooperative_groups::this_grid ().sync (), which is
+   implemented on AMD GPUs using the Global Wave Sync (GWS) hardware
+   mechanism.  It is launched through hipLaunchCooperativeKernel so
+   the whole grid is co-resident and can synchronize at the grid
+   level.
+
+   The companion .exp file uses this program to exercise the debugger
+   while a kernel is running with GWS-based grid synchronization.  */
+
+#include <hip/hip_cooperative_groups.h>
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rocm-test-utils.h"
+
+namespace cg = cooperative_groups;
+
+/* Use small but non-trivial launch dimensions so the test runs quickly
+   while still creating waves from multiple workgroups participating
+   in the GWS barrier.  Two workgroups of 64 threads each give 128
+   threads in total.
+
+   N is exactly one slot per thread so Phase 2 has no inter-thread
+   write conflict and the host-side expected values can be computed
+   straightforwardly.  */
+
+constexpr unsigned int group_size = 64;
+constexpr unsigned int num_groups = 2;
+constexpr unsigned int total_threads = group_size * num_groups;
+constexpr unsigned int N = total_threads;
+
+/* Two-phase grid-cooperative kernel.
+
+   Phase 1: every thread writes its slot in in_buf.
+   GWS    : the whole grid synchronizes via cooperative_groups::this_grid ().
+   Phase 2: every thread reads a slot owned by a thread in a *different*
+   workgroup and stores it into out_buf.
+
+   Because the Phase 2 read targets a slot written by a different
+   workgroup during Phase 1, this is only correct if grid.sync ()
+   actually synchronized every wave in the grid.  */
+
+__global__ void
+coop_grid_sync_kernel (int *in_buf, int *out_buf)
+{
+  cg::grid_group grid = cg::this_grid ();
+
+  unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  /* Phase 1: each thread writes its own value.  */
+  in_buf[tid] = (int) (tid + 1);	/* before-sync line */
+
+  /* Grid-wide synchronization (GWS).  */
+  grid.sync ();				/* sync line */
+
+  /* Phase 2: read the slot owned by a thread in a different workgroup
+     and store it in our own slot of the output buffer.  */
+  unsigned int peer = (tid + blockDim.x) % total_threads;
+  int v = in_buf[peer];			/* after-sync line */
+  out_buf[tid] = v;
+}
+
+int
+main ()
+{
+  int n_devices = 0;
+  CHECK (hipGetDeviceCount (&n_devices));
+  if (n_devices <= 0)
+    {
+      printf ("No HIP devices found, skipping.\n");
+      return 0;
+    }
+
+  int device_id = -1;
+  hipDeviceProp_t props;
+  for (int id = 0; id < n_devices; ++id)
+    {
+      CHECK (hipGetDeviceProperties (&props, id));
+      if (props.cooperativeLaunch)
+	{
+	  device_id = id;
+	  break;
+	}
+    }
+
+  if (device_id < 0)
+    {
+      printf ("None of the %d HIP device(s) support cooperative launch, "
+	      "skipping.\n",
+	      n_devices);
+      return 0;
+    }
+
+  CHECK (hipSetDevice (device_id));
+
+  int *in_d = nullptr;
+  int *out_d = nullptr;
+  CHECK (hipMalloc ((void **) &in_d, N * sizeof (int)));
+  CHECK (hipMalloc ((void **) &out_d, N * sizeof (int)));
+  CHECK (hipMemset (in_d, 0, N * sizeof (int)));
+  CHECK (hipMemset (out_d, 0, N * sizeof (int)));
+
+  dim3 grid_dim (num_groups, 1, 1);
+  dim3 block_dim (group_size, 1, 1);
+
+  void *kernel_args[2];
+  kernel_args[0] = (void *) &in_d;
+  kernel_args[1] = (void *) &out_d;
+
+  /* Launch the kernel cooperatively.  This is the API that enables
+     grid.sync () support via GWS.  The trailing 0, 0 arguments are
+     sharedMem and stream respectively.  */
+  CHECK (hipLaunchCooperativeKernel
+	   (reinterpret_cast<void *> (coop_grid_sync_kernel),
+	    grid_dim, block_dim, kernel_args, 0, 0));
+
+  CHECK (hipDeviceSynchronize ());
+
+  int out_h[N];
+  CHECK (hipMemcpy (out_h, out_d, N * sizeof (int), hipMemcpyDeviceToHost));
+
+  CHECK (hipFree (in_d));
+  CHECK (hipFree (out_d));
+
+  /* Each thread tid stores in_buf[(tid + group_size) % total_threads]
+     into out_buf[tid].  After Phase 1, in_buf[k] == k + 1, so the
+     expected value at out_h[tid] is ((tid + group_size) %
+     total_threads) + 1.  */
+  int errors = 0;
+  for (unsigned int tid = 0; tid < N; tid++)
+    {
+      unsigned int peer = (tid + group_size) % total_threads;
+      int expected = (int) (peer + 1);
+      if (out_h[tid] != expected)
+	{
+	  fprintf (stderr, "mismatch at %u: got %d, expected %d\n",
+		   tid, out_h[tid], expected);
+	  errors++;
+	}
+    }
+
+  if (errors != 0)
+    {
+      fprintf (stderr, "FAILED: %d mismatches\n", errors);
+      return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
+++ b/gdb/testsuite/gdb.rocm/coop-group-grid-sync.exp
@@ -1,0 +1,145 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Tests for debugging a single-device cooperative kernel that uses
+# cooperative_groups::this_grid ().sync (), implemented on AMD GPUs
+# using the Global Wave Sync (GWS) hardware mechanism.
+#
+# The test verifies that GDB can:
+#   - hit a breakpoint placed after grid.sync () in a cooperatively
+#     launched kernel (proving GWS-protected code is debuggable across
+#     the barrier),
+#   - list the cooperative dispatch via "info dispatches",
+#   - observe waves from multiple workgroups,
+#   - inspect correct per-wave and per-lane state, and
+#   - resume the kernel to normal completion.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+require supports_cooperative_groups
+
+standard_testfile .cpp
+
+if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
+    return
+}
+
+# Test debugging a single-device cooperative kernel.  Stop at a
+# breakpoint after grid.sync () -- which fires once all waves have
+# crossed the GWS barrier, proving GWS-protected code can be debugged
+# across the barrier -- and, with the co-resident waves parked there,
+# check the dispatch and GDB's per-wave / per-lane state reporting, all
+# in a single debug session.
+
+proc_with_prefix test_coop_grid_sync {} {
+    clean_restart $::testfile
+
+    with_rocm_gpu_lock {
+	if {![runto_main]} {
+	    return
+	}
+
+	# Place a breakpoint after grid.sync ().  Use "allow-pending"
+	# because the kernel is loaded as device code at dispatch time.
+	gdb_breakpoint \
+	    [gdb_get_line_number "after-sync line"] allow-pending temporary
+
+	# Continue into the kernel.  If the program self-skips (no device
+	# advertises cooperativeLaunch) it exits cleanly; treat that as
+	# UNSUPPORTED rather than a FAIL.
+	set reached 0
+	gdb_test_multiple "continue" "stop after grid.sync" {
+	    -re -wrap "Temporary breakpoint $::decimal,\[^\r\n\]*coop_grid_sync_kernel .*" {
+		set reached 1
+		pass $gdb_test_name
+	    }
+	    -re -wrap "$::inferior_exited_re normally.*" {
+		unsupported "cooperative launch not available"
+	    }
+	}
+	if { !$reached } {
+	    return
+	}
+
+	# Verify that waves from multiple workgroups are stopped.
+	# Counting waves alone is wave-size dependent (1 wave
+	# per workgroup on wave64 vs 2 on wave32) and would let the test
+	# pass on wave32 even if all visible waves came from a single
+	# workgroup.  Instead, collect the distinct workgroup (block)
+	# coordinates from the AMDGPU Wave entries in "info threads" and
+	# require at least two distinct workgroups.
+	set blocks {}
+	gdb_test_multiple "info threads" "blocks present" -lbl {
+	    -re "AMDGPU Wave \[^(\r\n\]*\\((\[^()\r\n\]+)\\)" {
+		if {[lsearch -exact $blocks $expect_out(1,string)] == -1} {
+		    lappend blocks $expect_out(1,string)
+		}
+		exp_continue
+	    }
+	    -re -wrap "" {
+		verbose -log "blocks: $blocks"
+		gdb_assert {[llength $blocks] >= 2} \
+		    "waves from at least 2 distinct workgroups are present"
+	    }
+	}
+
+	# "info dispatches" should show the cooperative dispatch.
+	gdb_test "info dispatches" \
+	    ".*AMDGPU Dispatch\[^\r\n\]*coop_grid_sync_kernel.*" \
+	    "info dispatches lists cooperative dispatch"
+
+	# Check that GDB reports correct, distinct per-wave state: switching
+	# to each wave and reading blockIdx.x must yield that wave's owning
+	# workgroup, and across all waves we must observe more than one
+	# distinct workgroup.
+	set waves [info_thread_get_wave_list]
+	gdb_assert {[llength $waves] >= 2} "multiple GPU waves listed"
+
+	set wave_blocks {}
+	foreach wave $waves {
+	    with_test_prefix "wave $wave" {
+		gdb_test "thread $wave" "Switching to thread $wave.*" \
+		    "switch to wave"
+		set bidx [get_integer_valueof "blockIdx.x" -1 "blockIdx.x"]
+		if {[lsearch -exact $wave_blocks $bidx] == -1} {
+		    lappend wave_blocks $bidx
+		}
+	    }
+	}
+	gdb_assert {[llength $wave_blocks] >= 2} \
+	    "distinct workgroups observed across waves"
+
+	# Per-lane (SIMT) state: within a single wave, different lanes map
+	# to different threads, so threadIdx.x must differ between lanes.
+	gdb_test "thread [lindex $waves 0]" "Switching to thread .*" \
+	    "switch to first wave for lane inspection"
+	gdb_test "lane 0" "\\\[Switching to thread $::decimal, lane 0 .*" \
+	    "switch to lane 0"
+	set tid0 [get_integer_valueof "threadIdx.x" -1 "threadIdx.x at lane 0"]
+	gdb_test "lane 1" "\\\[Switching to thread $::decimal, lane 1 .*" \
+	    "switch to lane 1"
+	set tid1 [get_integer_valueof "threadIdx.x" -1 "threadIdx.x at lane 1"]
+	gdb_assert {$tid0 != $tid1} "distinct threadIdx.x across lanes"
+
+	# The kernel should run to completion afterwards.
+	gdb_continue_to_end "continue to program end" "continue" 1
+    }
+}
+
+test_coop_grid_sync

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -412,6 +412,45 @@ proc hip_devices_support_debug_multi_process {} {
     return 1
 }
 
+# Helpers below gate cooperative-group debugging tests, i.e. tests that
+# debug kernels launched with hipLaunchCooperativeKernel and
+# synchronized via cooperative_groups::this_grid ().sync ().
+#
+# This is a debugger-side gate, distinct from what the HIP runtime
+# advertises via hipDeviceProp_t::cooperativeLaunch: the Global Wave
+# Sync (GWS) hardware implementing the grid barrier exists on
+# architectures where the kernel runs correctly outside the debugger
+# but ROCgdb cannot yet step or breakpoint through the cooperative
+# dispatch.
+
+# Return true if TARGET (a gfx name like "gfx90a") is an architecture
+# where ROCgdb supports debugging cooperative-group kernels.
+
+proc target_supports_cooperative_groups { target } {
+    set unsupported_targets {
+	gfx1100 gfx1101 gfx1102 gfx1103
+    }
+
+    return [expr {[lsearch -exact $unsupported_targets $target] == -1}]
+}
+
+# Return true if every AMDGPU device on the system is an architecture
+# where ROCgdb supports debugging cooperative-group kernels.
+
+proc supports_cooperative_groups {} {
+    set targets [find_amdgpu_devices]
+    if { [llength $targets] == 0 } {
+	return 0
+    }
+
+    foreach target $targets {
+	if { ![target_supports_cooperative_groups $target] } {
+	    return 0
+	}
+    }
+    return 1
+}
+
 # Return true if the current device's version is less than VERSION.
 #
 # VERSION must be the "gfx" name of the device, such as gfx906 or gfx90a.


### PR DESCRIPTION
## Summary

Add dejagnu coverage for debugging AMD GPU **cooperative-group** kernels —
i.e. kernels launched via `hipLaunchCooperativeKernel` /
`hipLaunchCooperativeKernelMultiDevice` that synchronize at the grid /
multi-grid level. On AMD GPUs these synchronization primitives are
implemented in hardware via **Global Wave Sync (GWS)**, and they have a
distinct wave/scheduling model that has historically only been covered by
out-of-tree tests. This PR brings that coverage into the dejagnu testsuite
so it runs as part of the regular ROCgdb regression suite.

## Tests added

| File | Scenario |
|---|---|
| `gdb.rocm/coop-group-grid-sync.{cpp,exp}` | **Single-device** cooperative kernel using `cooperative_groups::this_grid().sync()` (intra-device GWS), launched via `hipLaunchCooperativeKernel`. |
| `gdb.rocm/coop-group-multi-grid-sync.{cpp,exp}` | **Multi-device** cooperative kernel using both `this_grid().sync()` and `cooperative_groups::this_multi_grid().sync()` (intra + cross-device GWS), launched via `hipLaunchCooperativeKernelMultiDevice`. |

## What gets verified

**`coop-group-grid-sync.exp`** — two sub-tests:

- `test_break_around_grid_sync`
  - Hit a breakpoint **before** `grid.sync()` inside a cooperative dispatch.
  - Confirm multiple `AMDGPU Wave` threads are stopped (waves participating
    in the GWS barrier).
  - Confirm `info dispatches` lists the cooperative dispatch.
  - Move the breakpoint to **after** `grid.sync()` and continue: it must
    fire (proves GWS-protected code can be debugged across the barrier).
  - Continue to clean program exit.
- `test_threads_in_coop_kernel`
  - For every `AMDGPU Wave` parked inside the kernel, switch to it and
    confirm `bt 1` reports a frame inside `coop_grid_sync_kernel`.

**`coop-group-multi-grid-sync.exp`** — runs in **non-stop mode**:

- After `continue -a &`, confirm a kernel-side breakpoint fires inside
  `coop_multi_grid_sync_kernel`. Per-GPU child breakpoint instances
  (`Breakpoint X.Y`) are observed for every participating GPU.
- Continue all threads to program exit, which only succeeds if both
  `this_grid().sync()` and `this_multi_grid().sync()` release correctly
  under the debugger.

The host-side post-conditions in the `.cpp` programs additionally validate
the cooperative semantics numerically (cross-workgroup data dependency for
the single-device case, cross-device sum aggregation for the multi-device
case), so any regression in GWS behavior under the debugger turns into a
test failure rather than a silent miscompare.

## Skip / unsupported handling

The tests degrade cleanly on systems that cannot run them:

- Single-device test: queries `cooperativeLaunch`; if unsupported the
  program prints a recognizable message and exits, and the `.exp` marks
  the test `UNSUPPORTED`.
- Multi-device test: requires `>= 2` GPUs and
  `cooperativeMultiDeviceLaunch` on every device. It is also gated by
  the existing `hip_devices_support_debug_multi_process` requirement.
  Any of those missing → `UNSUPPORTED`.

No new dejagnu helpers are required; both `.exp` files use existing
infrastructure in `lib/rocm.exp`.

## Out of scope / follow-ups

Intentionally left out of this PR; happy to extend if reviewers ask:

- Stepping (`next` / `step` / `stepi`) across `grid.sync()` /
  `mgrid.sync()` boundaries.
- Conditional breakpoints inside cooperative kernels.
- `lane apply` / per-lane register inspection while waves are parked at
  the GWS barrier.
- Watchpoints on cooperative shared buffers.