### PR TITLE
Update workflow to use installed test_rocgdb.py location

### DIFF
--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -68,4 +68,4 @@ jobs:
 
       - name: Run rocgdb tests
         run: |
-          python build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+          python ${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py


### PR DESCRIPTION
The test script has been moved from TheRock's build_tools directory to ROCgdb's .github/scripts and is now installed by TheRock's build into <ROCm root>/tests/rocgdb during the build process. Update the workflow to invoke the script from its installed location.