### PR TITLE
[amd-staging][2026-05-14] Handle merge conflict with upstream/master

### DIFF
--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260512
+#define BFD_VERSION_DATE 20260513
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20260513
+#define BFD_VERSION_DATE 20260514
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -26840,7 +26840,7 @@ all uses of @value{GDBN} with the architecture, both native and cross.
 * PowerPC::
 * Sparc64::
 * S12Z::
-* AMD GPU::            @acronym{AMD GPU} architectures
+* AMD GPU::            @acronym{AMD} @acronym{GPU} architectures
 * RISC-V::
 @end menu
 
@@ -27602,59 +27602,60 @@ BDCCSR register.
 @end table
 
 @node AMD GPU
-@subsection @acronym{AMD GPU}
-@cindex @acronym{AMD GPU} support
+@subsection @acronym{AMD} @acronym{GPU}
+@cindex @acronym{AMD} @acronym{GPU} support
 
-@value{GDBN} supports debugging programs offloaded to @acronym{AMD GPU} devices
-using the @url{https://docs.amd.com/, @acronym{AMD ROCm}} platform.
+@value{GDBN} supports debugging programs offloaded to @acronym{AMD}
+@acronym{GPU} devices using the
+@url{https://docs.amd.com/, @acronym{AMD} @acronym{ROCm}} platform.
 @value{GDBN} presents host threads alongside GPU wavefronts, allowing debugging
 both the host and device parts of the program simultaneously.
 
-@subsubsection @acronym{AMD GPU} Architectures
+@subsubsection @acronym{AMD} @acronym{GPU} Architectures
 
-The list of @acronym{AMD GPU} architectures supported by @value{GDBN} depends
-on the version of the AMD Debugger API library used.  See its
+The list of @acronym{AMD} @acronym{GPU} architectures supported by @value{GDBN}
+depends on the version of the AMD Debugger API library used.  See its
 @uref{https://docs.amd.com/bundle/ROCDebugger_User_and_API, documentation} for
 more details.
 
-@subsubsection @acronym{AMD GPU} Device Driver and @acronym{AMD ROCm} Runtime
+@subsubsection @acronym{AMD} @acronym{GPU} Device Driver and @acronym{AMD} @acronym{ROCm} Runtime
 
-@value{GDBN} requires a compatible @acronym{AMD GPU} device driver to
+@value{GDBN} requires a compatible @acronym{AMD} @acronym{GPU} device driver to
 be installed.  A warning message is displayed if either the device
 driver version or the version of the debug support it implements is
 unsupported.  @value{GDBN} will continue to function except no
-@acronym{AMD GPU} debugging will be possible.
+@acronym{AMD} @acronym{GPU} debugging will be possible.
 
 @value{GDBN} requires each agent to have compatible firmware installed
 by the device driver.  A warning message is displayed if unsupported
 firmware is detected.  @value{GDBN} will continue to function except
-no @acronym{AMD GPU} debugging will be possible on the agent.
+no @acronym{AMD} @acronym{GPU} debugging will be possible on the agent.
 
-@value{GDBN} requires a compatible @acronym{AMD ROCm} runtime to be
-loaded in order to detect @acronym{AMD GPU} code objects and
+@value{GDBN} requires a compatible @acronym{AMD} @acronym{ROCm} runtime to be
+loaded in order to detect @acronym{AMD} @acronym{GPU} code objects and
 wavefronts.  A warning message is displayed if an unsupported
-@acronym{AMD ROCm} runtime is detected, or there is an error or
+@acronym{AMD} @acronym{ROCm} runtime is detected, or there is an error or
 restriction that prevents debugging.  @value{GDBN} will continue to
-function except no @acronym{AMD GPU} debugging will be possible.
+function except no @acronym{AMD} @acronym{GPU} debugging will be possible.
 
-@subsubsection @acronym{AMD GPU} Wavefronts
+@subsubsection @acronym{AMD} @acronym{GPU} Wavefronts
 @cindex wavefronts
 
-An @acronym{AMD GPU} wavefront is represented in @value{GDBN} as a
+An @acronym{AMD} @acronym{GPU} wavefront is represented in @value{GDBN} as a
 thread.
 
-Note that some @acronym{AMD GPU} architectures may have restrictions
-on providing information about @acronym{AMD GPU} wavefronts created
+Note that some @acronym{AMD} @acronym{GPU} architectures may have restrictions
+on providing information about @acronym{AMD} @acronym{GPU} wavefronts created
 when @value{GDBN} is not attached (@pxref{AMD GPU Attaching
-Restrictions, , @acronym{AMD GPU} Attaching Restrictions}).
+Restrictions, , @acronym{AMD} @acronym{GPU} Attaching Restrictions}).
 
 When scheduler-locking is in effect (@pxref{set scheduler-locking}),
 new wavefronts created by the resumed thread (either CPU thread or GPU
 wavefront) are held in the halt state.
 
-@subsubsection @acronym{AMD GPU} Code Objects
+@subsubsection @acronym{AMD} @acronym{GPU} Code Objects
 
-The @samp{info sharedlibrary} command will show the @acronym{AMD GPU}
+The @samp{info sharedlibrary} command will show the @acronym{AMD} @acronym{GPU}
 code objects as file or memory URIs, together with the host's shared
 libraries.  For example:
 
@@ -27682,22 +27683,23 @@ process owning the memory containing the code object.  The @var{offset}
 parameter is the memory address where the code object is found, and
 the @var{size} parameter is its size in bytes.
 
-@acronym{AMD GPU} code objects are loaded into each @acronym{AMD GPU}
-device separately.  The @samp{info sharedlibrary} command may
+@acronym{AMD} @acronym{GPU} code objects are loaded into each @acronym{AMD}
+@acronym{GPU} device separately.  The @samp{info sharedlibrary} command may
 therefore show the same code object loaded multiple times.  As a
-consequence, setting a breakpoint in @acronym{AMD GPU} code will
+consequence, setting a breakpoint in @acronym{AMD} @acronym{GPU} code will
 result in multiple breakpoint locations if there are multiple
-@acronym{AMD GPU} devices.
+@acronym{AMD} @acronym{GPU} devices.
 
-@subsubsection @acronym{AMD GPU} Entity Target Identifiers and Convenience Variables
+@subsubsection @acronym{AMD} @acronym{GPU} Entity Target Identifiers and Convenience Variables
 
-The @acronym{AMD GPU} entities have the following target identifier formats:
+The @acronym{AMD} @acronym{GPU} entities have the following target
+identifier formats:
 
 @table @asis
 
 @item Thread Target ID
-The @acronym{AMD GPU} thread target identifier (@var{systag}) string has the
-following format:
+The @acronym{AMD} @acronym{GPU} thread target identifier (@var{systag})
+string has the following format:
 
 @smallexample
 AMDGPU Wave @var{agent-id}:@var{queue-id}:@var{dispatch-id}:@var{wave-id} (@var{work-group-x},@var{work-group-y},@var{work-group-z})/@var{work-group-thread-index}
@@ -27706,10 +27708,10 @@ AMDGPU Wave @var{agent-id}:@var{queue-id}:@var{dispatch-id}:@var{wave-id} (@var{
 @end table
 
 @anchor{AMD GPU Signals}
-@subsubsection @acronym{AMD GPU} Signals
+@subsubsection @acronym{AMD} @acronym{GPU} Signals
 
-For @acronym{AMD GPU} wavefronts, @value{GDBN} maps target conditions to stop
-signals in the following way:
+For @acronym{AMD} @acronym{GPU} wavefronts, @value{GDBN} maps target
+conditions to stop signals in the following way:
 
 @table @code
 
@@ -27764,7 +27766,7 @@ Integer operation performed a division by zero.
 @end itemize
 
 By default, these conditions are not enabled to raise signals.  The
-@samp{set $mode} command can be used to change the @acronym{AMD GPU}
+@samp{set $mode} command can be used to change the @acronym{AMD} @acronym{GPU}
 wavefront's register that has bits controlling which conditions are
 enabled to raise signals.  The @samp{print $trapsts} command can be
 used to inspect which conditions have been detected even if they are
@@ -27783,7 +27785,7 @@ either not mapped or accessed with incompatible permissions.
 If a single instruction raises more than one signal, they will be
 reported one at a time each time the wavefront is continued.
 
-@subsubsection @acronym{AMD GPU} Memory Violation Reporting
+@subsubsection @acronym{AMD} @acronym{GPU} Memory Violation Reporting
 
 A wavefront can report memory violation events.  However, the program
 location at which they are reported may be after the machine instruction
@@ -27796,8 +27798,8 @@ behavior:
 @kindex set amdgpu precise-memory
 @cindex AMD GPU precise memory event reporting
 @item set amdgpu precise-memory @var{mode}
-Controls how @acronym{AMD GPU} devices detect memory violations, where
-@var{mode} can be:
+Controls how @acronym{AMD} @acronym{GPU} devices detect memory violations,
+where @var{mode} can be:
 
 @table @code
 
@@ -27808,8 +27810,8 @@ caused the memory violation.  This is the default.
 @item on
 Requests that the program location will be immediately after the
 instruction that caused a memory violation.  Enabling this mode may make
-the @acronym{AMD GPU} device execution significantly slower as it has to
-wait for each memory operation to complete before executing the next
+the @acronym{AMD} @acronym{GPU} device execution significantly slower as it
+has to wait for each memory operation to complete before executing the next
 instruction.
 
 @end table
@@ -27826,7 +27828,7 @@ Displays the currently requested AMD GPU precise memory setting.
 
 @end table
 
-@subsubsection @acronym{AMD GPU} Logging
+@subsubsection @acronym{AMD} @acronym{GPU} Logging
 
 The @samp{set debug amd-dbgapi} command can be used
 to enable diagnostic messages in the @samp{amd-dbgapi} target.  The
@@ -27839,7 +27841,7 @@ to enable diagnostic messages from the @samp{amd-dbgapi} library (which
 log-level} command displays the current @samp{amd-dbgapi} library log level.
 @xref{set debug amd-dbgapi-lib}.
 
-@subsubsection @acronym{AMD GPU} Restrictions
+@subsubsection @acronym{AMD} @acronym{GPU} Restrictions
 
 @enumerate
 
@@ -27850,8 +27852,9 @@ until the wavefront is next stopped.  Memory updated by non-stopped
 wavefronts may not be visible until the wavefront is next stopped.
 
 @item The HIP runtime performs deferred code object loading by default.
-@acronym{AMD GPU} code objects are not loaded until the first kernel is
-launched.  Before then, all breakpoints have to be set as pending breakpoints.
+@acronym{AMD} @acronym{GPU} code objects are not loaded until the first kernel
+is launched.  Before then, all breakpoints have to be set as pending
+breakpoints.
 
 If source line positions are used that only correspond to source lines in
 unloaded code objects, then @value{GDBN} may not set pending breakpoints, and
@@ -27869,25 +27872,26 @@ of the @code{main} function.
 
 @item
 If no CPU thread is running, then @samp{Ctrl-C} is not able to stop
-@acronym{AMD GPU} threads.  This can happen for example if you enable
+@acronym{AMD} @acronym{GPU} threads.  This can happen for example if you enable
 @code{scheduler-locking} after the whole program stopped, and then resume an
-@acronym{AMD GPU} thread.  The only way to unblock the situation is to kill the
-@value{GDBN} process.
+@acronym{AMD} @acronym{GPU} thread.  The only way to unblock the situation is
+to kill the @value{GDBN} process.
 
 @anchor{AMD GPU Attaching Restrictions}
 @item
 
-By default, for some architectures, the @acronym{AMD GPU} device driver causes
-all @acronym{AMD GPU} wavefronts created when @value{GDBN} is not attached to
-be unable to report the dispatch associated with the wavefront, or the
-wavefront's work-group position.  The @samp{info threads} command will display
-this missing information with a @samp{?}.
+By default, for some architectures, the @acronym{AMD} @acronym{GPU} device
+driver causes all @acronym{AMD} @acronym{GPU} wavefronts created when
+@value{GDBN} is not attached to be unable to report the dispatch associated
+with the wavefront, or the wavefront's work-group position.  The
+@samp{info threads} command will display this missing information with a
+@samp{?}.
 
 This does not affect wavefronts created while @value{GDBN} is attached which
 are always capable of reporting this information.
 
 If the @env{HSA_ENABLE_DEBUG} environment variable is set to @samp{1} when the
-@acronym{AMD ROCm} runtime is initialized, then this information will be
+@acronym{AMD} @acronym{ROCm} runtime is initialized, then this information will be
 available for all architectures even for wavefronts created when @value{GDBN}
 was not attached.
 

--- a/gdb/dwarf2/cu.c
+++ b/gdb/dwarf2/cu.c
@@ -58,6 +58,17 @@ dwarf2_cu::dwarf2_cu (dwarf2_per_cu *per_cu, dwarf2_per_objfile *per_objfile)
 
 /* See cu.h.  */
 
+const dwarf2_section_info &
+dwarf2_cu::section () const
+{
+  if (this->dwo_unit != nullptr)
+    return *this->dwo_unit->section;
+  else
+    return *this->per_cu->section ();
+}
+
+/* See cu.h.  */
+
 struct type *
 dwarf2_cu::addr_sized_int_type (bool unsigned_p) const
 {

--- a/gdb/dwarf2/dwo.h
+++ b/gdb/dwarf2/dwo.h
@@ -20,10 +20,14 @@
 #ifndef GDB_DWARF2_DWO_H
 #define GDB_DWARF2_DWO_H
 
+#include <atomic>
+
 #include "dwarf2/section.h"
 #include "gdb_bfd.h"
 #include "gdbsupport/unordered_set.h"
 #include "hashtab.h"
+
+struct dwarf2_per_cu;
 
 /* These sections are what may appear in a (real or virtual) DWO file.  */
 
@@ -49,6 +53,11 @@ struct dwo_unit
 {
   /* Backlink to the containing struct dwo_file.  */
   struct dwo_file *dwo_file = nullptr;
+
+  /* For compile units only, the per-CU structure that represents the skeleton
+     that we used to reach this dwo_unit.  It starts as nullptr, and gets set
+     in cutu_reader::lookup_dwo_cutu.  */
+  std::atomic<dwarf2_per_cu *> per_cu = nullptr;
 
   /* The "id" that distinguishes this CU/TU.
      .debug_info calls this "dwo_id", .debug_types calls this "signature".

--- a/gdb/dwarf2/dwo.h
+++ b/gdb/dwarf2/dwo.h
@@ -121,6 +121,17 @@ struct dwo_file
   dwo_file () = default;
   DISABLE_COPY_AND_ASSIGN (dwo_file);
 
+  /* Look for a type unit with signature SIGNATURE in this dwo_file.
+
+     Return nullptr if not found.  */
+  dwo_unit *find_tu (ULONGEST signature) const
+  {
+    if (auto it = this->tus.find (signature); it != this->tus.end ())
+      return it->get ();
+
+    return nullptr;
+  }
+
   /* The DW_AT_GNU_dwo_name or DW_AT_dwo_name attribute.
      For virtual DWO files the name is constructed from the section offsets
      of abbrev,line,loc,str_offsets so that we combine virtual DWO files

--- a/gdb/dwarf2/dwo.h
+++ b/gdb/dwarf2/dwo.h
@@ -1,0 +1,219 @@
+/* DWARF 2 debugging format support for GDB.
+
+   Copyright (C) 1994-2026 Free Software Foundation, Inc.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef GDB_DWARF2_DWO_H
+#define GDB_DWARF2_DWO_H
+
+#include "dwarf2/section.h"
+#include "gdb_bfd.h"
+#include "gdbsupport/unordered_set.h"
+#include "hashtab.h"
+
+/* These sections are what may appear in a (real or virtual) DWO file.  */
+
+struct dwo_sections
+{
+  struct dwarf2_section_info abbrev;
+  struct dwarf2_section_info line;
+  struct dwarf2_section_info loc;
+  struct dwarf2_section_info loclists;
+  struct dwarf2_section_info macinfo;
+  struct dwarf2_section_info macro;
+  struct dwarf2_section_info rnglists;
+  struct dwarf2_section_info str;
+  struct dwarf2_section_info str_offsets;
+  /* In the case of a virtual DWO file, these two are unused.  */
+  std::vector<dwarf2_section_info> infos;
+  std::vector<dwarf2_section_info> types;
+};
+
+/* CUs/TUs in DWP/DWO files.  */
+
+struct dwo_unit
+{
+  /* Backlink to the containing struct dwo_file.  */
+  struct dwo_file *dwo_file = nullptr;
+
+  /* The "id" that distinguishes this CU/TU.
+     .debug_info calls this "dwo_id", .debug_types calls this "signature".
+     Since signatures came first, we stick with it for consistency.  */
+  ULONGEST signature = 0;
+
+  /* The section this CU/TU lives in, in the DWO file.  */
+  dwarf2_section_info *section = nullptr;
+
+  /* This is set if SECTION is owned by this dwo_unit.  */
+  dwarf2_section_info_up section_holder;
+
+  /* Same as dwarf2_per_cu::{sect_off,length} but in the DWO section.  */
+  sect_offset sect_off {};
+  unsigned int length = 0;
+
+  /* For types, offset in the type's DIE of the type defined by this TU.  */
+  cu_offset type_offset_in_tu;
+};
+
+using dwo_unit_up = std::unique_ptr<dwo_unit>;
+
+/* Hash function for dwo_unit objects, based on the signature.  */
+
+struct dwo_unit_hash
+{
+  using is_transparent = void;
+
+  std::size_t operator() (ULONGEST signature) const noexcept
+  { return signature; }
+
+  std::size_t operator() (const dwo_unit_up &unit) const noexcept
+  { return (*this) (unit->signature); }
+};
+
+/* Equal function for dwo_unit objects, based on the signature.
+
+   The signature is assumed to be unique within the DWO file.  So while object
+   file CU dwo_id's always have the value zero, that's OK, assuming each object
+   file DWO file has only one CU, and that's the rule for now.  */
+
+struct dwo_unit_eq
+{
+  using is_transparent = void;
+
+  bool operator() (ULONGEST sig, const dwo_unit_up  &unit) const noexcept
+  { return sig == unit->signature; }
+
+  bool operator() (const dwo_unit_up &a, const dwo_unit_up &b) const noexcept
+  { return (*this) (a->signature, b); }
+};
+
+/* Set of dwo_unit object, using their signature as identity.  */
+
+using dwo_unit_set = gdb::unordered_set<dwo_unit_up, dwo_unit_hash, dwo_unit_eq>;
+
+/* Data for one DWO file.
+
+   This includes virtual DWO files (a virtual DWO file is a DWO file as it
+   appears in a DWP file).  DWP files don't really have DWO files per se -
+   comdat folding of types "loses" the DWO file they came from, and from
+   a high level view DWP files appear to contain a mass of random types.
+   However, to maintain consistency with the non-DWP case we pretend DWP
+   files contain virtual DWO files, and we assign each TU with one virtual
+   DWO file (generally based on the line and abbrev section offsets -
+   a heuristic that seems to work in practice).  */
+
+struct dwo_file
+{
+  dwo_file () = default;
+  DISABLE_COPY_AND_ASSIGN (dwo_file);
+
+  /* The DW_AT_GNU_dwo_name or DW_AT_dwo_name attribute.
+     For virtual DWO files the name is constructed from the section offsets
+     of abbrev,line,loc,str_offsets so that we combine virtual DWO files
+     from related CU+TUs.  */
+  std::string dwo_name;
+
+  /* The DW_AT_comp_dir attribute.  */
+  const char *comp_dir = nullptr;
+
+  /* The bfd, when the file is open.  Otherwise this is NULL.
+     This is unused(NULL) for virtual DWO files where we use dwp_file.dbfd.  */
+  gdb_bfd_ref_ptr dbfd;
+
+  /* The sections that make up this DWO file.
+     Remember that for virtual DWO files in DWP V2 or DWP V5, these are virtual
+     sections (for lack of a better name).  */
+  struct dwo_sections sections {};
+
+  /* The CUs in the file.
+
+     Multiple CUs per DWO are supported as an extension to handle LLVM's Link
+     Time Optimization output (where multiple source files may be compiled into
+     a single object/dwo pair).  */
+  dwo_unit_set cus;
+
+  /* Table of TUs in the file.  */
+  dwo_unit_set tus;
+};
+
+using dwo_file_up = std::unique_ptr<dwo_file>;
+
+/* This is used when looking up entries in a dwo_file_set.  */
+
+struct dwo_file_search
+{
+  /* Name of the DWO to look for.  */
+  const char *dwo_name;
+
+  /* Compilation directory to look for.  */
+  const char *comp_dir;
+};
+
+/* Hash function for dwo_file objects, using their dwo_name and comp_dir as
+   identity.  */
+
+struct dwo_file_hash
+{
+  using is_transparent = void;
+
+  std::size_t operator() (const dwo_file_search &search) const noexcept
+  {
+    hashval_t hash = htab_hash_string (search.dwo_name);
+
+    if (search.comp_dir != nullptr)
+      hash += htab_hash_string (search.comp_dir);
+
+    return hash;
+  }
+
+  std::size_t operator() (const dwo_file_up &file) const noexcept
+  {
+    return (*this) ({ file->dwo_name.c_str (), file->comp_dir });
+  }
+};
+
+/* Equal function for dwo_file objects, using their dwo_name and comp_dir as
+   identity.  */
+
+struct dwo_file_eq
+{
+  using is_transparent = void;
+
+  bool operator() (const dwo_file_search &search,
+		   const dwo_file_up &dwo_file) const noexcept
+  {
+    if (search.dwo_name != dwo_file->dwo_name)
+      return false;
+
+    if (search.comp_dir == nullptr || dwo_file->comp_dir == nullptr)
+      return search.comp_dir == dwo_file->comp_dir;
+
+    return streq (search.comp_dir, dwo_file->comp_dir);
+  }
+
+  bool operator() (const dwo_file_up &a, const dwo_file_up &b) const noexcept
+  {
+    return (*this) ({ a->dwo_name.c_str (), a->comp_dir }, b);
+  }
+};
+
+/* Set of dwo_file objects, using their dwo_name and comp_dir as identity.  */
+
+using dwo_file_up_set
+  = gdb::unordered_set<dwo_file_up, dwo_file_hash, dwo_file_eq>;
+
+#endif /* GDB_DWARF2_DWO_H */

--- a/gdb/dwarf2/index-write.c
+++ b/gdb/dwarf2/index-write.c
@@ -22,6 +22,7 @@
 
 #include "addrmap.h"
 #include "cli/cli-decode.h"
+#include "cli/cli-style.h"
 #include "exceptions.h"
 #include "gdbsupport/byte-vector.h"
 #include "gdbsupport/enumerate.h"
@@ -41,6 +42,7 @@
 #include "dwarf2/tag.h"
 #include "dwarf2/read-debug-names.h"
 #include "extract-store-integer.h"
+#include "ui-out.h"
 
 #include <algorithm>
 #include <map>
@@ -633,6 +635,10 @@ write_address_map (const addrmap *addrmap, data_buf &addr_vec,
 		       addrmap_index_data.previous_cu_index);
 }
 
+/* Is this symbol a compile unit, local type unit (type unit in the main file)
+   or foreign type unit (type unit in a .dwo file)?  */
+enum class unit_kind { cu, local_tu, foreign_tu };
+
 /* Return true if TU is a foreign type unit, that is a type unit defined in a
    .dwo file without a corresponding skeleton in the main file.  */
 
@@ -643,6 +649,22 @@ is_foreign_tu (const signatured_type *tu)
      of the skeleton, in the main file.  If it's foreign, it will point to the
      section in the .dwo file.  */
   return endswith (tu->section ()->get_name (), ".dwo");
+}
+
+/* Determine the unit_kind for PER_CU.  */
+
+static unit_kind
+classify_unit (const dwarf2_per_cu &per_cu)
+{
+  if (auto sig_type = per_cu.as_signatured_type (); sig_type != nullptr)
+    {
+      if (is_foreign_tu (sig_type))
+	return unit_kind::foreign_tu;
+      else
+	return unit_kind::local_tu;
+    }
+  else
+    return unit_kind::cu;
 }
 
 /* DWARF-5 .debug_names builder.  */
@@ -667,9 +689,6 @@ public:
     const bool dwarf5_is_dwarf64 = &m_dwarf == &m_dwarf64;
     return dwarf5_is_dwarf64 ? 8 : 4;
   }
-
-  /* Is this symbol from DW_TAG_compile_unit or DW_TAG_type_unit?  */
-  enum class unit_kind { cu, tu };
 
   /* Insert one symbol.  */
   void insert (const cooked_index_entry *entry)
@@ -744,9 +763,8 @@ public:
 
 	    for (dwarf2_per_cu *one_cu : per_cus)
 	      {
-		unit_kind kind = (entry->per_cu->is_debug_types ()
-				  ? unit_kind::tu
-				  : unit_kind::cu);
+		unit_kind kind = classify_unit (*one_cu);
+
 		/* Some Ada parentage is synthesized by the reader and so
 		   must be ignored here.  */
 		const cooked_index_entry *parent = entry->get_parent ();
@@ -772,6 +790,15 @@ public:
 		       ? DW_IDX_compile_unit
 		       : DW_IDX_type_unit);
 		    m_abbrev_table.append_unsigned_leb128 (DW_FORM_udata);
+
+		    /* For foreign TUs only: the index of a CU that can be used
+		       to locate the .dwo file containing that TU.  */
+		    if (kind == unit_kind::foreign_tu)
+		      {
+			m_abbrev_table.append_unsigned_leb128
+			  (DW_IDX_compile_unit);
+			m_abbrev_table.append_unsigned_leb128 (DW_FORM_udata);
+		      }
 
 		    /* DIE offset.  */
 		    m_abbrev_table.append_unsigned_leb128 (DW_IDX_die_offset);
@@ -838,6 +865,69 @@ public:
 		const auto it = m_cu_index_htab.find (one_cu);
 		gdb_assert (it != m_cu_index_htab.cend ());
 		m_entry_pool.append_unsigned_leb128 (it->second);
+
+		/* For foreign TUs only: the index of a CU that can be used to
+		   locate the .dwo file containing that TU.
+
+		   This code implements this snippet of the DWARF 5 standard,
+		   from section 6.1.1.2, "Structure of the Name Index":
+
+		     When an index entry refers to a foreign type unit, it may
+		     have attributes for both CU and (foreign) TU.  For such
+		     entries, the CU attribute gives the consumer a reference
+		     to the CU that may be used to locate a split DWARF object
+		     file that contains the type unit
+
+		   So, the idea here is to find a CU in the same .dwo file as
+		   the type unit (there will typically be one) and write the
+		   offset to its skeleton.  */
+		if (kind == unit_kind::foreign_tu)
+		  {
+		    /* If we know about this TU that is only listed in some .dwo
+		       file, it means that we looked up the .dwo file from a CU
+		       skeleton at some point during indexing, and recorded it
+		       in ENTRY->PER_CU.  */
+		    gdb_assert (entry->per_cu != nullptr);
+
+		    signatured_type *sig_type
+		      = entry->per_cu->as_signatured_type ();
+
+		    /* We know it's a TU, because it has been classified as
+		       foreign_tu.  */
+		    gdb_assert (sig_type != nullptr);
+
+		    /* We know it has a dwo_unit, because it's foreign.  */
+		    gdb_assert (sig_type->dwo_unit != nullptr);
+
+		    /* Find a CU in the same .dwo file as the TU.  */
+		    dwarf2_per_cu *per_cu = nullptr;
+		    for (auto &dwo_cu : sig_type->dwo_unit->dwo_file->cus)
+		      if (dwo_cu->per_cu != nullptr)
+			{
+			  per_cu = dwo_cu->per_cu;
+			  break;
+			}
+
+		    /* It would be really weird to not find a CU that we looked
+		       up in this .dwo file.  Otherwise, how would we know about
+		       this foreign TU?  But it might be possible to craft a bad
+		       faith .dwo file that does this by having a one TU with a
+		       skeleton and one TU without a skeleton in the same .dwo
+		       file (i.e. non-standard DWARF 5).  So, just in case, we
+		       error out gracefully.  */
+		    if (per_cu == nullptr)
+		      error (_("Could not find a CU for foreign type unit in "
+			       "DWO file %ps"),
+				styled_string (file_name_style.style (),
+					       (sig_type->dwo_unit->dwo_file
+						->dwo_name.c_str ())));
+
+		    /* This is the CU that can be used to find the .dwo file
+		       containing the type unit, write its offset.  */
+		    const auto cu_it = m_cu_index_htab.find (per_cu);
+		    gdb_assert (cu_it != m_cu_index_htab.cend ());
+		    m_entry_pool.append_unsigned_leb128 (cu_it->second);
+		  }
 
 		/* DIE offset.  */
 		m_entry_pool.append_uint (dwarf5_offset_size (),
@@ -1369,8 +1459,9 @@ struct unit_lists
   /* Compilation units.  */
   std::vector<const dwarf2_per_cu *> comp;
 
-  /* Type units.  */
-  std::vector<const signatured_type *> type;
+  /* Type units, local and foreign.  */
+  std::vector<const signatured_type *> local_type;
+  std::vector<const signatured_type *> foreign_type;
 };
 
 /* Get sorted (by section offset) lists of comp units and type units.  */
@@ -1381,16 +1472,28 @@ get_unit_lists (const dwarf2_per_bfd &per_bfd)
   unit_lists lists;
 
   for (const auto &unit : per_bfd.all_units)
-    if (const signatured_type *sig_type = unit->as_signatured_type ();
-	sig_type != nullptr)
-      lists.type.emplace_back (sig_type);
-    else
-      lists.comp.emplace_back (unit.get ());
+    switch (classify_unit (*unit))
+      {
+      case unit_kind::cu:
+	lists.comp.emplace_back (unit.get ());
+	break;
+
+      case unit_kind::local_tu:
+	lists.local_type.emplace_back (unit->as_signatured_type ());
+	break;
+
+      case unit_kind::foreign_tu:
+	lists.foreign_type.emplace_back (unit->as_signatured_type ());
+	break;
+      }
 
   auto by_sect_off = [] (const dwarf2_per_cu *lhs, const dwarf2_per_cu *rhs)
 		       { return lhs->sect_off () < rhs->sect_off (); };
 
-  /* Sort both lists, even though it is technically not always required:
+  auto by_sig = [] (const signatured_type *lhs, const signatured_type *rhs)
+		  { return lhs->signature < rhs->signature; };
+
+  /* Sort the lists, even though it is technically not always required:
 
       - while .gdb_index requires the CU list to be sorted, DWARF 5 doesn't
 	say anything about the order of CUs in .debug_names.
@@ -1400,7 +1503,8 @@ get_unit_lists (const dwarf2_per_bfd &per_bfd)
      However, it helps make sure that GDB produce a stable and predictable
      output, which is nice.  */
   std::sort (lists.comp.begin (), lists.comp.end (), by_sect_off);
-  std::sort (lists.type.begin (), lists.type.end (), by_sect_off);
+  std::sort (lists.local_type.begin (), lists.local_type.end (), by_sect_off);
+  std::sort (lists.foreign_type.begin (), lists.foreign_type.end (), by_sig);
 
   return lists;
 }
@@ -1428,10 +1532,9 @@ write_gdbindex (dwarf2_per_bfd *per_bfd, cooked_index *table,
      that DWARF 5's .debug_names does with "foreign type units".  If the
      executable has such skeletonless type units, refuse to produce an index,
      instead of producing a bogus one.  */
-  for (const signatured_type *tu : units.type)
-    if (is_foreign_tu (tu))
-      error (_("Found foreign (skeletonless) type unit, unable to produce "
-	       ".gdb_index.  Consider using .debug_names instead."));
+  if (!units.foreign_type.empty ())
+    error (_("Found foreign (skeletonless) type unit, unable to produce "
+	     ".gdb_index.  Consider using .debug_names instead."));
 
   int counter = 0;
 
@@ -1457,7 +1560,7 @@ write_gdbindex (dwarf2_per_bfd *per_bfd, cooked_index *table,
   /* Write type units.  */
   data_buf types_cu_list;
 
-  for (const signatured_type *sig_type : units.type)
+  for (const signatured_type *sig_type : units.local_type)
     {
       const auto insertpair = cu_index_htab.emplace (sig_type, counter);
       gdb_assert (insertpair.second);
@@ -1530,7 +1633,7 @@ write_debug_names (dwarf2_per_bfd *per_bfd, cooked_index *table,
 
   data_buf type_unit_list;
 
-  for (auto [i, per_cu] : gdb::ranges::views::enumerate (units.type))
+  for (auto [i, per_cu] : gdb::ranges::views::enumerate (units.local_type))
     {
       nametable.add_cu (per_cu, i);
       type_unit_list.append_uint (nametable.dwarf5_offset_size (),
@@ -1538,9 +1641,21 @@ write_debug_names (dwarf2_per_bfd *per_bfd, cooked_index *table,
 				  to_underlying (per_cu->sect_off ()));
     }
 
+  data_buf foreign_type_unit_list;
+
+  for (auto [i, sig_type] : gdb::ranges::views::enumerate (units.foreign_type))
+    {
+      /* The numbering of foreign type units follows the numbering of local type
+	 units.  */
+      nametable.add_cu (sig_type, units.local_type.size () + i);
+      foreign_type_unit_list.append_uint (8, dwarf5_byte_order,
+					  sig_type->signature);
+    }
+
   /* Verify that all units are represented.  */
   gdb_assert (units.comp.size () == per_bfd->num_comp_units);
-  gdb_assert (units.type.size () == per_bfd->num_type_units);
+  gdb_assert (units.local_type.size () + units.foreign_type.size ()
+	      == per_bfd->num_type_units);
 
   for (const cooked_index_entry *entry : table->all_entries ())
     nametable.insert (entry);
@@ -1557,6 +1672,7 @@ write_debug_names (dwarf2_per_bfd *per_bfd, cooked_index *table,
   expected_bytes += bytes_of_header;
   expected_bytes += comp_unit_list.size ();
   expected_bytes += type_unit_list.size ();
+  expected_bytes += foreign_type_unit_list.size ();
   expected_bytes += nametable.bytes ();
   data_buf header;
 
@@ -1583,11 +1699,11 @@ write_debug_names (dwarf2_per_bfd *per_bfd, cooked_index *table,
 
   /* local_type_unit_count - The number of TUs in the local TU
      list.  */
-  header.append_uint (4, dwarf5_byte_order, units.type.size ());
+  header.append_uint (4, dwarf5_byte_order, units.local_type.size ());
 
   /* foreign_type_unit_count - The number of TUs in the foreign TU
      list.  */
-  header.append_uint (4, dwarf5_byte_order, 0);
+  header.append_uint (4, dwarf5_byte_order, units.foreign_type.size ());
 
   /* bucket_count - The number of hash buckets in the hash lookup
      table.  GDB does not use the hash table, so there's also no need
@@ -1613,6 +1729,7 @@ write_debug_names (dwarf2_per_bfd *per_bfd, cooked_index *table,
   header.file_write (out_file);
   comp_unit_list.file_write (out_file);
   type_unit_list.file_write (out_file);
+  foreign_type_unit_list.file_write (out_file);
   nametable.file_write (out_file, out_file_str);
 
   assert_file_size (out_file, expected_bytes);

--- a/gdb/dwarf2/read-debug-names.c
+++ b/gdb/dwarf2/read-debug-names.c
@@ -88,9 +88,13 @@ struct mapped_debug_names_reader
 
   uint8_t offset_size = 0;
   uint32_t cu_count = 0;
-  uint32_t tu_count = 0, bucket_count = 0, name_count = 0;
+  uint32_t tu_count = 0;
+  uint32_t foreign_tu_count = 0;
+  uint32_t bucket_count = 0;
+  uint32_t name_count = 0;
   const gdb_byte *cu_table_reordered = nullptr;
   const gdb_byte *tu_table_reordered = nullptr;
+  const gdb_byte *foreign_tu_table_reordered = nullptr;
   const uint32_t *bucket_table_reordered = nullptr;
   const uint32_t *hash_table_reordered = nullptr;
   const gdb_byte *name_table_string_offs_reordered = nullptr;
@@ -122,7 +126,11 @@ struct mapped_debug_names_reader
 
   /* List of local TUs in the same order as found in the index (DWARF 5 section
      6.1.1.4.3).  */
-  std::vector<dwarf2_per_cu *> type_units;
+  std::vector<signatured_type *> type_units;
+
+  /* List of foreign TUs in the same order as found in the index (DWARF 5
+     section 6.1.1.4.4).  */
+  std::vector<signatured_type *> foreign_type_units;
 
   /* Even though the scanning of .debug_names and creation of the
      cooked index entries is done serially, we create multiple shards
@@ -217,7 +225,10 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
   cooked_index_flag flags = 0;
   sect_offset die_offset {};
   enum language lang = language_unknown;
-  dwarf2_per_cu *per_cu = nullptr;
+  dwarf2_per_cu *comp_unit = nullptr;
+  signatured_type *type_unit = nullptr;
+  signatured_type *foreign_type_unit = nullptr;
+
   for (const auto &attr : indexval.attr_vec)
     {
       ULONGEST ull;
@@ -282,7 +293,6 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 	{
 	case DW_IDX_compile_unit:
 	  {
-	    /* Don't crash on bad data.  */
 	    if (ull >= this->comp_units.size ())
 	      {
 		complain_about_index_entry
@@ -292,13 +302,17 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 		continue;
 	      }
 
-	    per_cu = this->comp_units[ull];
+	    comp_unit = this->comp_units[ull];
 	    break;
 	  }
 	case DW_IDX_type_unit:
 	  {
-	    /* Don't crash on bad data.  */
-	    if (ull >= this->type_units.size ())
+	    if (ull < this->type_units.size ())
+	      type_unit = this->type_units[ull];
+	    else if (auto foreign_idx = ull - this->type_units.size ();
+		     foreign_idx < this->foreign_type_units.size ())
+	      foreign_type_unit = this->foreign_type_units[foreign_idx];
+	    else
 	      {
 		complain_about_index_entry
 		  (abfd, name, offset_in_entry_pool,
@@ -307,15 +321,10 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 		continue;
 	      }
 
-	    per_cu = this->type_units[ull];
 	    break;
 	  }
 	case DW_IDX_die_offset:
 	  die_offset = sect_offset (ull);
-	  /* In a per-CU index (as opposed to a per-module index), index
-	     entries without CU attribute implicitly refer to the single CU.  */
-	  if (per_cu == nullptr)
-	    per_cu = this->comp_units[0];
 	  break;
 	case DW_IDX_parent:
 	  parent = ull;
@@ -339,27 +348,117 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 	}
     }
 
-  /* Skip if we couldn't find a valid CU/TU index.  */
-  if (per_cu != nullptr)
+  /* From DWARF 5 section 6.1.1.3 ("Per-CU versus Per-Module Indexes"):
+
+       In a per-CU index, the CU list may have only a single entry, and index
+       entries may omit the CU attribute.  */
+  if (comp_unit == nullptr
+      && type_unit == nullptr
+      && foreign_type_unit == nullptr)
     {
-      dwarf_read_debug_printf_v
-	("    -> die_offset %s, per_cu offset %s",
-	 sect_offset_str (die_offset),
-	 sect_offset_str (per_cu->sect_off ()));
+      if (this->comp_units.size () != 1)
+	{
+	  complain_about_index_entry
+	   (abfd, name, offset_in_entry_pool,
+	    _(".debug_names entry is missing CU index, but index has %zu CUs "
+	      "(expecting 1)"),
+	    this->comp_units.size ());
+	  return entry;
+	}
 
-      *result
-	= indices[next_shard].add (die_offset, (dwarf_tag) indexval.dwarf_tag,
-				   flags, lang, name, nullptr, per_cu);
-
-      ++next_shard;
-      if (next_shard == indices.size ())
-	next_shard = 0;
-
-      entry_pool_offsets_to_entries.emplace (offset_in_entry_pool, *result);
+      comp_unit = this->comp_units[0];
     }
-  else
-    dwarf_read_debug_printf_v ("    -> no valid CU/TU, skipping");
 
+  /* Figure out which unit this entry refers to.  */
+  dwarf2_per_cu *actual_unit;
+
+  if (foreign_type_unit != nullptr)
+    {
+      if (type_unit != nullptr)
+	{
+	  complain_about_index_entry
+	    (abfd, name, offset_in_entry_pool,
+	     _(".debug_names entry refers to two TUs"));
+	  return entry;
+	}
+
+      /* Implement this part of DWARF 5 section 6.1.1.2 ("Structure of the Name
+	 Index"):
+
+	   When an index entry refers to a foreign type unit, it may have
+	   attributes for both CU and (foreign) TU.  For such entries, the CU
+	   attribute gives the consumer a reference to the CU that may be used
+	   to locate a split DWARF object file that contains the type unit.  */
+      if (comp_unit == nullptr)
+	{
+	  /* If a foreign type unit does not say which compile unit to follow
+	     to find it, it's pretty much useless.  */
+	  complain_about_index_entry
+	    (abfd, name, offset_in_entry_pool,
+	     _(".debug_names entry refers to foreign type unit but "
+	       "no compile unit"));
+	  return entry;
+	}
+
+      actual_unit = foreign_type_unit;
+
+      /* .debug_names attaches one "hint" CU per index entry, insinuating that
+	 for some names / index entries, it is important which .dwo we choose to
+	 locate the TU.  Even if it's important, the DWARF reader is not
+	 currently able to load multiple versions of the same TU.  So just
+	 record one hint CU for each foreign TU.  */
+      if (foreign_type_unit->hint_per_cu == nullptr)
+	{
+	  foreign_type_unit->hint_per_cu = comp_unit;
+	  dwarf_read_debug_printf_v
+	    ("    hint CU for foreign type unit with signature %s: "
+	     "unit offset %s",
+	     hex_string (foreign_type_unit->signature),
+	     sect_offset_str (comp_unit->sect_off ()));
+	}
+    }
+  else if (type_unit != nullptr)
+    {
+      if (comp_unit != nullptr)
+	{
+	  complain_about_index_entry
+	    (abfd, name, offset_in_entry_pool,
+	     _(".debug_names entry refers to both a CU and a TU"));
+	  return entry;
+	}
+
+      actual_unit = type_unit;
+    }
+  else if (comp_unit != nullptr)
+    actual_unit = comp_unit;
+  else
+    {
+      complain_about_index_entry
+	(abfd, name, offset_in_entry_pool,
+	 _(".debug_names entry is missing a CU or TU reference"));
+      return entry;
+    }
+
+  gdb_assert (actual_unit != nullptr);
+
+  if (foreign_type_unit != nullptr)
+    dwarf_read_debug_printf_v ("    -> signature %s, DIE offset: %s",
+			       hex_string (foreign_type_unit->signature),
+			       sect_offset_str (die_offset));
+  else
+    dwarf_read_debug_printf_v ("    -> unit offset %s, DIE offset %s",
+			       sect_offset_str (actual_unit->sect_off ()),
+			       sect_offset_str (die_offset));
+
+  *result = indices[next_shard].add (die_offset,
+				     (dwarf_tag) indexval.dwarf_tag, flags,
+				     lang, name, nullptr, actual_unit);
+
+  ++next_shard;
+  if (next_shard == indices.size ())
+    next_shard = 0;
+
+  entry_pool_offsets_to_entries.emplace (offset_in_entry_pool, *result);
   return entry;
 }
 
@@ -553,7 +652,7 @@ build_and_check_tu_list_from_debug_names (dwarf2_per_objfile *per_objfile,
 	  return false;
 	}
 
-      map.type_units.emplace_back (per_cu);
+      map.type_units.emplace_back (per_cu->as_signatured_type ());
     }
 
   return true;
@@ -665,22 +764,12 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
 
   /* foreign_type_unit_count - The number of TUs in the foreign TU
      list.  */
-  uint32_t foreign_tu_count = read_4_bytes (abfd, addr);
+  map.foreign_tu_count = read_4_bytes (abfd, addr);
   addr += 4;
 
   dwarf_read_debug_printf ("cu_count: %u, tu_count: %u, "
 			   "foreign_tu_count: %u",
-			   map.cu_count, map.tu_count, foreign_tu_count);
-
-  if (foreign_tu_count != 0)
-    {
-      warning (_("Section .debug_names in %ps has unsupported %lu foreign TUs, "
-		 "ignoring .debug_names."),
-	       styled_string (file_name_style.style (),
-			      filename),
-	       static_cast<unsigned long> (foreign_tu_count));
-      return false;
-    }
+			   map.cu_count, map.tu_count, map.foreign_tu_count);
 
   /* bucket_count - The number of hash buckets in the hash lookup
      table.  */
@@ -760,6 +849,10 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
   /* List of Local TUs */
   map.tu_table_reordered = addr;
   addr += map.tu_count * map.offset_size;
+
+  /* List of foreign TUs */
+  map.foreign_tu_table_reordered = addr;
+  addr += map.foreign_tu_count * sizeof (std::uint64_t);
 
   /* Hash Lookup Table */
   map.bucket_table_reordered = reinterpret_cast<const uint32_t *> (addr);
@@ -918,6 +1011,35 @@ build_and_check_cu_lists_from_debug_names (dwarf2_per_bfd *per_bfd,
   return build_and_check_cu_list_from_debug_names (per_bfd, dwz_map, dwz->info);
 }
 
+/* Create signatured_type objects for the foreign TU list in MAP.  */
+
+static void
+create_foreign_type_units_from_debug_names (dwarf2_per_bfd *per_bfd,
+					    mapped_debug_names_reader &map)
+{
+  for (uint32_t i = 0; i < map.foreign_tu_count; ++i)
+    {
+      /* The list of foreign TUs is a list of 64-bit (DW_FORM_ref_sig8) type
+	 signatures representing type units placed in .dwo files.  All we know
+	 about them for now is the signature.  */
+      const gdb_byte *ptr
+	= map.foreign_tu_table_reordered + i * sizeof (std::uint64_t);
+      std::uint64_t sig
+	= extract_unsigned_integer (ptr, sizeof (std::uint64_t),
+				    map.dwarf5_byte_order);
+
+      dwarf_read_debug_printf_v ("  Foreign TU %u (%u): signature %s", i,
+				 i + map.tu_count, hex_string (sig));
+
+      signatured_type_up sig_type
+	= per_bfd->allocate_signatured_type (sig);
+
+      map.foreign_type_units.emplace_back (sig_type.get ());
+      per_bfd->signatured_types.emplace (sig_type.get ());
+      per_bfd->all_units.emplace_back (sig_type.release ());
+    }
+}
+
 /* See read-debug-names.h.  */
 
 bool
@@ -974,6 +1096,12 @@ dwarf2_read_debug_names (dwarf2_per_objfile *per_objfile)
 						     section))
 	return false;
     }
+
+  create_foreign_type_units_from_debug_names (per_objfile->per_bfd, map);
+
+  /* create_foreign_type_units_from_debug_names may add more entries to the
+     ALL_UNITS vector, so it must be called before finalize_all_units.  */
+  finalize_all_units (per_objfile->per_bfd);
 
   per_bfd->debug_aranges.read (per_objfile->objfile);
 

--- a/gdb/dwarf2/read-debug-names.c
+++ b/gdb/dwarf2/read-debug-names.c
@@ -170,7 +170,12 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
   const ULONGEST abbrev = read_unsigned_leb128 (abfd, entry, &bytes_read);
   entry += bytes_read;
   if (abbrev == 0)
-    return nullptr;
+    {
+      dwarf_read_debug_printf_v
+	("  entry pool offset 0x%tx: end of entries (abbrev 0)",
+	 offset_in_entry_pool);
+      return nullptr;
+    }
 
   const auto indexval_it = abbrev_map.find (abbrev);
   if (indexval_it == abbrev_map.cend ())
@@ -182,6 +187,12 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
     }
 
   const auto &indexval = indexval_it->second;
+
+  dwarf_read_debug_printf_v
+    ("  entry pool offset 0x%tx: abbrev %s, tag %s",
+     offset_in_entry_pool, pulongest (abbrev),
+     dwarf_tag_name (indexval.dwarf_tag));
+
   cooked_index_flag flags = 0;
   sect_offset die_offset {};
   enum language lang = language_unknown;
@@ -238,6 +249,14 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 				  bfd_get_filename (abfd)));
 	  return nullptr;
 	}
+
+      dwarf_read_debug_printf_v ("    %s (%s): %s",
+				 get_DW_IDX_name (attr.dw_idx),
+				 dwarf_form_name (attr.form),
+				 (attr.form == DW_FORM_ref_addr
+				  ? hex_string (ull)
+				  : pulongest (ull)));
+
       switch (attr.dw_idx)
 	{
 	case DW_IDX_compile_unit:
@@ -302,6 +321,11 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
   /* Skip if we couldn't find a valid CU/TU index.  */
   if (per_cu != nullptr)
     {
+      dwarf_read_debug_printf_v
+	("    -> die_offset %s, per_cu offset %s",
+	 sect_offset_str (die_offset),
+	 sect_offset_str (per_cu->sect_off ()));
+
       *result
 	= indices[next_shard].add (die_offset, (dwarf_tag) indexval.dwarf_tag,
 				   flags, lang, name, nullptr, per_cu);
@@ -312,6 +336,8 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 
       entry_pool_offsets_to_entries.emplace (offset_in_entry_pool, *result);
     }
+  else
+    dwarf_read_debug_printf_v ("    -> no valid CU/TU, skipping");
 
   return entry;
 }
@@ -323,6 +349,12 @@ mapped_debug_names_reader::scan_entries (uint32_t index,
 					 const char *name,
 					 const gdb_byte *entry)
 {
+  /* Print a 1-based index, because this is what readelf and llvm-dwarfdump
+     do.  This makes it easier to compare output side-by-side.  */
+  dwarf_read_debug_printf_v
+    ("scanning entries for name %u: \"%s\" (entry pool offset 0x%tx)",
+     index + 1, name, entry - entry_pool);
+
   std::vector<cooked_index_entry *> these_entries;
 
   while (true)
@@ -347,6 +379,9 @@ mapped_debug_names_reader::scan_entries (uint32_t index,
 void
 mapped_debug_names_reader::scan_all_names ()
 {
+  DWARF_READ_SCOPED_DEBUG_START_END
+    ("scanning %u names from .debug_names", name_count);
+
   all_entries.resize (name_count);
 
   /* In the first pass, create all the entries.  */
@@ -377,6 +412,9 @@ mapped_debug_names_reader::scan_all_names ()
 
      Otherwise, the DW_IDX_parent value is an offset into the entry pool, which
      is not ambiguous.  */
+  dwarf_read_debug_printf ("resolving %zu parent pointers",
+			   needs_parent.size ());
+
   for (auto &[entry, parent_val] : needs_parent)
     {
       if (augmentation_is_gdb && gdb_augmentation_version == 2)
@@ -463,6 +501,9 @@ build_and_check_tu_list_from_debug_names (dwarf2_per_objfile *per_objfile,
 					  mapped_debug_names_reader &map,
 					  dwarf2_section_info *section)
 {
+  dwarf_read_debug_printf ("building TU list from .debug_names (%u TUs)",
+			   map.tu_count);
+
   struct objfile *objfile = per_objfile->objfile;
   dwarf2_per_bfd *per_bfd = per_objfile->per_bfd;
 
@@ -476,6 +517,9 @@ build_and_check_tu_list_from_debug_names (dwarf2_per_objfile *per_objfile,
 			 (map.tu_table_reordered + i * map.offset_size,
 			  map.offset_size,
 			  map.dwarf5_byte_order));
+
+      dwarf_read_debug_printf_v ("  TU %u: offset %s", i,
+				 sect_offset_str (sect_off));
 
       /* Find the matching dwarf2_per_cu.  */
       dwarf2_per_cu *per_cu = dwarf2_find_unit ({ section, sect_off },
@@ -508,15 +552,24 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
 			       struct dwarf2_section_info *section,
 			       mapped_debug_names_reader &map)
 {
+  DWARF_READ_SCOPED_DEBUG_START_END
+    ("reading .debug_names from %s", filename);
+
   struct objfile *objfile = per_objfile->objfile;
 
   if (section->empty ())
-    return false;
+    {
+      dwarf_read_debug_printf ("section is empty");
+      return false;
+    }
 
   /* Older elfutils strip versions could keep the section in the main
      executable while splitting it for the separate debug info file.  */
   if ((section->get_flags () & SEC_HAS_CONTENTS) == 0)
-    return false;
+    {
+      dwarf_read_debug_printf ("section has no contents");
+      return false;
+    }
 
   section->read (objfile);
 
@@ -534,6 +587,11 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
 
   map.dwarf5_is_dwarf64 = bytes_read != 4;
   map.offset_size = map.dwarf5_is_dwarf64 ? 8 : 4;
+
+  dwarf_read_debug_printf ("section size: %s, initial length: %s, "
+			   "dwarf64: %d, offset_size: %d",
+			   hex_string (section->size), hex_string (length),
+			   map.dwarf5_is_dwarf64, map.offset_size);
   if (bytes_read + length != section->size)
     {
       /* There may be multiple per-CU indices.  */
@@ -549,6 +607,9 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
   /* The version number.  */
   uint16_t version = read_2_bytes (abfd, addr);
   addr += 2;
+
+  dwarf_read_debug_printf ("version: %d", version);
+
   if (version != 5)
     {
       warning (_("Section .debug_names in %ps has unsupported version %d, "
@@ -585,6 +646,11 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
      list.  */
   uint32_t foreign_tu_count = read_4_bytes (abfd, addr);
   addr += 4;
+
+  dwarf_read_debug_printf ("cu_count: %u, tu_count: %u, "
+			   "foreign_tu_count: %u",
+			   map.cu_count, map.tu_count, foreign_tu_count);
+
   if (foreign_tu_count != 0)
     {
       warning (_("Section .debug_names in %ps has unsupported %lu foreign TUs, "
@@ -613,10 +679,33 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
      string.  This value is rounded up to a multiple of 4.  */
   uint32_t augmentation_string_size = read_4_bytes (abfd, addr);
   addr += 4;
+
+  dwarf_read_debug_printf ("bucket_count: %u, name_count: %u, "
+			   "abbrev_table_size: %u, "
+			   "augmentation_string_size: %u",
+			   map.bucket_count, map.name_count,
+			   abbrev_table_size, augmentation_string_size);
+
   augmentation_string_size += (-augmentation_string_size) & 3;
 
   const auto augmentation_string
     = gdb::make_array_view (addr, augmentation_string_size);
+
+  if (dwarf_read_debug >= 1)
+    {
+      std::string aug_repr;
+      for (size_t i = 0; i < augmentation_string_size; i++)
+	{
+	  gdb_byte b = addr[i];
+	  if (c_isprint (b))
+	    aug_repr += b;
+	  else
+	    aug_repr += string_printf ("\\x%02x", b);
+	}
+
+      dwarf_read_debug_printf ("augmentation string: \"%s\"",
+			       aug_repr.c_str ());
+    }
 
   if (augmentation_string == gdb::make_array_view (dwarf5_augmentation_1))
     {
@@ -704,7 +793,26 @@ read_debug_names_from_section (dwarf2_per_objfile *per_objfile,
 	    break;
 	  indexval.attr_vec.push_back (std::move (attr));
 	}
+
+      dwarf_read_debug_printf_v
+	("  abbrev %s: tag %s, %zu attributes",
+	 pulongest (index_num), dwarf_tag_name (indexval.dwarf_tag),
+	 indexval.attr_vec.size ());
+
+      for (const auto &attr : indexval.attr_vec)
+	dwarf_read_debug_printf_v
+	  ("    %s %s%s",
+	   get_DW_IDX_name (attr.dw_idx),
+	   dwarf_form_name (attr.form),
+	   (attr.form == DW_FORM_implicit_const
+	    ? string_printf (" (%s)",
+			     plongest (attr.implicit_const)).c_str ()
+	    : ""));
     }
+
+  dwarf_read_debug_printf ("%zu abbreviations read",
+			   map.abbrev_map.size ());
+
   if (addr != abbrev_table_start + abbrev_table_size)
     {
       warning (_("Section .debug_names in %ps has abbreviation_table "
@@ -728,6 +836,9 @@ build_and_check_cu_list_from_debug_names (dwarf2_per_bfd *per_bfd,
 					  mapped_debug_names_reader &map,
 					  dwarf2_section_info &section)
 {
+  dwarf_read_debug_printf ("building CU list from .debug_names (%u CUs)",
+			   map.cu_count);
+
   int nr_cus = per_bfd->num_comp_units;
 
   if (map.cu_count != nr_cus)
@@ -744,6 +855,9 @@ build_and_check_cu_list_from_debug_names (dwarf2_per_bfd *per_bfd,
 			 (map.cu_table_reordered + i * map.offset_size,
 			  map.offset_size,
 			  map.dwarf5_byte_order));
+
+      dwarf_read_debug_printf_v ("  CU %u: offset %s", i,
+				 sect_offset_str (sect_off));
 
       /* Find the matching dwarf2_per_cu.  */
       dwarf2_per_cu *per_cu = dwarf2_find_unit ({ &section, sect_off }, per_bfd);

--- a/gdb/dwarf2/read-debug-names.c
+++ b/gdb/dwarf2/read-debug-names.c
@@ -155,6 +155,25 @@ struct mapped_debug_names_reader
   std::vector<std::vector<cooked_index_entry *>> all_entries;
 };
 
+/* Emit a complaint about a specific index entry.  */
+
+static void ATTRIBUTE_PRINTF (4, 5)
+complain_about_index_entry (bfd *abfd, const char *name,
+			    ptrdiff_t offset_in_entry_pool, const char *fmt,
+			    ...)
+{
+  va_list ap;
+  va_start (ap, fmt);
+  std::string msg = string_vprintf (fmt, ap);
+  va_end (ap);
+
+  msg += string_printf (_(" [in module %s, index entry for name %s,"
+			   " entry pool offset 0x%tx]"),
+			bfd_get_filename (abfd), name, offset_in_entry_pool);
+
+  complaint ("%s", msg.c_str ());
+}
+
 /* Scan a single entry from the entries table.  Set *RESULT and PARENT
    (if needed) and return the updated pointer on success, or return
    nullptr on error, or at the end of the table.  */
@@ -180,9 +199,11 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
   const auto indexval_it = abbrev_map.find (abbrev);
   if (indexval_it == abbrev_map.cend ())
     {
-      complaint (_("Wrong .debug_names undefined abbrev code %s "
-		   "[in module %s]"),
-		 pulongest (abbrev), bfd_get_filename (abfd));
+      complain_about_index_entry (abfd, name, offset_in_entry_pool,
+				  _("Wrong .debug_names abbrev code %s"),
+				  pulongest (abbrev));
+      /* We can't go past this entry because we don't know its size, stop
+	 reading this entry chain.  */
       return nullptr;
     }
 
@@ -264,10 +285,10 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 	    /* Don't crash on bad data.  */
 	    if (ull >= this->comp_units.size ())
 	      {
-		complaint (_(".debug_names entry has bad CU index %s"
-			     " [in module %s]"),
-			   pulongest (ull),
-			   bfd_get_filename (abfd));
+		complain_about_index_entry
+		  (abfd, name, offset_in_entry_pool,
+		   _(".debug_names entry has bad CU index %s"),
+		   pulongest (ull));
 		continue;
 	      }
 
@@ -279,10 +300,10 @@ mapped_debug_names_reader::scan_one_entry (const char *name,
 	    /* Don't crash on bad data.  */
 	    if (ull >= this->type_units.size ())
 	      {
-		complaint (_(".debug_names entry has bad TU index %s"
-			     " [in module %s]"),
-			   pulongest (ull),
-			   bfd_get_filename (abfd));
+		complain_about_index_entry
+		  (abfd, name, offset_in_entry_pool,
+		   _(".debug_names entry has bad TU index %s"),
+		   pulongest (ull));
 		continue;
 	      }
 

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -695,6 +695,13 @@ static struct die_info *follow_die_ref (struct die_info *,
 					const struct attribute *,
 					struct dwarf2_cu **);
 
+static void fill_in_sig_entry_from_dwo_entry (dwarf2_per_objfile *per_objfile,
+					      signatured_type *sig_entry,
+					      dwo_unit *dwo_entry);
+
+static void fill_in_sig_entry_from_per_cu_hint
+  (dwarf2_per_objfile &per_objfile, signatured_type &sig_type);
+
 static struct die_info *follow_die_sig (struct die_info *,
 					const struct attribute *,
 					struct dwarf2_cu **);
@@ -1415,6 +1422,7 @@ dwarf2_per_bfd::allocate_per_cu (dwarf2_section_info *section,
 				 sect_offset sect_off, unsigned int length,
 				 bool is_dwz)
 {
+  gdb_assert (section != nullptr);
   dwarf2_per_cu_up result (new dwarf2_per_cu (this, section, sect_off,
 					      length, is_dwz));
   result->index = all_units.size ();
@@ -1431,9 +1439,24 @@ dwarf2_per_bfd::allocate_signatured_type (dwarf2_section_info *section,
 					  bool is_dwz,
 					  ULONGEST signature)
 {
+  gdb_assert (section != nullptr);
   auto result
     = std::make_unique<signatured_type> (this, section, sect_off, length,
 					 is_dwz, signature);
+  result->index = all_units.size ();
+  this->num_type_units++;
+  return result;
+}
+
+/* See read.h.  */
+
+signatured_type_up
+dwarf2_per_bfd::allocate_signatured_type (ULONGEST signature)
+{
+  auto result
+    = std::make_unique<signatured_type> (this, nullptr,
+					 invalid_sect_offset,
+					 0, false, signature);
   result->index = all_units.size ();
   this->num_type_units++;
   return result;
@@ -1722,6 +1745,20 @@ dwarf2_base_index_functions::expand_all_symtabs (struct objfile *objfile)
 
   for (dwarf2_per_cu *per_cu : all_units_range (per_objfile->per_bfd))
     {
+      /* If a .debug_names index contains a foreign TU but no index entry
+	 references it, the TU won't have a hint CU.  This is a problem, because
+	 we won't be able to locate it.  Skip them, for the following reasons:
+
+	  - If they don't contain anything worthy of a named index entry, they
+	    are unlikely to contain anything interesting, symbol-wise.
+	  - They are likely to be referred to by some other unit (otherwise,
+	    why does it exist?), so will get expanded anyway.  */
+      if (signatured_type *sig_type = per_cu->as_signatured_type ();
+	  (sig_type != nullptr
+	   && sig_type->section () == nullptr
+	   && sig_type->hint_per_cu == nullptr))
+	continue;
+
       /* We don't want to directly expand a partial CU, because if we
 	 read it with the wrong language, then assertion failures can
 	 be triggered later on.  See PR symtab/23010.  So, tell
@@ -2223,8 +2260,7 @@ add_type_unit (dwarf2_per_bfd *per_bfd, dwarf2_section_info *section,
   return emplace_ret.first;
 }
 
-/* Subroutine of lookup_dwo_signatured_type and lookup_dwp_signatured_type.
-   Fill in SIG_ENTRY with DWO_ENTRY.  */
+/* Fill in the missing details in SIG_ENTRY from DWO_ENTRY.  */
 
 static void
 fill_in_sig_entry_from_dwo_entry (dwarf2_per_objfile *per_objfile,
@@ -2680,6 +2716,10 @@ cutu_reader::cutu_reader (dwarf2_per_cu &this_cu,
 {
   struct objfile *objfile = per_objfile.objfile;
   struct dwarf2_section_info *section = this_cu.section ();
+
+  /* Any foreign TU must have been located before getting here.  */
+  gdb_assert (section != nullptr);
+
   bfd *abfd = section->get_bfd_owner ();
   const gdb_byte *begin_info_ptr;
   struct dwarf2_section_info *abbrev_section;
@@ -3278,6 +3318,7 @@ cooked_index_worker_debug_info::do_reading ()
   dwarf2_per_bfd *per_bfd = m_per_objfile->per_bfd;
 
   create_all_units (m_per_objfile);
+  finalize_all_units (m_per_objfile->per_bfd);
   process_type_units (m_per_objfile, &m_index_storage);
 
   if (!per_bfd->debug_aranges.empty ())
@@ -3359,20 +3400,26 @@ read_comp_units_from_section (dwarf2_per_objfile *per_objfile,
 /* See read.h.  */
 
 void
+dwarf2_per_bfd::sort_all_units ()
+{
+  std::sort (this->all_units.begin (), this->all_units.end (),
+	     [] (const dwarf2_per_cu_up &a, const dwarf2_per_cu_up &b)
+	       {
+		 return all_units_less_than (*a, { b->section (),
+						   b->sect_off () });
+	       });
+}
+
+/* See read.h.  */
+
+void
 finalize_all_units (dwarf2_per_bfd *per_bfd)
 {
   /* Sanity check.  */
   gdb_assert (per_bfd->all_units.size ()
 	      == per_bfd->num_comp_units + per_bfd->num_type_units);
 
-  /* Ensure that the all_units vector is in the expected order for
-     dwarf2_find_containing_unit to be able to perform a binary search.  */
-  std::sort (per_bfd->all_units.begin (), per_bfd->all_units.end (),
-	     [] (const dwarf2_per_cu_up &a, const dwarf2_per_cu_up &b)
-	       {
-		 return all_units_less_than (*a, { b->section (),
-						   b->sect_off () });
-	       });
+  per_bfd->sort_all_units ();
 }
 
 /* See read.h.  */
@@ -3410,7 +3457,6 @@ create_all_units (dwarf2_per_objfile *per_objfile)
 
   per_objfile->per_bfd->signatured_types = std::move (sig_types);
 
-  finalize_all_units (per_objfile->per_bfd);
   remove_all_units.disable ();
 }
 
@@ -17104,6 +17150,77 @@ dwarf2_get_die_type (cu_offset die_offset, dwarf2_per_cu *per_cu,
   return get_die_type_at_offset (die_offset_sect, per_cu, per_objfile);
 }
 
+/* Fill in the missing details in SIG_TYPE from DWO_FILE.
+
+   Error out if there isn't a type unit with the appropriate signature in
+   DWO_FILE.  */
+
+static void
+fill_in_sig_entry_from_dwo_file (dwarf2_per_objfile &per_objfile,
+				 signatured_type &sig_type, dwo_file &dwo_file)
+{
+  gdb_assert (sig_type.section () == nullptr);
+
+  dwo_unit *dwo_tu = dwo_file.find_tu (sig_type.signature);
+  if (dwo_tu == nullptr)
+    error (_(DWARF_ERROR_PREFIX
+	     "Unable to locate type unit with signature %s in DWO file %s "
+	     "[in module %s]"),
+	   hex_string (sig_type.signature), dwo_file.dwo_name.c_str (),
+	   objfile_name (per_objfile.objfile));
+
+  fill_in_sig_entry_from_dwo_entry (&per_objfile, &sig_type, dwo_tu);
+  sig_type.set_section (dwo_tu->section);
+  sig_type.set_sect_off (dwo_tu->sect_off);
+  sig_type.set_length (dwo_tu->length);
+
+  /* Setting SIG_TYPE's section invalidates the ALL_UNITS vector order,
+     re-sort it.  */
+  per_objfile.per_bfd->sort_all_units ();
+}
+
+/* Fill in the missing details in SIG_TYPE from its hint CU.
+
+   Error out if we're unable to locate the .dwo file using the hint CU.  */
+
+static void
+fill_in_sig_entry_from_per_cu_hint (dwarf2_per_objfile &per_objfile,
+				    signatured_type &sig_type)
+{
+  gdb_assert (sig_type.section () == nullptr);
+  gdb_assert (sig_type.hint_per_cu != nullptr);
+
+  dwarf2_per_cu *hint_per_cu = sig_type.hint_per_cu;
+  dwo_unit *dwo_unit;
+
+  /* If a dwarf2_cu already exists for HINT_PER_CU, no need to build another
+     one.  */
+  if (dwarf2_cu *hint_cu = per_objfile.get_cu (hint_per_cu);
+      hint_cu != nullptr)
+    dwo_unit = hint_cu->dwo_unit;
+  else
+    {
+      /* Constructing this cutu_reader will look for the .dwo file, creating
+	 the dwo_file if necessary.  */
+      abbrev_table_cache abbrev_table_cache;
+      cutu_reader reader (*hint_per_cu, per_objfile, nullptr, true,
+			  std::nullopt, abbrev_table_cache);
+
+      /* dwo_unit is owned by the per_bfd, which outlives the reader.  */
+      dwo_unit = reader.cu ()->dwo_unit;
+    }
+
+  if (dwo_unit == nullptr)
+    error (_(DWARF_ERROR_PREFIX
+	     "Hint compilation unit for foreign type unit with signature %s is "
+	     "not in a DWO file [in module %s]"),
+	   hex_string (sig_type.signature),
+	   objfile_name (per_objfile.objfile));
+
+  fill_in_sig_entry_from_dwo_file (per_objfile, sig_type,
+				   *dwo_unit->dwo_file);
+}
+
 /* Follow type unit SIG_TYPE referenced by SRC_DIE.
    On entry *REF_CU is the CU of SRC_DIE.
    On exit *REF_CU is the CU of the result.
@@ -17118,6 +17235,28 @@ follow_die_sig_1 (struct die_info *src_die, struct signatured_type *sig_type,
   /* While it might be nice to assert sig_type->type == NULL here,
      we can get here for DW_AT_imported_declaration where we need
      the DIE not the type.  */
+
+  /* If SIG_TYPE's section is not set, it means it's a .debug_names foreign
+     type unit for which we don't know the containing file or section yet.
+     Use the referencing CU as the hint: we know there must exist a TU with
+     the correct signature in its .dwo file, and that .dwo is already open,
+     might as well use it.
+
+     But this is not only an optimization.  If a .debug_names foreign unit
+     does not have any index entry referencing it, then we don't have any
+     "hint CU" for it.  The only hint we have is the referencing CU.  */
+  if (sig_type->section () == nullptr)
+    {
+      if ((*ref_cu)->dwo_unit == nullptr)
+	error (_(DWARF_ERROR_PREFIX
+		 "Unit referencing foreign type unit with signature %s is "
+		 "not from a DWO file [in module %s]"),
+	       hex_string (sig_type->signature),
+	       objfile_name (per_objfile->objfile));
+
+      fill_in_sig_entry_from_dwo_file (*per_objfile, *sig_type,
+				       *(*ref_cu)->dwo_unit->dwo_file);
+    }
 
   dwarf2_cu *sig_cu = ensure_loaded_type_unit (sig_type, per_objfile);
 
@@ -17298,6 +17437,12 @@ load_full_type_unit (signatured_type *sig_type,
 {
   gdb_assert (sig_type->is_debug_types ());
   gdb_assert (per_objfile->get_cu (sig_type) == nullptr);
+
+  /* If the section is not set, this is a .debug_names foreign type unit for
+     which we don't know the containing file nor section yet.  For these, we
+     must have a "hint" CU to follow to find the file and section.  */
+  if (sig_type->section () == nullptr)
+    fill_in_sig_entry_from_per_cu_hint (*per_objfile, *sig_type);
 
   abbrev_table_cache abbrev_table_cache;
   cutu_reader reader (*sig_type, *per_objfile, nullptr, false,

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -5765,19 +5765,7 @@ read_file_scope (struct die_info *die, struct dwarf2_cu *cu)
     }
 }
 
-/* See cu.h.
-
-   This function is defined in this file (instead of cu.c) because it needs
-   to see the definition of struct dwo_unit.  */
-
-const dwarf2_section_info &
-dwarf2_cu::section () const
-{
-  if (this->dwo_unit != nullptr)
-    return *this->dwo_unit->section;
-  else
-    return *this->per_cu->section ();
-}
+/* See cu.h.  */
 
 /* See cu.h.
 

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -2311,11 +2311,9 @@ lookup_dwo_signatured_type (struct dwarf2_cu *cu, ULONGEST sig)
   /* Note: cu->dwo_unit is the dwo_unit that references this TU, not the
      dwo_unit of the TU itself.  */
   dwo_file *dwo_file = cu->dwo_unit->dwo_file;
-  auto it = dwo_file->tus.find (sig);
-  if (it == dwo_file->tus.end ())
+  dwo_unit *dwo_entry = dwo_file->find_tu (sig);
+  if (dwo_entry == nullptr)
     return nullptr;
-
-  dwo_unit *dwo_entry = it->get ();
 
   /* If the global table doesn't have an entry for this TU, add one.  */
   if (sig_type_it == per_bfd->signatured_types.end ())

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -31,6 +31,7 @@
 #include "dwarf2/abbrev.h"
 #include "dwarf2/aranges.h"
 #include "dwarf2/attribute.h"
+#include "dwarf2/dwo.h"
 #include "dwarf2/unit-head.h"
 #include "dwarf2/cooked-index-worker.h"
 #include "dwarf2/cooked-indexer.h"
@@ -65,7 +66,6 @@
 #include "dwarf2/expr.h"
 #include "dwarf2/loc.h"
 #include "cp-support.h"
-#include "hashtab.h"
 #include "command.h"
 #include "cli/cli-cmds.h"
 #include "block.h"
@@ -266,86 +266,6 @@ struct loclists_rnglists_header
   unsigned int offset_entry_count;
 };
 
-/* These sections are what may appear in a (real or virtual) DWO file.  */
-
-struct dwo_sections
-{
-  struct dwarf2_section_info abbrev;
-  struct dwarf2_section_info line;
-  struct dwarf2_section_info loc;
-  struct dwarf2_section_info loclists;
-  struct dwarf2_section_info macinfo;
-  struct dwarf2_section_info macro;
-  struct dwarf2_section_info rnglists;
-  struct dwarf2_section_info str;
-  struct dwarf2_section_info str_offsets;
-  /* In the case of a virtual DWO file, these two are unused.  */
-  std::vector<dwarf2_section_info> infos;
-  std::vector<dwarf2_section_info> types;
-};
-
-/* CUs/TUs in DWP/DWO files.  */
-
-struct dwo_unit
-{
-  /* Backlink to the containing struct dwo_file.  */
-  struct dwo_file *dwo_file = nullptr;
-
-  /* The "id" that distinguishes this CU/TU.
-     .debug_info calls this "dwo_id", .debug_types calls this "signature".
-     Since signatures came first, we stick with it for consistency.  */
-  ULONGEST signature = 0;
-
-  /* The section this CU/TU lives in, in the DWO file.  */
-  dwarf2_section_info *section = nullptr;
-
-  /* This is set if SECTION is owned by this dwo_unit.  */
-  dwarf2_section_info_up section_holder;
-
-  /* Same as dwarf2_per_cu::{sect_off,length} but in the DWO section.  */
-  sect_offset sect_off {};
-  unsigned int length = 0;
-
-  /* For types, offset in the type's DIE of the type defined by this TU.  */
-  cu_offset type_offset_in_tu;
-};
-
-using dwo_unit_up = std::unique_ptr<dwo_unit>;
-
-/* Hash function for dwo_unit objects, based on the signature.  */
-
-struct dwo_unit_hash
-{
-  using is_transparent = void;
-
-  std::size_t operator() (ULONGEST signature) const noexcept
-  { return signature; }
-
-  std::size_t operator() (const dwo_unit_up &unit) const noexcept
-  { return (*this) (unit->signature); }
-};
-
-/* Equal function for dwo_unit objects, based on the signature.
-
-   The signature is assumed to be unique within the DWO file.  So while object
-   file CU dwo_id's always have the value zero, that's OK, assuming each object
-   file DWO file has only one CU, and that's the rule for now.  */
-
-struct dwo_unit_eq
-{
-  using is_transparent = void;
-
-  bool operator() (ULONGEST sig, const dwo_unit_up  &unit) const noexcept
-  { return sig == unit->signature; }
-
-  bool operator() (const dwo_unit_up &a, const dwo_unit_up &b) const noexcept
-  { return (*this) (a->signature, b); }
-};
-
-/* Set of dwo_unit object, using their signature as identity.  */
-
-using dwo_unit_set = gdb::unordered_set<dwo_unit_up, dwo_unit_hash, dwo_unit_eq>;
-
 /* include/dwarf2.h defines the DWP section codes.
    It defines a max value but it doesn't define a min value, which we
    use for error checking, so provide one.  */
@@ -354,94 +274,6 @@ enum dwp_v2_section_ids
 {
   DW_SECT_MIN = 1
 };
-
-/* Data for one DWO file.
-
-   This includes virtual DWO files (a virtual DWO file is a DWO file as it
-   appears in a DWP file).  DWP files don't really have DWO files per se -
-   comdat folding of types "loses" the DWO file they came from, and from
-   a high level view DWP files appear to contain a mass of random types.
-   However, to maintain consistency with the non-DWP case we pretend DWP
-   files contain virtual DWO files, and we assign each TU with one virtual
-   DWO file (generally based on the line and abbrev section offsets -
-   a heuristic that seems to work in practice).  */
-
-struct dwo_file
-{
-  dwo_file () = default;
-  DISABLE_COPY_AND_ASSIGN (dwo_file);
-
-  /* The DW_AT_GNU_dwo_name or DW_AT_dwo_name attribute.
-     For virtual DWO files the name is constructed from the section offsets
-     of abbrev,line,loc,str_offsets so that we combine virtual DWO files
-     from related CU+TUs.  */
-  std::string dwo_name;
-
-  /* The DW_AT_comp_dir attribute.  */
-  const char *comp_dir = nullptr;
-
-  /* The bfd, when the file is open.  Otherwise this is NULL.
-     This is unused(NULL) for virtual DWO files where we use dwp_file.dbfd.  */
-  gdb_bfd_ref_ptr dbfd;
-
-  /* The sections that make up this DWO file.
-     Remember that for virtual DWO files in DWP V2 or DWP V5, these are virtual
-     sections (for lack of a better name).  */
-  struct dwo_sections sections {};
-
-  /* The CUs in the file.
-
-     Multiple CUs per DWO are supported as an extension to handle LLVM's Link
-     Time Optimization output (where multiple source files may be compiled into
-     a single object/dwo pair).  */
-  dwo_unit_set cus;
-
-  /* Table of TUs in the file.  */
-  dwo_unit_set tus;
-};
-
-/* See dwarf2/read.h.  */
-
-std::size_t
-dwo_file_hash::operator() (const dwo_file_search &search) const noexcept
-{
-  hashval_t hash = htab_hash_string (search.dwo_name);
-
-  if (search.comp_dir != nullptr)
-    hash += htab_hash_string (search.comp_dir);
-
-  return hash;
-}
-
-/* See dwarf2/read.h.  */
-
-std::size_t
-dwo_file_hash::operator() (const dwo_file_up &file) const noexcept
-{
-  return (*this) ({ file->dwo_name.c_str (), file->comp_dir });
-}
-
-/* See dwarf2/read.h.  */
-
-bool
-dwo_file_eq::operator() (const dwo_file_search &search,
-			 const dwo_file_up &dwo_file) const noexcept
-{
-  if (search.dwo_name != dwo_file->dwo_name)
-    return false;
-
-  if (search.comp_dir == nullptr || dwo_file->comp_dir == nullptr)
-    return search.comp_dir == dwo_file->comp_dir;
-
-  return streq (search.comp_dir, dwo_file->comp_dir);
-}
-
-/* See dwarf2/read.h.  */
-
-bool
-dwo_file_eq::operator() (const dwo_file_up &a,
-			 const dwo_file_up &b) const noexcept
-{ return (*this) ({ a->dwo_name.c_str (), a->comp_dir }, b); }
 
 /* These sections are what may appear in a DWP file.  */
 

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -7179,6 +7179,15 @@ cutu_reader::lookup_dwo_cutu (dwarf2_cu *cu, const char *dwo_name,
 		("DWO %s %s(%s) found: @%s", kind, dwo_name,
 		 hex_string (signature),
 		 host_address_to_string (dwo_unit_it->get ()));
+
+	      /* Record the dwarf2_per_cu that was used to look up this
+		 dwo_unit.  There will typically be exactly one skeleton
+		 pointing to each DWO CU.  But if for some mysterious reason
+		 there are multiple skeletons pointing to the same DWO CU, it's
+		 fine, we just need to remember one.  This will keep the last
+		 one seen.  */
+	      (*dwo_unit_it)->per_cu = cu->per_cu;
+
 	      return dwo_unit_it->get ();
 	    }
 	}

--- a/gdb/dwarf2/read.c
+++ b/gdb/dwarf2/read.c
@@ -99,28 +99,8 @@
 #include "extract-store-integer.h"
 #include "cli/cli-style.h"
 
-/* When == 1, print basic high level tracing messages.
-   When > 1, be more verbose.
-   This is in contrast to the low level DIE reading of dwarf_die_debug.  */
-static unsigned int dwarf_read_debug = 0;
-
-/* Print a "dwarf-read" debug statement if dwarf_read_debug is >= 1.  */
-
-#define dwarf_read_debug_printf(fmt, ...) \
-  debug_prefixed_printf_cond (dwarf_read_debug >= 1, "dwarf-read", fmt, \
-			      ##__VA_ARGS__)
-
-/* Print a "dwarf-read" debug statement if dwarf_read_debug is >= 2.  */
-
-#define dwarf_read_debug_printf_v(fmt, ...) \
-  debug_prefixed_printf_cond (dwarf_read_debug >= 2, "dwarf-read", fmt, \
-			      ##__VA_ARGS__)
-
-/* Print "dwarf-read" start/end debug statements.  */
-
-#define DWARF_READ_SCOPED_DEBUG_START_END(fmt, ...)                           \
-  scoped_debug_start_end ([] { return dwarf_read_debug >= 1; }, "dwarf-read", \
-			  fmt, ##__VA_ARGS__)
+/* See read.h.  */
+unsigned int dwarf_read_debug = 0;
 
 /* When non-zero, dump DIEs after they are read in.  */
 static unsigned int dwarf_die_debug = 0;

--- a/gdb/dwarf2/read.h
+++ b/gdb/dwarf2/read.h
@@ -110,7 +110,6 @@ struct dwarf2_per_cu
       m_per_bfd (per_bfd)
   {
     gdb_assert (per_bfd != nullptr);
-    gdb_assert (section != nullptr);
   }
 
 private:
@@ -285,8 +284,23 @@ public:
   dwarf2_section_info *section () const
   { return m_section; }
 
+  /* Set the section of this unit.  */
+  void set_section (dwarf2_section_info *section)
+  {
+    gdb_assert (section != nullptr);
+    gdb_assert (m_section == nullptr);
+    m_section = section;
+  }
+
   sect_offset sect_off () const
   { return m_sect_off; }
+
+  /* Set the section offset of this unit.  */
+  void set_sect_off (sect_offset sect_off)
+  {
+    gdb_assert (m_sect_off == invalid_sect_offset);
+    m_sect_off = sect_off;
+  }
 
   bool is_dwz () const
   { return m_is_dwz; }
@@ -482,6 +496,12 @@ struct signatured_type : public dwarf2_per_cu
   /* Containing DWO unit.
      This field is valid iff per_cu.reading_dwo_directly.  */
   struct dwo_unit *dwo_unit = nullptr;
+
+  /* When using a .debug_names index, the section is not initially known for
+     foreign type units (aka skeletonless type units).  This is a reference to
+     a CU that can be used to locate the .dwo file and section containing the
+     type unit.  */
+  dwarf2_per_cu *hint_per_cu = nullptr;
 };
 
 using signatured_type_up = std::unique_ptr<signatured_type>;
@@ -576,6 +596,10 @@ struct dwarf2_per_bfd
     return this->all_units[index].get ();
   }
 
+  /* Ensure that the all_units vector is in the expected order for
+     dwarf2_find_containing_unit to be able to perform a binary search.  */
+  void sort_all_units ();
+
   /* Return the separate '.dwz' debug file.  If there is no
      .gnu_debugaltlink or .debug_sup section in the file, then the
      result depends on REQUIRE: if REQUIRE is true, error out; if
@@ -609,6 +633,12 @@ struct dwarf2_per_bfd
 					       unsigned int length,
 					       bool is_dwz,
 					       ULONGEST signature);
+
+  /* A convenience function to allocate a signatured_type.  The
+     returned object has its "index" field set properly.
+
+     This one is used when only the signature is known at creation time.  */
+  signatured_type_up allocate_signatured_type (ULONGEST signature);
 
   /* Map all the DWARF section data needed when scanning
      .debug_info.  */
@@ -1334,7 +1364,10 @@ extern const char *read_indirect_string_at_offset
 
 extern void finalize_all_units (dwarf2_per_bfd *per_bfd);
 
-/* Create a list of all compilation units in OBJFILE.  */
+/* Create a list of all compilation units in OBJFILE.
+
+   After it is done creating all units, the caller is responsible for calling
+   finalize_all_units.  */
 
 extern void create_all_units (dwarf2_per_objfile *per_objfile);
 

--- a/gdb/dwarf2/read.h
+++ b/gdb/dwarf2/read.h
@@ -22,6 +22,7 @@
 
 #include <queue>
 #include "dwarf2/abbrev.h"
+#include "dwarf2/dwo.h"
 #include "dwarf2/unit-head.h"
 #include "dwarf2/file-and-dir.h"
 #include "dwarf2/index-cache.h"
@@ -528,49 +529,6 @@ struct signatured_type_eq
 using signatured_type_set
   = gdb::unordered_set<signatured_type *, signatured_type_hash,
 		       signatured_type_eq>;
-
-struct dwo_file;
-
-using dwo_file_up = std::unique_ptr<dwo_file>;
-
-/* This is used when looking up entries in a dwo_file_set.  */
-
-struct dwo_file_search
-{
-  /* Name of the DWO to look for.  */
-  const char *dwo_name;
-
-  /* Compilation directory to look for.  */
-  const char *comp_dir;
-};
-
-/* Hash function for dwo_file objects, using their dwo_name and comp_dir as
-   identity.  */
-
-struct dwo_file_hash
-{
-  using is_transparent = void;
-
-  std::size_t operator() (const dwo_file_search &search) const noexcept;
-  std::size_t operator() (const dwo_file_up &file) const noexcept;
-};
-
-/* Equal function for dwo_file objects, using their dwo_name and comp_dir as
-   identity.  */
-
-struct dwo_file_eq
-{
-  using is_transparent = void;
-
-  bool operator() (const dwo_file_search &search,
-		   const dwo_file_up &dwo_file) const noexcept;
-  bool operator() (const dwo_file_up &a, const dwo_file_up &b) const noexcept;
-};
-
-/* Set of dwo_file objects, using their dwo_name and comp_dir as identity.  */
-
-using dwo_file_up_set
-  = gdb::unordered_set<dwo_file_up, dwo_file_hash, dwo_file_eq>;
 
 struct dwp_file;
 

--- a/gdb/dwarf2/read.h
+++ b/gdb/dwarf2/read.h
@@ -1209,6 +1209,30 @@ type *dwarf2_fetch_die_type_sect_off (sect_offset sect_off,
 				      dwarf2_per_objfile *per_objfile,
 				      const char **var_name = nullptr);
 
+/* When == 1, print basic high level tracing messages.
+   When > 1, be more verbose.
+   This is in contrast to the low level DIE reading of dwarf_die_debug.  */
+
+extern unsigned int dwarf_read_debug;
+
+/* Print a "dwarf-read" debug statement if dwarf_read_debug is >= 1.  */
+
+#define dwarf_read_debug_printf(fmt, ...) 				\
+  debug_prefixed_printf_cond (dwarf_read_debug >= 1, "dwarf-read", fmt,	\
+			      ##__VA_ARGS__)
+
+/* Print a "dwarf-read" debug statement if dwarf_read_debug is >= 2.  */
+
+#define dwarf_read_debug_printf_v(fmt, ...) \
+  debug_prefixed_printf_cond (dwarf_read_debug >= 2, "dwarf-read", fmt,	\
+			      ##__VA_ARGS__)
+
+/* Print "dwarf-read" start/end debug statements.  */
+
+#define DWARF_READ_SCOPED_DEBUG_START_END(fmt, ...)			      \
+  scoped_debug_start_end ([] { return dwarf_read_debug >= 1; }, "dwarf-read", \
+			  fmt, ##__VA_ARGS__)
+
 /* When non-zero, dump line number entries as they are read in.  */
 extern unsigned int dwarf_line_debug;
 

--- a/gdb/dwarf2/read.h
+++ b/gdb/dwarf2/read.h
@@ -277,6 +277,7 @@ public:
   /* If this dwarf2_per_cu is a signatured_type, return "this" cast to
      signatured_type.  Otherwise, return nullptr.  */
   signatured_type *as_signatured_type ();
+  const signatured_type *as_signatured_type () const;
 
   dwarf2_per_bfd *per_bfd () const
   { return m_per_bfd; }
@@ -492,6 +493,17 @@ dwarf2_per_cu::as_signatured_type ()
 {
   if (m_is_debug_types)
     return static_cast<signatured_type *> (this);
+
+  return nullptr;
+}
+
+/* See dwarf2_per_cu declaration.  */
+
+inline const signatured_type *
+dwarf2_per_cu::as_signatured_type () const
+{
+  if (m_is_debug_types)
+    return static_cast<const signatured_type *> (this);
 
   return nullptr;
 }

--- a/gdb/dwarf2/types.h
+++ b/gdb/dwarf2/types.h
@@ -31,6 +31,8 @@ DEFINE_OFFSET_TYPE (cu_offset, unsigned int);
    section.  */
 DEFINE_OFFSET_TYPE (sect_offset, uint64_t);
 
+constexpr auto invalid_sect_offset = static_cast<sect_offset> (-1);
+
 static inline const char *
 sect_offset_str (sect_offset offset)
 {

--- a/gdb/testsuite/boards/dwarf5-fission-debug-types-debug-names.exp
+++ b/gdb/testsuite/boards/dwarf5-fission-debug-types-debug-names.exp
@@ -1,0 +1,29 @@
+# Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# A board that compiles with DWARF 5, split DWARF (fission) and type units,
+# and generates a .debug_names index using GDB.
+#
+# Example usage:
+# bash$ make check \
+#   RUNTESTFLAGS='--target_board=dwarf5-fission-debug-types-debug-names'
+
+set CC_WITH_TWEAKS_FLAGS "-n"
+load_board_description "cc-with-tweaks"
+
+set_board_info debug_flags \
+    [join { "-gdwarf-5" \
+	    "-gsplit-dwarf" \
+	    "-fdebug-types-section" }]


### PR DESCRIPTION
Merge remote-tracking branch 'origin/master' into amd-staging

Handle conflicts introduced by:

- 80491726b42 gdb/doc: split 'AMD GPU' and 'AMD ROCm' acronyms

While importing this change, this merge commit applies the same
transformation to the rest of the downstream gdb/doc/gdb.texinfo file.
