### PR TITLE
gdb: add "catch hiperr" to break on HIP API errors

### DIFF
--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -10,6 +10,9 @@ Full documentation for ROCgdb is available at
 - Dumping core of AMD GPU programs with the "gcore" command is now
   significantly faster, particularly for kernels that use small
   amounts of VRAM.
+- New "catch hiperr" command that stops the inferior when a HIP API
+  call returns an error.  The convenience variable `$_hiperr` holds
+  the error code at the catchpoint.
 
 ## ROCgdb-16-3 for ROCm-7.13
 

--- a/gdb/Makefile.in
+++ b/gdb/Makefile.in
@@ -1053,6 +1053,7 @@ COMMON_SFILES = \
 	blockframe.c \
 	break-catch-exec.c \
 	break-catch-fork.c \
+	break-catch-hiperr.c \
 	break-catch-load.c \
 	break-catch-sig.c \
 	break-catch-syscall.c \

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -2080,6 +2080,17 @@ amd64_init_reg (gdbarch *gdbarch, int regnum, dwarf2_frame_state_reg *reg,
     }
 }
 
+/* The AMD64 Linux ABI version of fetch_hiperr_parameters.  */
+
+static std::optional<hiperr_parameters>
+amd64_linux_fetch_hiperr_parameters (frame_info_ptr frame)
+{
+  CORE_ADDR struct_addr
+    = value_as_address (value_of_register (AMD64_RDI_REGNUM, frame));
+
+  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+}
+
 static void
 amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
 			     int num_disp_step_buffers)
@@ -2142,6 +2153,10 @@ amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
   set_gdbarch_get_shadow_stack_pointer (gdbarch,
 					amd64_linux_get_shadow_stack_pointer);
   dwarf2_frame_set_init_reg (gdbarch, amd64_init_reg);
+
+  /* Extract hiperr parameters for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_parameters
+    (gdbarch, amd64_linux_fetch_hiperr_parameters);
 }
 
 static void

--- a/gdb/amd64-tdep.c
+++ b/gdb/amd64-tdep.c
@@ -41,6 +41,7 @@
 #include "i387-tdep.h"
 #include "gdbsupport/x86-xstate.h"
 #include <algorithm>
+#include <string>
 #include "target-descriptions.h"
 #include "arch/amd64.h"
 #include "producer.h"
@@ -1058,6 +1059,81 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
   return sp + 16;
 }
 
+
+/* Extract HIP error parameters from the STRUCT_ADDR which is
+   a struct address passed to "__hipOnError ()" as an argument.
+
+   Only when all the parameters are retrieved successfully, return
+   them as the result.  Otherwise [1], return an std::nullopt.
+
+   [1]
+   - The "version" was not expected
+   - Not all the fields were read successfully
+   - Not all the strings were read successfully
+*/
+
+std::optional<hiperr_parameters>
+amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
+{
+  /* The HIP error parameters are packed in a struct with the following format:
+
+     struct {
+	uint32_t version;
+	uint32_t err_no;
+	const char *err_name;
+	const char *err_str;
+     };
+
+    The "version" is bumped when more fields are added to the structure.
+    Newer versions must keep backward compatibility with the previous ones,
+    by only tacking new fields at the end of the structure, so that older
+    clients can still extract the parameters they know.
+  */
+
+  /* Cover the version (4), number (4) and two pointers (2*8).  */
+  constexpr size_t buf_size = 24;
+  gdb_byte buf[buf_size];
+  CORE_ADDR addr;
+  uint32_t version, err_no;
+  gdb::unique_xmalloc_ptr<char> str, err_name, err_str;
+  enum bfd_endian byte_order = gdbarch_byte_order (get_frame_arch (frame));
+
+  /* Read the whole struct in one go.  */
+  if (target_read_memory (struct_addr, buf, buf_size) != 0)
+    return std::nullopt;
+
+  /* Get the version.  */
+  version = extract_unsigned_integer (buf, 4, byte_order);
+  /* Use less-than because versioning is designed to be ABI backwards
+     compatible.  See note above.  */
+  if (version < 1)
+    {
+      warning (_("version '%s' for HIP error parameters is not supported."),
+	       pulongest (version));
+      return std::nullopt;
+    }
+
+  /* The error code.  */
+  err_no = extract_unsigned_integer (buf + 4, 4, byte_order);
+
+  /* The error name.  */
+  addr = extract_unsigned_integer (buf + 8, 8, byte_order);
+  str = target_read_string (addr, -1);
+  if (str == nullptr)
+    return std::nullopt;
+  err_name = std::move (str);
+
+  /* The error description.  */
+  addr = extract_unsigned_integer (buf + 16, 8, byte_order);
+  str = target_read_string (addr, -1);
+  if (str == nullptr)
+    return std::nullopt;
+  err_str = std::move (str);
+
+  return hiperr_parameters {err_no, std::move (err_name), std::move (err_str)};
+}
+
+
 /* Displaced instruction handling.  */
 
 /* A partially decoded instruction.

--- a/gdb/amd64-tdep.h
+++ b/gdb/amd64-tdep.h
@@ -138,6 +138,12 @@ extern void amd64_collect_fxsave (const struct regcache *regcache, int regnum,
 /* Similar to amd64_collect_fxsave, but use XSAVE extended state.  */
 extern void amd64_collect_xsave (const struct regcache *regcache,
 				 int regnum, void *xsave, int gcore);
+
+/* Helper routine to fetch error parameters of a HIP error from the
+   STRUCT_ADDR within the FRAME context.  */
+
+extern std::optional<hiperr_parameters> amd64_fetch_hiperr_parameters
+  (frame_info_ptr frame, CORE_ADDR struct_addr);
 
 /* Floating-point register set. */
 extern const struct regset amd64_fpregset;

--- a/gdb/amd64-windows-tdep.c
+++ b/gdb/amd64-windows-tdep.c
@@ -1271,6 +1271,17 @@ amd64_windows_skip_trampoline_code (const frame_info_ptr &frame, CORE_ADDR pc)
   return destination;
 }
 
+/* The AMD64 Windows ABI version of fetch_hiperr_parameters.  */
+
+static std::optional<hiperr_parameters>
+amd64_windows_fetch_hiperr_parameters (frame_info_ptr frame)
+{
+  CORE_ADDR struct_addr
+    = value_as_address (value_of_register (AMD64_RCX_REGNUM, frame));
+
+  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+}
+
 /* Common parts for gdbarch initialization for Windows and Cygwin on AMD64.  */
 
 static void
@@ -1312,6 +1323,10 @@ amd64_windows_init_abi_common (gdbarch_info info, struct gdbarch *gdbarch)
   set_gdbarch_core_xfer_shared_libraries
     (gdbarch, windows_core_xfer_shared_libraries);
   set_gdbarch_core_pid_to_str (gdbarch, windows_core_pid_to_str);
+
+  /* Extract hiperr parameters for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_parameters
+    (gdbarch, amd64_windows_fetch_hiperr_parameters);
 }
 
 /* gdbarch initialization for Windows on AMD64.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -1,0 +1,296 @@
+/* Everything about catching HIP API errors ("catch hiperr").
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc.  All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include "annotate.h"
+#include "arch-utils.h"
+#include "breakpoint.h"
+#include "cli/cli-decode.h"
+#include "extract-store-integer.h"
+#include "inferior.h"
+#include "gdbarch.h"
+#include "progspace.h"
+#include "language.h"
+#include "stack.h"
+#include "valprint.h"
+
+struct hiperr_catchpoint : public code_breakpoint
+{
+  hiperr_catchpoint (struct gdbarch *gdbarch, bool temp,
+		     const char *cond_string)
+    : code_breakpoint (gdbarch, bp_catchpoint, temp, cond_string)
+  {
+    /* Make sure "locspec" is initialized, irrespective of the
+       "__hipOnError ()" symbol being found.  This allows listing the
+       breakpoint as a pending one when the binary is not loaded yet.
+       Otherwise, "info breakpoints" is going to trigger an assert.  */
+    locspec = new_explicit_location_spec_function ("__hipOnError");
+    pspace = current_program_space;
+    re_set (nullptr);
+  }
+
+  bp_location *allocate_location () override;
+  void re_set (program_space *pspace) override;
+  bool print_one (const bp_location **last_loc) const override;
+  void print_mention () const override;
+  void print_recreate (struct ui_file *fp) const override;
+  enum print_stop_action print_it (const bpstat *bs) const override;
+};
+
+/* Implement the "allocate_location" method for hiperr catchpoint.  */
+
+bp_location *
+hiperr_catchpoint::allocate_location ()
+{
+  return new bp_location (this, bp_loc_software_breakpoint);
+}
+
+/* Implement the "re_set" method for hiperr catchpoint.  It is used
+   when a breakpoint must be re-evaluated, like at symbols change.  */
+
+void
+hiperr_catchpoint::re_set (program_space * /*ps*/)
+{
+  std::vector<symtab_and_line> sals;
+
+  try
+    {
+      sals = this->decode_location_spec (this->locspec.get (),
+					 current_program_space);
+    }
+  catch (const gdb_exception_error &ex)
+    {
+      /* NOT_FOUND_ERROR is the result of a pending breakpoint.
+	 Anything else, must be rethrown.  */
+      if (ex.error != NOT_FOUND_ERROR)
+	throw;
+    }
+  update_breakpoint_locations (this, current_program_space, sals, {});
+}
+
+/* Implement the "print_one" method for hiperr catchpoint.  It
+   displays information about the breakpoint ("info breakpoints").  */
+
+bool
+hiperr_catchpoint::print_one (const bp_location **last_loc) const
+{
+  struct value_print_options opts;
+  struct ui_out *uiout = current_uiout;
+
+  get_user_print_options (&opts);
+
+  if (opts.addressprint)
+    uiout->field_skip ("addr");
+  annotate_field (5);
+
+  uiout->field_string ("what", "catch hiperr");
+  if (uiout->is_mi_like_p ())
+    uiout->field_string ("catch-type", "hiperr");
+
+  return true;
+}
+
+/* Message printed when the breakpoint is set.  */
+
+void
+hiperr_catchpoint::print_mention () const
+{
+  struct ui_out *uiout = current_uiout;
+  const char *bp_type = "Catchpoint";
+
+  if (disposition == disp_del)
+    bp_type = "Temporary catchpoint";
+
+  uiout->message ("%s %d (HIP error)", _(bp_type), number);
+}
+
+/* Implement the "print_recreate" method for catch hiperr.
+   It's used for saving the breakpoints.  */
+
+void
+hiperr_catchpoint::print_recreate (struct ui_file *fp) const
+{
+  bool bp_temp = (disposition == disp_del);
+  gdb_printf (fp, bp_temp ? "tcatch hiperr" : "catch hiperr");
+  /* The condition, if any, is read from the object's "cond_string".  */
+  print_recreate_thread (fp);
+}
+
+/* Check if FRAME is the "__hipOnError ()" frame.  */
+
+static bool
+hiperr_frame_p (frame_info_ptr frame)
+{
+  enum language func_lang;
+
+  gdb::unique_xmalloc_ptr<char> func_name
+    = find_frame_funname (frame, &func_lang, nullptr);
+  if (func_name == nullptr || strcmp (func_name.get (), "__hipOnError") != 0)
+    return false;
+
+  return true;
+}
+
+/* Format the HIP error info as a string (with newline) for printing.
+   Returns an empty string if the parameters cannot be fetched.  */
+
+static std::string
+hiperr_info_string (struct gdbarch *gdbarch)
+{
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+    return std::string ();
+
+  std::optional<hiperr_parameters> err_params
+    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+
+  if (!err_params.has_value ())
+    return std::string ();
+
+  return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
+			err_params->err_name.get (),
+			err_params->err_no,
+			err_params->err_str.get ());
+}
+
+/* Message printed when the breakpoint is hit.  */
+
+enum print_stop_action
+hiperr_catchpoint::print_it (const bpstat *bs) const
+{
+  struct ui_out *uiout = current_uiout;
+  const char *bp_type = "Catchpoint ";
+
+  annotate_catchpoint (number);
+  maybe_print_thread_hit_breakpoint (uiout);
+
+  if (disposition == disp_del)
+    bp_type = "Temporary catchpoint ";
+  uiout->text (bp_type);
+
+  print_num_locno (bs, uiout);
+  uiout->text (" (HIP error)\n");
+
+  const std::string hiperr_info
+    = hiperr_info_string (bs->bp_location_at->gdbarch);
+  if (!hiperr_info.empty ())
+    {
+      uiout->text (hiperr_info.c_str ());
+      uiout->text
+	("\nThe $_hiperr convenience variable holds the error number.\n");
+    }
+  else
+    uiout->text ("\nwarning: failed to extract HIP error information.\n");
+
+  if (uiout->is_mi_like_p ())
+    {
+      uiout->field_string ("reason",
+			   async_reason_lookup (EXEC_ASYNC_BREAKPOINT_HIT));
+      uiout->field_string ("disp", bpdisp_text (disposition));
+    }
+
+  return PRINT_NOTHING;
+}
+
+/* Implementation of "catch hiperr" command.  */
+
+static void
+catch_hiperr_command (const char *arg,
+		      int /*from_tty*/,
+		      struct cmd_list_element *command)
+{
+  bool tempflag = command->context () == CATCH_TEMPORARY;
+  const char *cond_string = nullptr;
+
+  if (arg == nullptr)
+    arg = "";
+  arg = skip_spaces (arg);
+  cond_string = ep_parse_optional_if_clause (&arg);
+
+  if ((*arg != '\0') && !c_isspace (*arg))
+    error (_("Junk at the end of arguments."));
+
+  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
+						  tempflag, cond_string);
+
+  install_breakpoint (0, std::move (hcp), 1);
+}
+
+
+
+/* Implement the 'make_value' method for the $_hiperr internalvar.  */
+
+static struct value *
+compute_hiperr (struct gdbarch *gdbarch,
+		struct internalvar * /*var*/,
+		void * /*ignore*/)
+{
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+    return value::allocate (builtin_type (gdbarch)->builtin_void);
+
+  std::optional<hiperr_parameters> err_params
+    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+
+  if (!err_params.has_value ())
+    return value::allocate (builtin_type (gdbarch)->builtin_void);
+
+  /* If there's a "hipError_t" type in the debug symbols that is
+     a 4-byte enum, use it.  */
+  struct block_symbol bs
+    = lookup_symbol ("hipError_t", nullptr, SEARCH_TYPE_DOMAIN, nullptr);
+  if (bs.symbol != nullptr
+      && bs.symbol->type ()->length () == 4
+      && bs.symbol->type ()->code () == TYPE_CODE_ENUM)
+    {
+      gdb_byte err_no[4];
+      const bfd_endian byte_order = gdbarch_byte_order (gdbarch);
+      store_unsigned_integer (err_no, 4, byte_order, err_params->err_no);
+      return value_from_contents (bs.symbol->type (), err_no);
+    }
+
+  /* Return hiperr as an unsigned int.  */
+  return value_from_ulongest (builtin_type (gdbarch)->builtin_uint32,
+			      err_params->err_no);
+}
+
+/* Implementation of the '$_hiperr' variable.  */
+
+static const struct internalvar_funcs hiperr_funcs =
+{
+  compute_hiperr,
+  nullptr,
+};
+
+
+
+INIT_GDB_FILE (break_catch_hiperr)
+{
+  /* Add "(t)catch hiperr" sub-command.  */
+  add_catch_command ("hiperr",
+		     _("Catch a HIP error."),
+		     catch_hiperr_command,
+		     nullptr,
+		     CATCH_PERMANENT,
+		     CATCH_TEMPORARY);
+
+  create_internalvar_type_lazy ("_hiperr", &hiperr_funcs, nullptr);
+}

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -5947,6 +5947,16 @@ However, whether the signal is still delivered to the inferior depends
 on the @code{pass} setting; this can be changed in the catchpoint's
 commands.
 
+@anchor{catch hiperr}
+@item hiperr
+@kindex catch hiperr
+The failure of a HIP API.  This catchpoint catches any HIP API error
+that is returned by the HIP runtime.  You can combine it with an
+@var{if condition@dots{}} clause that uses the @samp{$_hiperr}
+convenience variable to stop on specific HIP errors.
+@xref{Conditions,,Break Conditions}, and
+@ref{HIP error convenience variable}.
+
 @end table
 
 @item tcatch @var{event}
@@ -13469,6 +13479,9 @@ The heterogeneous work-group position string of the current thread or
 heterogeneous lane respectively, or the empty string if not associated
 with a heterogeneous dispatch.  @xref{Heterogeneous Debugging}.
 
+@item $_hiperr
+The current HIP API error.  @xref{HIP error convenience variable}.
+
 @end table
 
 @node Convenience Funs
@@ -20209,6 +20222,48 @@ The size of the wavefront for the dispatch that the current kernel
 belongs to.
 
 @end table
+
+@node HIP Runtime Errors
+@subsubsection HIP Runtime Errors
+@cindex HIP runtime error
+If the HIP runtime library provides the necessary means, @value{GDBN}
+can stop the program when a HIP API error is returned.  To catch such
+errors, use the @samp{catch hiperr} command.  @xref{catch hiperr},
+for details.
+
+@smallexample
+(@value{GDBP}) catch hiperr
+Catchpoint 1 (HIP error)
+
+(@value{GDBP}) run
+...
+Thread 1 "prog" hit Catchpoint 1 (HIP error)
+HIP API call failed with error hipErrorInvalidDevice (101): invalid device ordinal
+
+The $_hiperr convenience variable holds the error number.
+(@value{GDBP}) p $_hiperr
+$1 = hipErrorInvalidDevice
+(@value{GDBP}) p/d $_hiperr
+$2 = 101
+@end smallexample
+
+@anchor{HIP error convenience variable}
+@cindex HIP runtime error convenience variable
+@vindex $_hiperr@r{, convenience variable}
+There's also a convenience variable named @samp{$_hiperr} that represents
+the error.  If the @samp{hipError_t} type is known to @value{GDBN}, then
+@samp{$_hiperr} is printed as that type, else it is printed as a number.
+One common use-case of this convenience variable is to set conditional
+catchpoints.
+
+@smallexample
+(@value{GDBP}) catch hiperr if $_hiperr == hipErrorInvalidDevice
+Catchpoint 1 (HIP error)
+(@value{GDBP}) info breakpoints
+Num     Type           Disp Enb Address    What
+1       catchpoint     keep y              catch hiperr
+        stop only if $_hiperr == hipErrorInvalidDevice
+@end smallexample
 
 @c TODO: Add any language specific differences.
 

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -179,6 +179,7 @@ struct gdbarch
   gdbarch_address_class_name_to_type_flags_ftype *address_class_name_to_type_flags = nullptr;
   gdbarch_register_reggroup_p_ftype *register_reggroup_p = default_register_reggroup_p;
   gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument = nullptr;
+  gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters = nullptr;
   gdbarch_iterate_over_regset_sections_ftype *iterate_over_regset_sections = nullptr;
   gdbarch_make_corefile_notes_ftype *make_corefile_notes = nullptr;
   gdbarch_find_memory_regions_ftype *find_memory_regions = nullptr;
@@ -455,6 +456,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of address_class_name_to_type_flags, has predicate.  */
   /* Skip verify of register_reggroup_p, invalid_p == 0.  */
   /* Skip verify of fetch_pointer_argument, invalid_p == 0.  */
+  /* Skip verify of fetch_hiperr_parameters, has predicate.  */
   /* Skip verify of iterate_over_regset_sections, has predicate.  */
   /* Skip verify of make_corefile_notes, has predicate.  */
   /* Skip verify of find_memory_regions, has predicate.  */
@@ -1053,6 +1055,12 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: fetch_pointer_argument = <%s>\n",
 	      host_address_to_string (gdbarch->fetch_pointer_argument));
+  gdb_printf (file,
+	      "gdbarch_dump: gdbarch_fetch_hiperr_parameters_p() = %d\n",
+	      gdbarch_fetch_hiperr_parameters_p (gdbarch));
+  gdb_printf (file,
+	      "gdbarch_dump: fetch_hiperr_parameters = <%s>\n",
+	      host_address_to_string (gdbarch->fetch_hiperr_parameters));
   gdb_printf (file,
 	      "gdbarch_dump: gdbarch_iterate_over_regset_sections_p() = %d\n",
 	      gdbarch_iterate_over_regset_sections_p (gdbarch));
@@ -3874,6 +3882,30 @@ set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch,
 				    gdbarch_fetch_pointer_argument_ftype fetch_pointer_argument)
 {
   gdbarch->fetch_pointer_argument = fetch_pointer_argument;
+}
+
+bool
+gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch)
+{
+  gdb_assert (gdbarch != nullptr);
+  return gdbarch->fetch_hiperr_parameters != nullptr;
+}
+
+std::optional<hiperr_parameters>
+gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame)
+{
+  gdb_assert (gdbarch != nullptr);
+  gdb_assert (gdbarch->fetch_hiperr_parameters != nullptr);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_parameters called\n");
+  return gdbarch->fetch_hiperr_parameters (frame);
+}
+
+void
+set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch,
+				     gdbarch_fetch_hiperr_parameters_ftype fetch_hiperr_parameters)
+{
+  gdbarch->fetch_hiperr_parameters = fetch_hiperr_parameters;
 }
 
 bool

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1019,6 +1019,16 @@ using gdbarch_fetch_pointer_argument_ftype = CORE_ADDR (const frame_info_ptr &fr
 CORE_ADDR gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, const frame_info_ptr &frame, int argi, struct type *type);
 void set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument);
 
+/* Fetch HIP error parameters from the FRAME's function arguments.
+   FRAME is the frame of a "__hipOnError ()" function.  On a successful
+   run, return the parameters.  Otherwise, return a std::nullopt. */
+
+bool gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch);
+
+using gdbarch_fetch_hiperr_parameters_ftype = std::optional<hiperr_parameters> (frame_info_ptr frame);
+std::optional<hiperr_parameters> gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame);
+void set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters);
+
 /* Iterate over all supported register notes in a core file.  For each
    supported register note section, the iterator must call CB and pass
    CB_DATA unchanged.  If REGCACHE is not NULL, the iterator can limit

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -144,6 +144,20 @@ enum call_dummy_location_type
   AT_ENTRY_POINT,
 };
 
+/* The data structure holding the HIP error parameters.  */
+
+struct hiperr_parameters
+{
+  /* The error number.  */
+  uint32_t err_no;
+
+  /* The string representing the error name.  */
+  gdb::unique_xmalloc_ptr<char> err_name;
+
+  /* The string describing the error name.  */
+  gdb::unique_xmalloc_ptr<char> err_str;
+};
+
 #include "gdbarch-gen.h"
 
 /* An internal function that should _only_ be called from gdbarch_tdep.

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -1740,6 +1740,20 @@ Fetch the pointer to the ith function argument.
     invalid=False,
 )
 
+Function(
+    comment="""
+Fetch HIP error parameters from the FRAME's function arguments.
+FRAME is the frame of a "__hipOnError ()" function.  On a successful
+run, return the parameters.  Otherwise, return a std::nullopt.
+""",
+    type="std::optional<hiperr_parameters>",
+    name="fetch_hiperr_parameters",
+    params=[
+        ("frame_info_ptr", "frame"),
+    ],
+    predicate=True,
+)
+
 Method(
     comment="""
 Iterate over all supported register notes in a core file.  For each

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -1,0 +1,151 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <iostream>
+#include <cassert>
+#include <hip/hip_runtime.h>
+#include "rocm-test-utils.h"
+
+/* If set, the "hip_* ()" functions will record the error parameters.  */
+static bool gen_ref = false;
+
+struct hiperr_params_ref
+{
+  int no;
+  const char *name;
+  const char *str;
+
+  void save (hipError_t err_no)
+  {
+    no = static_cast <int> (err_no);
+    name = hipGetErrorName (err_no);
+    str = hipGetErrorString (err_no);
+  }
+};
+
+/* Reference values for the test.  */
+static hiperr_params_ref hip_set_device_err;
+static hiperr_params_ref hip_get_device_err;
+static hiperr_params_ref hip_launch_kernel_err;
+
+/* Get the maximum number of threads per block.  */
+
+static size_t
+get_max_block ()
+{
+  static size_t max_block = 0;
+
+  if (max_block == 0)
+    {
+      int deviceId;
+      CHECK (hipGetDevice (&deviceId));
+      hipDeviceProp_t props;
+      CHECK (hipGetDeviceProperties (&props, deviceId));
+      max_block = props.maxThreadsPerBlock;
+    }
+
+  return max_block;
+}
+
+/* An empty kernel used for an oversized dispatch.  */
+
+__global__ void
+kernel ()
+{
+}
+
+/* The purpose of these "hip_* ()" functions is to produce some errors
+   and have the error parameters recorded.  GDB can use these recorded
+   values as references to verify the catchpoints outputs.  */
+
+/* Dispatch a kernel via the triple chevron syntax with an oversized
+   dimension, which in turn launches the kernel using HIP APIs.  */
+
+static void
+hip_launch_kernel ()
+{
+  size_t max_block = get_max_block ();
+  assert (max_block != 0);
+  kernel<<<1, max_block + 1>>> ();
+  hipError_t err = hipGetLastError ();
+  assert (hipErrorInvalidConfiguration == err);
+
+  if (gen_ref)
+    hip_launch_kernel_err.save (err);
+}
+
+/* Set a device with bad ID.  */
+
+static void
+hip_set_device ()
+{
+  constexpr int bogus = 87654321;
+  hipError_t err = hipSetDevice (bogus);
+  assert (hipErrorInvalidDevice == err);
+
+  if (gen_ref)
+    hip_set_device_err.save (err);
+}
+
+/* Get a device with nullptr.  */
+
+static void
+hip_get_device ()
+{
+  hipError_t err = hipGetDevice (nullptr);
+  assert (hipErrorInvalidValue == err);
+
+  if (gen_ref)
+    hip_get_device_err.save (err);
+}
+
+int
+main (int argc, const char **argv)
+{
+  if (argc != 2)
+    {
+      std::cerr << "Usage: " << argv[0] << " ref|one|two|launch" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  const std::string test (argv[1]);
+  if (test == "ref")
+    {
+      gen_ref = true;
+      hip_set_device ();
+      hip_get_device ();
+      hip_launch_kernel ();
+      /* Break after reference initialization.  */
+    }
+  else if (test == "one")
+    hip_set_device ();
+  else if (test == "two")
+    {
+      hip_set_device ();
+      hip_get_device ();
+    }
+  else if (test == "launch")
+    hip_launch_kernel ();
+  else
+    {
+      std::cerr << "Unsupported test " << test << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -1,0 +1,332 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test catching HIP's API errors:
+#
+# 1. The executable is loaded and started.
+# 2. The executable is loaded but not started.
+# 3. There's no executable set yet.
+# 4. Two API errors are returned and caught.
+# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
+# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
+# 7. Temporary catch of the first error, while there are 2 errors.
+# 8. $_hiperr is printed correctly when debug symbols are available.
+# 9. $_hiperr is printed correctly without debug symbols.
+#    This one checks if "catch hiperr" works without debug symbols as well.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare debug version of ${testfile}" \
+	${::testfile}.dbg ${::srcfile} {debug hip}]} {
+    return -1
+}
+
+if {[prepare_for_testing "failed to prepare non-debug version of ${testfile}" \
+	${::testfile}.nodbg ${::srcfile} {hip}]} {
+    return -1
+}
+
+# Reference error parameters for HIP API calls:
+#   hipSetDevice (...)
+#   hipGetDevice (...)
+#   hipLaunchKernel (...)
+#
+# See init_reference_hip_errors.
+
+set hip_set_device_err_no ""
+set hip_set_device_err_name ""
+set hip_set_device_err_str ""
+set hip_get_device_err_no ""
+set hip_get_device_err_name ""
+set hip_get_device_err_str ""
+set hip_launch_kernel_err_no ""
+set hip_launch_kernel_err_name ""
+set hip_launch_kernel_err_str ""
+
+# Retrieve the value of EXP in the inferior, as a string value
+# (using "print /s").  DEFAULT is used as fallback if print fails.
+
+proc get_string_valueof {exp default} {
+    set val ${default}
+    gdb_test_multiple "print /s ${exp}" "get string value of \"${exp}\"" {
+	-re -wrap "^${::valnum_re} = $::hex \"(\[^\"\]*)\"" {
+	    set val $expect_out(1,string)
+	    pass $gdb_test_name
+	}
+    }
+    return ${val}
+}
+
+# Get the reference values from the program (which is run with "ref" argument)
+
+proc init_reference_hip_errors {} {
+    foreach func {set_device get_device launch_kernel} {
+	set ::hip_${func}_err_no [get_integer_valueof "hip_${func}_err.no" bad]
+	gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
+	    "hip_${func}_err_no initialized"
+
+	set ::hip_${func}_err_name [get_string_valueof "hip_${func}_err.name" bad]
+	gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
+	    "hip_${func}_err_name initialized"
+
+	set ::hip_${func}_err_str [get_string_valueof "hip_${func}_err.str" bad]
+	gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
+	    "hip_${func}_err_str initialized"
+    }
+}
+
+# Set a hiperr catchpoint and check if it set accordingly.  If TEMP is
+# true, then a temporary version (tcatch) is used.  Differences between the
+# permanent and temporary are:
+#
+# catch hiperr                 vs. tcatch hiperr
+# Catchpoint <number> ...      vs. Temporary catchpoint <number> ...
+# info breakpoints
+# <number> catchpoint keep ... vs. <number> catchpoint del ...
+
+proc catch_hiperr {{temp false}} {
+    if {!$temp} {
+	set cmd "catch hiperr"
+	set type "Catchpoint"
+	set catch_test_name "set catchpoint"
+	set disp "keep"
+    } else {
+	set cmd "tcatch hiperr"
+	set type "Temporary catchpoint"
+	set catch_test_name "set temporary catchpoint"
+	set disp "del"
+    }
+
+    gdb_test "$cmd" "$type $::decimal \\(HIP error\\)" "$catch_test_name"
+
+    gdb_test "info break" \
+	"$::decimal\[ \t\]+catchpoint\[ \t\]+$disp\[ \t\]+y\[ \t\]+catch hiperr" \
+	"check breakpoints"
+}
+
+# Set a conditional "catch hiperr" that checks the error number is NUMBER.
+
+proc catch_hiperr_cond {number} {
+    gdb_test "catch hiperr if \$_hiperr == $number" \
+	"Catchpoint $::decimal \\(HIP error\\)" \
+	"set conditional catchpoint"
+}
+
+# Execute CMD (e.g. "run" or "cont") and look for two lines
+# in the output:
+#
+# Thread 1 "hip" hit Catchpoint 1 (HIP error)
+# (...) hipErrorInvalidDevice (101): invalid device ordinal
+#       ^^^^^^^^^^^^^^^^^^^^^  ^^^   ^^^^^^^^^^^^^^^^^^^^^^
+#               NAME          NUMBER STR
+#
+# As the last step, also check that $_hiperr is equal to NUMBER.
+# If TEMP is true, the catchpoint is temporary.
+
+proc check_hiperr_is_caught {cmd number name str {temp false}} {
+    if {!$temp} {
+	set type "Catchpoint"
+    } else {
+	set type "Temporary catchpoint"
+    }
+    set hit_line "Thread $::decimal .* hit $type $::decimal \\(HIP error\\)"
+    set err_line "HIP API call failed with error $name \\($number\\): $str\r\n.*"
+
+    gdb_test "$cmd" "${hit_line}\r\n${err_line}" "caught $name"
+    gdb_test "p/d \$_hiperr" "= $number" "\$_hiperr must be $number"
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for hipSetDevice (...).  TEMP, if true, indicates
+# the catchpoint must be a temporary one.
+
+proc check_hip_set_device_err {cmd {temp false}} {
+    check_hiperr_is_caught $cmd \
+	$::hip_set_device_err_no \
+	$::hip_set_device_err_name \
+	$::hip_set_device_err_str \
+	$temp
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for hipGetDevice (...).
+
+proc check_hip_get_device_err {cmd} {
+    check_hiperr_is_caught $cmd \
+	$::hip_get_device_err_no \
+	$::hip_get_device_err_name \
+	$::hip_get_device_err_str
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for kernel<<<...>>> ().
+
+proc check_hip_launch_kernel_err {cmd} {
+    check_hiperr_is_caught $cmd \
+	$::hip_launch_kernel_err_no \
+	$::hip_launch_kernel_err_name \
+	$::hip_launch_kernel_err_str
+}
+
+proc do_test {} {
+    with_rocm_gpu_lock {
+
+	clean_restart ${::testfile}.dbg
+	if {![runto_main]} {
+	    return
+	}
+	gdb_test_multiple "info symbol __hipOnError" \
+	    "check if __hipOnError symbol exists" {
+	    -re -wrap "^__hipOnError in section .text of .*" {
+		pass $gdb_test_name
+	    }
+	    -re -wrap ".*" {
+		unsupported "no __hipOnError symbol was found"
+		return
+	    }
+	}
+
+	# Let all the errors occur and their values be recorded by the program.
+	with_test_prefix "getting reference values" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args ref"
+	    if {![runto [gdb_get_line_number \
+			    "Break after reference initialization"]]} {
+		return
+	    }
+	    init_reference_hip_errors
+	}
+
+	with_test_prefix "after starting" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    runto_main
+	    catch_hiperr
+	    check_hip_set_device_err "cont"
+	}
+
+	with_test_prefix "after loading" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    catch_hiperr
+	    check_hip_set_device_err "run"
+	}
+
+	with_test_prefix "before loading" {
+	    clean_restart
+	    catch_hiperr
+	    gdb_load ${::binfile}.dbg
+	    gdb_test_no_output "set args one"
+	    check_hip_set_device_err "run"
+	}
+
+	with_test_prefix "two catchpoints" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr
+	    check_hip_set_device_err "run"
+	    check_hip_get_device_err "cont"
+	}
+
+	with_test_prefix "stub kernel launch" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args launch"
+	    catch_hiperr
+	    check_hip_launch_kernel_err "run"
+	    gdb_test "backtrace" \
+		".*__hipOnError.*hipLaunchKernel.*__device_stub__kernel.*" \
+		"call stack"
+	}
+
+	with_test_prefix "conditional catchpoint" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr_cond $::hip_get_device_err_no
+	    check_hip_get_device_err "run"
+	}
+
+	with_test_prefix "temporary catchpoint" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr true
+	    check_hip_set_device_err "run" true
+	    gdb_test "continue" \
+		"Inferior $::decimal .* exited normally.*" \
+		"no more catches"
+	}
+
+	# With the debug symbols (with "hipError_t" type), $_hiperr
+	# must be printed as an enum like hipErrorSomething.
+	with_test_prefix "prints of \$_hiperr with debug symbols" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    runto_main
+	    # Without any error, "$_hiperr" must be "void".
+	    gdb_test "p \$_hiperr" " = void" "not in scope"
+
+	    # Check "hipError_t" type is known.
+	    set type_found false
+	    gdb_test_multiple "info types hipError_t" \
+		"check if hipError_t type exists" {
+		-re ".*File \[^\r\n\]+:\r\n" {
+		    set type_found true
+		    exp_continue
+		}
+		-re "$::gdb_prompt $" {
+		    gdb_assert {$type_found} $gdb_test_name
+		}
+	    }
+
+	    catch_hiperr
+	    gdb_test "cont" ".*call failed.*$::hip_set_device_err_name.*" \
+		"caught $::hip_set_device_err_name"
+	    gdb_test "p \$_hiperr" " = $::hip_set_device_err_name" \
+		"print as $::hip_set_device_err_name"
+	}
+
+	# Without the debug symbols (no "hipError_t" type),
+	# $_hiperr must be printed as a number.
+	with_test_prefix "print \$_hiperr without debug symbols" {
+	    clean_restart ${::testfile}.nodbg
+	    gdb_test_no_output "set args launch"
+	    runto_main
+
+	    # Check "hipError_t" type is not detected.
+	    set type_found true
+	    gdb_test_multiple "info types hipError_t" \
+		"check hipError_t type existence" {
+		-re -wrap "\r\nAll types matching regular expression \"hipError_t\":" {
+		    set type_found false
+		    pass $gdb_test_name
+		}
+	    }
+	    gdb_assert {!$type_found} "there must be no hipError_t"
+
+	    catch_hiperr
+	    check_hip_launch_kernel_err "cont"
+	    gdb_test "p \$_hiperr" " = $::hip_launch_kernel_err_no" \
+		"print as $::hip_launch_kernel_err_no"
+	}
+    }
+}
+
+do_test


### PR DESCRIPTION
This change relies on "Add __hipOnError debugger hook for HIP API failures" [PR](https://github.com/ROCm/rocm-systems/pull/4755) to be functional. Although, without it, ROCgdb won't be broken. Please read the commit message for the description of this change itself.

--

What
----
This change adds a new feature to GDB, when it is targeted for
amdgcn-amd-amdhsa, that enables it to stop whenever HIP API
errors are returned.  An abridged sample of execution looks
like this:

(gdb) catch hiperr
(gdb) run
Thread 1 "hip" hit Catchpoint 1 (HIP error)
hipErrorInvalidDevice (101): invalid device ordinal

Moreover, a $_hiperr convenience variable is added that holds
the error code.  For further details, please see the updated
documentation in this change.

Design
------
Most of the implementation is in the newly added module called
break-catch-hiperr.c.  The naming and its context follows the
break-catch-throw.c module.

The whole mechanism work by setting a breakpoint (catchpoint)
on a __hipOnError() symbol, that must be provided by the CLR
library.  Enabling the catchpoint when there's no __hipOnError
symbol, simply has no effect.

There's a architect dependent section that is responsible for
extracting the error parameters (code, name, description) from
a single argument passed to the __hipOnError() function as a
structure pointer.  The expected format of this struct is:

  uint32_t    version;   // at this point, only 1 is supported
  uint32_t    code;      // the numerical error code
  const char *name;      // name of the error
  const char *desc;      // a phrase about the error

The code is devised in such a way that if the __hipOnError()
exists, but for whatever reason the parameters cannot be deduced,
it won't interfere with the catchpoint being triggered.  It will
affect the reported data of the catchpoint though.

Test
----
A new test, gdb.rocm/hip-catch-errors, is added to the mix to
ensure that:

1. (Pending) catchpoints work.
2. Multiple catchpoints in one execution are reported accordingly.
3. Errors of indirect HIP calls like "kenel<<<...>>>()" are caught.
4. The convenience variable can be used for conditional situations.
5. Conditional and temporary catchpoints work as expected.

ROCM-1548