### PR TITLE
gdb/testsuite/gdb.rocm: add OpenMP GPU offload tests

### DIFF
--- a/gdb/testsuite/gdb.rocm/omp-target-basic.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-basic.c
@@ -1,0 +1,57 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* Basic OpenMP "target" offload program shared by the breakpoint,
+   data-sharing (locals) and single-stepping checks in
+   omp-target-basic.exp.  It offloads a single '#pragma omp target'
+   region with a mapped input array (to:), a mapped output array
+   (tofrom:) and a firstprivate scalar, plus a few distinguishable
+   statements at the top of the region for single-stepping.  */
+
+#include <stdio.h>
+
+#define N 8
+
+int
+main (void)
+{
+  int in_arr[N];
+  int out_arr[N];
+
+  for (int i = 0; i < N; i++)
+    {
+      in_arr[i] = 100 + i;
+      out_arr[i] = 0;
+    }
+
+  int firstpriv_val = 42;
+
+  #pragma omp target						\
+	      map(to:in_arr[0:N]) map(tofrom:out_arr[0:N])	\
+	      firstprivate(firstpriv_val)
+  {
+    int priv_val = 7;			/* first-target-line */
+    int step_two = priv_val + 1;
+    int step_three = step_two + 1;
+    out_arr[0] = (in_arr[0] + priv_val + firstpriv_val
+		  + step_two + step_three);
+  }
+
+  printf ("out[0]=%d\n", out_arr[0]);
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-basic.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-basic.exp
@@ -1,0 +1,82 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Basic OpenMP-offload device-debugging checks, all sharing a single
+# '#pragma omp target' binary:
+#
+#   - "breakpoint": set a breakpoint inside the target region by
+#     file:line, hit it on the device, and observe an AMDGPU wave.
+#   - "locals": inspect variables in different data-sharing classes
+#     (map(to:), map(tofrom:), firstprivate).
+#   - "step": single-step through statements in the region, staying on
+#     the device.
+
+load_lib rocm.exp
+
+require allow_omp_offload_tests
+
+standard_testfile
+
+set first_line [gdb_get_line_number "first-target-line"]
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug omp-rocm}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    gdb_breakpoint "$srcfile:$first_line" -allow-pending
+
+    with_test_prefix "breakpoint" {
+	gdb_continue_to_breakpoint "device breakpoint"
+	gdb_assert {[llength [info_thread_get_wave_list]] >= 1} \
+	    "AMDGPU wave at OMP-target stop"
+    }
+
+    # Still stopped at the first statement in the region (out_arr is
+    # not written yet), so the data-sharing values are deterministic.
+    with_test_prefix "locals" {
+	gdb_test "print firstpriv_val" "= 42" "firstprivate value"
+	gdb_test "print in_arr\[0\]" "= 100" "mapped-to in_arr\[0\]"
+	gdb_test "print in_arr\[7\]" "= 107" "mapped-to in_arr\[7\]"
+	gdb_test "print out_arr\[0\]" "= 0" \
+	    "mapped-tofrom out_arr\[0\] before fill"
+    }
+
+    # Step forward through a few statements; each step must stay on a
+    # GPU wave.  Line numbers are not pinned because OpenMP-offload
+    # line tables vary across compiler versions.
+    foreach which {1 2 3} {
+	with_test_prefix "next-$which" {
+	    # Require landing on a numbered source line (so a step that
+	    # errors out is not silently accepted); the exact line is
+	    # not pinned because OpenMP-offload line tables vary.
+	    gdb_test "next" "$::decimal\t\[^\r\n\]*" "next inside target region"
+	    gdb_assert {[llength [info_thread_get_wave_list]] >= 1} \
+		"still on AMDGPU wave"
+	}
+    }
+
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-cpp.cpp
+++ b/gdb/testsuite/gdb.rocm/omp-target-cpp.cpp
@@ -1,0 +1,95 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* C++-specific OpenMP-offload features.  Exercises a templated device
+   function and a callable functor used inside a '#pragma omp target'
+   region.  */
+
+#include <cstdio>
+
+#define N 16
+
+#pragma omp declare target
+template <typename T>
+static T
+add_t (T a, T b)
+{
+  return a + b;		/* tmpl-line */
+}
+
+/* A named caller of add_t, so the backtrace at the add_t breakpoint
+   shows a stable intermediate frame (sum_pair -> add_t) rather than
+   only the compiler-generated kernel frame.  */
+template <typename T>
+static T __attribute__ ((noinline))
+sum_pair (T a, T b)
+{
+  return add_t<T> (a, b);
+}
+
+struct multiplier
+{
+  int factor;
+
+  int
+  operator() (int x) const
+  {
+    return x * factor;	/* functor-line */
+  }
+};
+
+/* Likewise a named caller of the functor.  */
+static int __attribute__ ((noinline))
+scale (const multiplier &m, int x)
+{
+  return m (x);
+}
+#pragma omp end declare target
+
+int
+main ()
+{
+  int a[N];
+  int b[N];
+  int sum[N];
+  int prod[N];
+
+  for (int i = 0; i < N; i++)
+    {
+      a[i] = i;
+      b[i] = 2 * i;
+      sum[i] = 0;
+      prod[i] = 0;
+    }
+
+  multiplier m { 3 };
+
+  #pragma omp target						\
+	      map(to:a[0:N], b[0:N], m)				\
+	      map(tofrom:sum[0:N], prod[0:N])
+  {
+    for (int i = 0; i < N; i++)
+      {
+	sum[i] = sum_pair<int> (a[i], b[i]);
+	prod[i] = scale (m, a[i]);
+      }
+  }
+
+  std::printf ("sum[1]=%d prod[1]=%d\n", sum[1], prod[1]);
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-cpp.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-cpp.exp
@@ -1,0 +1,72 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# C++-specific OpenMP-offload tests.  Verify that GDB can break
+# inside a templated device function and a struct member function
+# used in a target region.
+
+load_lib rocm.exp
+
+require allow_omp_offload_tests
+
+standard_testfile .cpp
+
+set tmpl_line    [gdb_get_line_number "tmpl-line"]
+set functor_line [gdb_get_line_number "functor-line"]
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug c++ omp-rocm}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    with_test_prefix "templated add_t" {
+	gdb_breakpoint "$srcfile:$tmpl_line" -allow-pending
+	gdb_continue_to_breakpoint "add_t<int>"
+	# The kernel reaches add_t through sum_pair, so the device call
+	# stack shows both frames.
+	gdb_test "backtrace 2" \
+	    "#0 .*add_t<int> .*\r\n#1 .*sum_pair<int> .*" \
+	    "add_t called from sum_pair"
+	delete_breakpoints
+    }
+
+    with_test_prefix "multiplier::operator()" {
+	gdb_breakpoint "$srcfile:$functor_line" -allow-pending
+	gdb_continue_to_breakpoint "multiplier::operator()"
+	# Likewise, the functor is reached through scale.
+	gdb_test "backtrace 2" \
+	    "#0 .*multiplier::operator\\(\\) .*\r\n#1 .*scale .*" \
+	    "functor called from scale"
+
+	# 'this->factor' should be the value we set on the host (3),
+	# transferred via the implicit 'map(to:m)'.
+	gdb_test "print this->factor" \
+	    "= 3" \
+	    "factor visible via 'this'"
+	delete_breakpoints
+    }
+
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-data.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-data.c
@@ -1,0 +1,66 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* '#pragma omp target data' wraps two consecutive '#pragma omp target'
+   regions, sharing the device data buffer.  This is the natural way
+   OpenMP applications stage data to the GPU and exercise multiple
+   kernel launches against it.  */
+
+#include <stdio.h>
+
+#define N 32
+
+static void
+fill (int *p, int v)
+{
+  for (int i = 0; i < N; i++)
+    p[i] = v + i;
+}
+
+int
+main (void)
+{
+  int a[N];
+  int b[N];
+  int c[N];
+
+  fill (a, 0);
+  fill (b, 100);
+  for (int i = 0; i < N; i++)
+    c[i] = 0;
+
+  #pragma omp target data map(to:a[0:N], b[0:N]) map(tofrom:c[0:N])
+  {
+    /* First kernel: c = a + b.  */
+    #pragma omp target
+    {
+      for (int i = 0; i < N; i++)
+	c[i] = a[i] + b[i];	/* data-k1 */
+    }
+
+    /* Second kernel: c *= 2 (data buffer reused, no host transfer).  */
+    #pragma omp target
+    {
+      for (int i = 0; i < N; i++)
+	c[i] = c[i] * 2;	/* data-k2 */
+    }
+  }
+
+  printf ("c[0]=%d c[%d]=%d\n", c[0], N - 1, c[N - 1]);
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-data.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-data.exp
@@ -1,0 +1,64 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# 'target data' region with two nested 'target' regions that reuse
+# the same device buffer.  Verify GDB can break inside both kernels
+# in sequence.
+
+load_lib rocm.exp
+
+require allow_omp_offload_tests
+
+standard_testfile
+
+set k1_line [gdb_get_line_number "data-k1"]
+set k2_line [gdb_get_line_number "data-k2"]
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug omp-rocm}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    gdb_breakpoint "$srcfile:$k1_line" -temporary -allow-pending
+
+    with_test_prefix "first kernel" {
+	gdb_continue_to_breakpoint "first kernel"
+	gdb_test "print a\[0\]" "= 0"   "a\[0\] in first kernel"
+	gdb_test "print b\[0\]" "= 100" "b\[0\] in first kernel"
+    }
+
+    gdb_breakpoint "$srcfile:$k2_line" -temporary -allow-pending
+
+    with_test_prefix "second kernel" {
+	gdb_continue_to_breakpoint "second kernel"
+	# After the first kernel ran to completion (its temporary
+	# breakpoint already auto-deleted), c[0] = a[0] + b[0]
+	# = 0 + 100 = 100.  The 'target data' region preserves this on
+	# the device, so we observe it.
+	gdb_test "print c\[0\]" "= 100" "c\[0\] in second kernel"
+    }
+
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-fortran.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-fortran.exp
@@ -1,0 +1,70 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Fortran OpenMP-offload test: stop in the offloaded loop and read the
+# loop index, then stop inside a '!$omp declare target' function and
+# check the device-side call stack.
+
+load_lib rocm.exp
+
+require allow_omp_offload_fortran_tests
+
+standard_testfile .f90
+
+set add_line [gdb_get_line_number "fadd-line"]
+
+# Build with -O0 so device locals (e.g. the loop index) stay visible:
+# amdflang optimizes the offloaded code by default, dropping their
+# debug info.  This is amdflang-specific (amdclang already defaults to
+# -O0) and is tracked upstream as ROCM-19898, so keep the workaround
+# local to this test rather than in the shared compile flags.
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug f90 omp-rocm additional_flags=-O0}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    # Stop inside the '!$omp declare target' function and confirm the
+    # innermost frame is the device function.
+    gdb_breakpoint "$srcfile:$add_line" -temporary -allow-pending
+    gdb_continue_to_breakpoint "add_vals"
+    gdb_test "backtrace 1" "#0 .*add_vals .*" "stopped in add_vals"
+
+    # a(i) == i and b(i) == 2 * i, so the arguments satisfy y == 2 * x.
+    # Use distinct failure defaults so the relationship can't trivially
+    # hold if a read fails.
+    set x [get_integer_valueof "x" -1 "device function arg x"]
+    set y [get_integer_valueof "y" -2 "device function arg y"]
+    gdb_assert {$x >= 1 && $y == 2 * $x} "b(i) == 2 * a(i)"
+
+    # Read the device-local loop index in the kernel (caller) frame.
+    # 'i' is only visible because amdflang is built with -O0 (see
+    # ROCM-19898 for the default-optimization debug-info limitation).
+    gdb_test "frame 1" "__omp_offloading\[^\r\n\]*\r\n$::decimal\[^\r\n\]*" \
+	"select kernel frame"
+    set i [get_integer_valueof "i" 0 "loop index"]
+    gdb_assert {$i >= 1 && $i <= 32} "loop index is in range"
+
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-fortran.f90
+++ b/gdb/testsuite/gdb.rocm/omp-target-fortran.f90
@@ -1,0 +1,53 @@
+! Copyright 2026 Free Software Foundation, Inc.
+! Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+!
+! This file is part of GDB.
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+! Small Fortran program offloading a loop to the GPU via '!$omp
+! target'.  The loop calls a '!$omp declare target' function so the
+! test can also check the device-side call stack.
+
+module devmod
+  implicit none
+contains
+  function add_vals (x, y) result (r)
+    !$omp declare target
+    integer, intent(in) :: x, y
+    integer :: r
+    r = x + y                       ! fadd-line
+  end function add_vals
+end module devmod
+
+program omp_target_fortran
+  use devmod
+  implicit none
+  integer, parameter :: n = 32
+  integer :: a(n), b(n), c(n), i
+
+  do i = 1, n
+     a(i) = i
+     b(i) = 2 * i
+     c(i) = 0
+  end do
+
+  !$omp target map(to:a, b) map(tofrom:c)
+  do i = 1, n
+     c(i) = add_vals (a(i), b(i))
+  end do
+  !$omp end target
+
+  print *, 'c1=', c(1)
+end program omp_target_fortran

--- a/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.c
@@ -1,0 +1,70 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* A single binary that contains two distinct '#pragma omp declare
+   target' device functions and launches them from two separate
+   '#pragma omp target' regions.  Used to verify that GDB can place
+   breakpoints in named device functions and distinguish between
+   them.  */
+
+#include <stdio.h>
+
+#define N 32
+
+#pragma omp declare target
+static int
+square_dev (int x)
+{
+  return x * x;
+}
+
+static int
+cube_dev (int x)
+{
+  return x * x * x;
+}
+#pragma omp end declare target
+
+int
+main (void)
+{
+  int in[N];
+  int out_sq[N];
+  int out_cb[N];
+
+  for (int i = 0; i < N; i++)
+    {
+      in[i] = i + 1;
+      out_sq[i] = 0;
+      out_cb[i] = 0;
+    }
+
+  #pragma omp target map(to:in[0:N]) map(tofrom:out_sq[0:N])
+  for (int i = 0; i < N; i++)
+    out_sq[i] = square_dev (in[i]);
+
+  #pragma omp target map(to:in[0:N]) map(tofrom:out_cb[0:N])
+  for (int i = 0; i < N; i++)
+    out_cb[i] = cube_dev (in[i]);
+
+  printf ("sq[0]=%d cb[0]=%d sq[%d]=%d cb[%d]=%d\n",
+	  out_sq[0], out_cb[0],
+	  N - 1, out_sq[N - 1],
+	  N - 1, out_cb[N - 1]);
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-multi-kernel.exp
@@ -1,0 +1,59 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Two '#pragma omp declare target' device functions (square_dev and
+# cube_dev) launched from two separate target regions in a single
+# binary.  Verify breakpoints set on each named device function are
+# hit by their corresponding kernel only.
+
+load_lib rocm.exp
+
+require allow_omp_offload_tests
+
+standard_testfile
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug omp-rocm}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    # This is a serial 'omp target' loop, so the first iteration
+    # (i == 0) handles in[0] == 1; the device argument x is therefore 1
+    # in both kernels.  Reading it confirms we stopped in the right
+    # device function with a live argument (which also implies a wave).
+    with_test_prefix "square kernel" {
+	gdb_breakpoint "square_dev" -temporary -allow-pending
+	gdb_continue_to_breakpoint "square_dev"
+	gdb_test "print x" "= 1"
+    }
+
+    with_test_prefix "cube kernel" {
+	gdb_breakpoint "cube_dev" -temporary -allow-pending
+	gdb_continue_to_breakpoint "cube_dev"
+	gdb_test "print x" "= 1"
+    }
+
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-teams.c
+++ b/gdb/testsuite/gdb.rocm/omp-target-teams.c
@@ -1,0 +1,54 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* Use 'target teams distribute parallel for' so that GDB sees
+   multiple GPU waves at the same breakpoint.  */
+
+#include <stdio.h>
+
+#define N 256
+
+int
+main (void)
+{
+  int a[N];
+  int b[N];
+  int c[N];
+
+  for (int i = 0; i < N; i++)
+    {
+      a[i] = i;
+      b[i] = N - i;
+      c[i] = 0;
+    }
+
+  #pragma omp target teams distribute parallel for	\
+	      map(to:a[0:N], b[0:N]) map(tofrom:c[0:N])
+  for (int i = 0; i < N; i++)
+    c[i] = a[i] + b[i];		/* teams-line */
+
+  int correct = 1;
+  for (int i = 0; i < N; i++)
+    {
+      if (c[i] != N)
+	correct = 0;
+    }
+
+  printf ("correct=%d\n", correct);
+  return correct ? 0 : 1;
+}

--- a/gdb/testsuite/gdb.rocm/omp-target-teams.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-teams.exp
@@ -1,0 +1,65 @@
+# Copyright 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file is part of GDB.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# 'target teams distribute parallel for' spreads the loop across GPU
+# lanes, with consecutive iterations on consecutive lanes.  Verify this
+# by reading the loop index on two different lanes (the difference must
+# match the lane distance) and checking a per-lane computed value.
+
+load_lib rocm.exp
+
+require allow_omp_offload_tests
+
+standard_testfile
+
+set break_line [gdb_get_line_number "teams-line"]
+
+if {[prepare_for_testing "failed to prepare" $testfile $srcfile \
+	 {debug omp-rocm}] == -1} {
+    return -1
+}
+
+with_rocm_gpu_lock {
+    if {![runto_main]} {
+	return
+    }
+
+    gdb_breakpoint "$srcfile:$break_line" -allow-pending
+
+    gdb_continue_to_breakpoint "teams breakpoint"
+
+    # 'distribute parallel for' runs consecutive iterations on
+    # consecutive lanes, so lane L sees loop index i = i0 + L.  Switch
+    # to lane 0 explicitly (rather than relying on which lane the stop
+    # selected), read i, then read it on lane 7, and check the two
+    # lanes are 7 iterations apart.
+    gdb_test "lane 0" "Switching to .*lane 0 .*" "switch to lane 0"
+    set i0 [get_integer_valueof "i" -1 "loop index on lane 0"]
+    gdb_test "lane 7" "Switching to .*lane 7 .*" "switch to lane 7"
+    set i7 [get_integer_valueof "i" -1 "loop index on lane 7"]
+    gdb_assert {$i7 - $i0 == 7} "lane 7 runs 7 iterations past lane 0"
+
+    # a[i] == i and b[i] == N - i, so a[i] + b[i] == N (256) on any
+    # lane (evaluated here on lane 7).
+    gdb_test "print a\[i\] + b\[i\]" "= 256" "a\[i\] + b\[i\] == N"
+
+    delete_breakpoints
+    # The OpenMP runtime's host threads emit "[Thread ... exited]"
+    # lines before the program exits, so allow extra output.
+    gdb_continue_to_end "" "continue" 1
+}

--- a/gdb/testsuite/lib/future.exp
+++ b/gdb/testsuite/lib/future.exp
@@ -137,6 +137,26 @@ proc gdb_find_hip_compiler {} {
     return $compiler
 }
 
+# Find the AMD OpenMP-offload compiler driver TOOL (amdclang for C,
+# amdflang for Fortran).  Mirrors gdb_find_hip_compiler: look under the
+# tool root, then under $ROCM_PATH/lib/llvm/bin, then fall back on the
+# bare name (relying on PATH).  C++ reuses gdb_find_hip_compiler, which
+# already returns amdclang++.
+proc gdb_find_amd_omp_compiler {tool} {
+    global tool_root_dir
+    if {[is_remote host]} {
+	return ""
+    }
+    set compiler [lookfor_file $tool_root_dir $tool]
+    if {$compiler eq "" && [info exists ::env(ROCM_PATH)]} {
+	set compiler [lookfor_file $::env(ROCM_PATH)/lib/llvm/bin $tool]
+    }
+    if {$compiler eq ""} {
+	set compiler $tool
+    }
+    return $compiler
+}
+
 proc gdb_find_ldd {} {
     global LDD_FOR_TARGET
     if {[info exists LDD_FOR_TARGET]} {
@@ -234,6 +254,7 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     set libs ""
     set compiler_type "c"
     set compiler ""
+    set is_omp_rocm 0
     set linker ""
     # linker_opts_order is one of "sources-then-flags", "flags-then-sources".
     # The order matters for things like -Wl,--as-needed.  The default is to
@@ -345,6 +366,15 @@ proc gdb_default_target_compile_1 {source destfile type options} {
 	    } else {
 		set compiler [find_hip_compiler]
 	    }
+	}
+
+	if { $i == "omp-rocm" } {
+	    # OpenMP offload to AMD GPUs.  The actual compiler driver
+	    # depends on the source language and is selected after this
+	    # loop (see below), once the language options have been
+	    # processed.  The offload compile/link flags are added by
+	    # gdb_compile.
+	    set is_omp_rocm 1
 	}
 
 	if {[regexp "^dest=" $i]} {
@@ -459,6 +489,18 @@ proc gdb_default_target_compile_1 {source destfile type options} {
     if {[info exists HIP_COMPILER_FOR_TARGET]} {
 	if {$compiler_type == "hip"} {
 	    set compiler $HIP_COMPILER_FOR_TARGET
+	}
+    }
+
+    # OpenMP offload to AMD GPUs.  The compiler driver depends on the
+    # source language: amdclang for C, amdclang++ for C++ and amdflang
+    # for Fortran.  Override whatever language default was selected
+    # above.  C++ reuses find_hip_compiler, which returns amdclang++.
+    if { $is_omp_rocm } {
+	switch -- $compiler_type {
+	    "c++"   { set compiler [find_hip_compiler] }
+	    "f90"   { set compiler [gdb_find_amd_omp_compiler amdflang] }
+	    default { set compiler [gdb_find_amd_omp_compiler amdclang] }
 	}
     }
 

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6449,6 +6449,9 @@ proc quote_for_host { args } {
 #     information.
 #   - dwarf5: Force compilation with dwarf-5 debug information.
 #   - hip_no_offload_arch: Do not pass --offload-arch to the HIP compiler.
+#   - omp-rocm: Build an OpenMP-offload program for AMD GPUs.  Selects
+#     the AMD compiler driver (amdclang/amdclang++/amdflang, per the
+#     language option) and adds the -fopenmp offload flags.
 #
 # And here are some of the not too obscure options understood by DejaGnu that
 # influence the compilation:
@@ -6774,12 +6777,25 @@ proc gdb_compile {source dest type options} {
     # DWARF line numbering.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88432
     # This option defaults to on for Debian/Ubuntu.
+    #
+    # The bug is language-agnostic but the workaround is GCC-specific.
+    # Also skip -fno-stack-protector for non-GNU Fortran drivers, i.e.,
+    # "f90" with an F90 compiler that does not match gfortran-* (e.g.,
+    # flang, amdflang, ifx, ifort): such drivers reject the unknown
+    # argument even when test_compiler_info reports the host C compiler
+    # as GCC.  gfortran ("f90" with gfortran-*, as detected via
+    # lib/compiler.F90) keeps receiving the workaround.  Likewise skip
+    # it for "omp-rocm", which always uses an amdclang/amdflang driver
+    # (selected by default_target_compile), never GCC.
     if { !$getting_compiler_info
 	 && [test_compiler_info {gcc-*-*}]
 	 && !([test_compiler_info {gcc-[0-3]-*}]
 	      || [test_compiler_info {gcc-4-0-*}])
 	 && [lsearch -exact $options rust] == -1
-	 && [lsearch -exact $options hip] == -1} {
+	 && [lsearch -exact $options hip] == -1
+	 && [lsearch -exact $options "omp-rocm"] == -1
+	 && !([lsearch -exact $options f90] != -1
+	      && ![test_compiler_info {gfortran-*} f90])} {
 	# Put it at the front to not override any user-provided value.
 	lappend new_options "early_flags=-fno-stack-protector"
     }
@@ -6858,6 +6874,32 @@ proc gdb_compile {source dest type options} {
 	# don't do it if the testcase explicitly used --offload-arch.
 	if {[lsearch -exact $options hip_no_offload_arch] == -1
 	    && [lsearch -regexp $options "--offload-arch="] == -1} {
+	    foreach gpu_target [hcc_amdgpu_targets] {
+		lappend new_options "early_flags=--offload-arch=$gpu_target"
+	    }
+	}
+    }
+
+    if {[lsearch -exact $options "omp-rocm"] != -1 && !$getting_compiler_info} {
+	# OpenMP offload to AMD GPUs.  Enable the offload target and,
+	# like the HIP path above, the -mllvm option that makes AMDGPU
+	# backtraces work under -g (without hardcoding -g, which the
+	# "debug" option still controls).  The compiler driver itself
+	# (amdclang / amdclang++ / amdflang) is selected by
+	# default_target_compile based on the language option.
+	set omp_early_flags "-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa\
+			     -mllvm=-amdgpu-spill-cfi-saved-regs"
+
+	# amdflang does not understand some clang-only diagnostic
+	# flags, so only pass them on the C/C++ (non-f90) paths.
+	if {[lsearch -exact $options f90] == -1} {
+	    append omp_early_flags " -Wno-unused-command-line-argument"
+	}
+	lappend new_options "early_flags=$omp_early_flags"
+
+	# amdclang/amdflang require explicit --offload-arch; pass one
+	# per available device, unless the testcase set it itself.
+	if {[lsearch -regexp $options "--offload-arch="] == -1} {
 	    foreach gpu_target [hcc_amdgpu_targets] {
 		lappend new_options "early_flags=--offload-arch=$gpu_target"
 	    }
@@ -7098,6 +7140,30 @@ proc gdb_compile {source dest type options} {
 
     # Prune uninteresting compiler (and linker) output.
     regsub "Creating library file: \[^\r\n\]*\[\r\n\]+" $result "" result
+
+    # ROCm's device ld.lld can warn that the OpenMP runtime helper
+    # __keep_alive references LDS from a non-kernel function; the link
+    # still succeeds.  Drop that benign warning (and any immediately
+    # following ">>>" note lines) so the testcase isn't marked
+    # UNTESTED.  Anchored to that single warning, so genuine "error:"
+    # diagnostics are never pruned.
+    #
+    # Also drop benign "-Wunused-command-line-argument" warnings on the
+    # omp-rocm path.  build_executable compiles and links in two steps,
+    # so the offload/-mllvm flags (and the framework's -J module dir)
+    # are unused on the link step.  amdclang/amdclang++ silence these
+    # via -Wno-unused-command-line-argument, but amdflang does not
+    # accept that flag, so prune the resulting warnings here instead.
+    # Scoped to omp-rocm builds, whose flags we control, and to the
+    # unused-argument warning specifically (errors are never matched).
+    if {[lsearch -exact $options "omp-rocm"] != -1} {
+	regsub -all \
+	    {ld\.lld: warning:[^\r\n]*__keep_alive[^\r\n]*local memory global used by non-kernel function[^\r\n]*[\r\n]*(?:[ \t]*>>>[^\r\n]*[\r\n]*)*} \
+	    $result "" result
+	regsub -all \
+	    {[^\r\n]*: warning: argument unused during compilation:[^\r\n]*\[-Wunused-command-line-argument\][^\r\n]*[\r\n]*} \
+	    $result "" result
+    }
 
     # Starting with 2021.7.0 icc and icpc are marked as deprecated and both
     # compilers emit a remark #10441.  To let GDB still compile successfully,

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -693,3 +693,52 @@ gdb_caching_proc compiler_dwarf_language {} {
 	return "others"
     }
 }
+
+# OpenMP GPU offload support.
+#
+# The procs below extend the ROCm test framework to support running
+# tests that use the OpenMP "target" construct to offload code to
+# the GPU.
+
+# Return 1 if the C/C++ OpenMP-offload toolchain and a usable AMD GPU
+# are both available; otherwise return a {0 reason} pair suitable for
+# 'require'.
+#
+# The actual OpenMP-offload compile is driven by gdb_compile's
+# "omp-rocm" option, which selects the AMD compiler (amdclang /
+# amdclang++ / amdflang) and adds the offload flags.
+
+gdb_caching_proc allow_omp_offload_tests {} {
+    # Reuse the shared ROCm gate (native target, amd-dbgapi support and
+    # a usable AMD GPU device); the device check compiles a HIP program
+    # with amdclang++, proving the AMD LLVM toolchain that ships
+    # amdclang / amdclang++ is present.  OpenMP offload only adds a
+    # Linux-only restriction on top.
+    set base [allow_hip_tests]
+    if {[lindex $base 0] == 0} {
+	return $base
+    }
+
+    if {![istarget "*-linux*"]} {
+	return {0 "OpenMP offload is only tested on Linux"}
+    }
+
+    return 1
+}
+
+# Same as above, but also requires amdflang for Fortran tests.
+
+gdb_caching_proc allow_omp_offload_fortran_tests {} {
+    set base [allow_omp_offload_tests]
+    if {[lindex $base 0] == 0} {
+	return $base
+    }
+
+    # Fortran offload needs amdflang specifically.  Resolve it through
+    # the same discovery default_target_compile uses, and confirm it
+    # actually runs.
+    if {[catch {exec [gdb_find_amd_omp_compiler amdflang] --version}]} {
+	return {0 "amdflang not available"}
+    }
+    return 1
+}


### PR DESCRIPTION
## Summary
Add OpenMP GPU offload coverage to the `gdb.rocm/` testsuite.
The existing `gdb.rocm/` tests cover HIP-style kernels (`__global__`
functions launched via `hipLaunchKernelGGL`), but there is no coverage
for OpenMP `target` offload — an increasingly common way of programming
AMD GPUs from C, C++ and Fortran. Without these tests, regressions in
GDB's handling of:
- the `__omp_offloading_<hash>_<func>_l<line>` outliner-frame symbols,
- OpenMP-runtime-loaded device ELFs (loaded via `libomptarget` plugins,
  not `libamdhip64`),
- DWARF emitted for OpenMP `map`-clause variables,
can land silently while the HIP path keeps working.
## Motivation
`gdb.threads/` already has CPU-side OpenMP tests (`omp-par-scope.exp`,
`omp-task.exp`), but nothing in the testsuite exercises the `target`
construct on an actual GPU. This PR adds those tests and the dejagnu
framework hooks needed to drive an OpenMP-offload-capable Clang/Flang
toolchain.
## What changed
### Framework hooks in `gdb/testsuite/lib/rocm.exp` (+186 lines)
Reusable procs that future OpenMP-offload tests can also rely on:
- \`rocm_find_llvm_tool\` — locate a tool under \`\$ROCM_PATH/llvm/bin\`,
  then \`\$ROCM_PATH/lib/llvm/bin\`, then \`PATH\`.
- \`find_amdclang\`, \`find_amdclangpp\`, \`find_amdflang\` — cached
  wrappers for the three offload-capable compiler drivers.
- \`allow_omp_offload_tests\`, \`allow_omp_offload_fortran_tests\` —
  \`require\`-compatible predicates: amd-dbgapi support, toolchain
  availability, ≥ 1 AMD GPU.
- \`rocm_omp_offload_flags <lang>\` — build the
  \`-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa --offload-arch=…\`
  flag set; omits the Clang-only \`-Wno-unused-command-line-argument\`
  for Fortran (the Flang driver rejects that diagnostic option).
- \`gdb_compile_omp_offload\`, \`gdb_compile_omp_offload_cpp\`,
  \`gdb_compile_omp_offload_fortran\` — \`gdb_compile\` wrappers that
  swap in the right offload-capable driver and add the offload flags.
- \`with_rocm_omp_gpu_lock\` — alias for \`with_rocm_gpu_lock\` so
  OpenMP tests serialize with HIP tests on the GPU.
### New tests under \`gdb/testsuite/gdb.rocm/\` (16 files)
- \`omp-target-break\` — basic \`#pragma omp target\` breakpoint by
  \`file:line\`, AMDGPU wave check.
- \`omp-target-step\` — \`next\` stepping inside the offloaded region
  keeps the program on a wave.
- \`omp-target-locals\` — inspect \`map(to:)\`, \`map(tofrom:)\`,
  \`firstprivate\` and a device-local automatic variable.
- \`omp-target-teams\` — \`target teams distribute parallel for\`
  produces multiple AMDGPU waves at one breakpoint; \`thread N\`
  switches to a wave; \`print i\` works inside it.
- \`omp-target-data\` — \`target data\` enclosing two consecutive
  \`target\` regions; the device buffer is reused between kernels
  (verified via \`c[0] == 100\` in the second kernel).
- \`omp-target-multi-kernel\` — two \`declare target\` device functions
  launched from separate target regions; named breakpoints land on the
  right kernel.
- \`omp-target-cpp\` — templated device function (\`add_t<int>\`) and
  struct functor (\`multiplier::operator()\`) compiled with the C++
  driver; \`print this->factor\` works.
- \`omp-target-fortran\` — \`!\$omp target\` compiled with the Fortran
  driver; breakpoint inside the loop hits an AMDGPU wave.
Each \`.exp\` follows the established \`gdb.rocm/\` patterns:
\`load_lib rocm.exp\`, \`require allow_omp_offload_tests\`,
\`with_rocm_omp_gpu_lock { … }\`, and uses the \`gdb_test_multiple\` +
\`exp_continue\` idiom (same as \`gdb.rocm/shared-memory.exp\`) so the
patterns survive multi-line GDB output.
## Testing

\`\`\`
make -C testsuite check TESTS="gdb.rocm/omp-target-*.exp"
…
# of expected passes            47
# of unexpected failures        0
\`\`\`
Per-test PASS / FAIL counts:
- \`omp-target-break.exp\` — 3 PASS, 0 FAIL
- \`omp-target-step.exp\` — 9 PASS, 0 FAIL
- \`omp-target-locals.exp\` — 7 PASS, 0 FAIL
- \`omp-target-teams.exp\` — 6 PASS, 0 FAIL
- \`omp-target-data.exp\` — 8 PASS, 0 FAIL
- \`omp-target-multi-kernel.exp\` — 5 PASS, 0 FAIL
- \`omp-target-cpp.exp\` — 6 PASS, 0 FAIL
- \`omp-target-fortran.exp\` — 3 PASS, 0 FAIL
- **Total — 47 PASS, 0 FAIL**
On hosts without an offload-capable Clang/Flang toolchain or without an
AMD GPU, the \`require allow_omp_offload_tests\` /
\`allow_omp_offload_fortran_tests\` gates report the tests as
\`UNSUPPORTED\` rather than \`FAIL\`, so this PR is safe to land in CI
immediately.
## Backwards compatibility
- \`lib/rocm.exp\` is only extended; no existing proc is renamed and
  no signature changes. Existing HIP tests are unaffected.
- New procs are uniquely named (e.g. \`find_amdclang\` vs the existing
  \`find_hipcc\`) so there is no collision.
