### PR TITLE
gdb/testsuite Conditionally increasing the timeouts in tests to accommodate the emulator

### DIFF
--- a/gdb/testsuite/gdb.rocm/names.cpp
+++ b/gdb/testsuite/gdb.rocm/names.cpp
@@ -209,7 +209,7 @@ int
 main (int argc, char **argv)
 {
   /* So that the GPU threads don't spin forever.  */
-  gdb_watchdog (30);
+  gdb_watchdog (90);
 
   if (argc != 2)
     {


### PR DESCRIPTION
Increasing the timeout in names.cpp to 90 seconds; the current 30‑second limit isn’t sufficient under emulation.
