### PR TITLE
Add ci:skip label support to skip pre-commit and CI workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-24.04
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     env:
       BASE_REF: HEAD^
     outputs:


### PR DESCRIPTION
When the ci:skip label is added to a PR, this will now skip:
- Pre-commit checks
- TheRock CI builds
- TheRock tests