### PR TITLE
gdb/testsuite: add DAP tests for core-file state-tracking bugs

### DIFF
--- a/gdb/testsuite/gdb.dap/corefile-after-launch.exp
+++ b/gdb/testsuite/gdb.dap/corefile-after-launch.exp
@@ -1,0 +1,105 @@
+# Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test if GDB DAP doesn't recognize CLI-driven inferior state changes
+# First:
+# - launch with stopOnEntry, then DAP evaluate("core-file <path>") to
+#   load the core
+# Then:
+# - evaluate(core-file) succeeds and the core is loaded
+# - All subsequent DAP requests (threads, evaluate, backtrace) return
+#   success: false, message: "notStopped"
+# - The new inferior is in stopped state, but GDB DAP's state tracker
+#   is out of sync
+
+require allow_dap_tests
+
+load_lib dap-support.exp
+
+# Reuse the existing corefile.c source from gdb.dap.
+standard_testfile corefile.c
+
+if {[build_executable ${testfile}.exp $testfile $srcfile] == -1} {
+    return
+}
+
+set corefile [core_find $binfile {}]
+if {$corefile == ""} {
+    untested "unable to create or find corefile"
+    return
+}
+
+if {[dap_initialize] == ""} {
+    return
+}
+
+# Launch the inferior with stop_at_main so that we have an active,
+# stopped inferior before we touch the core file.
+set launch_id [dap_launch $testfile stop_at_main 1]
+
+dap_check_request_and_response "configurationDone" configurationDone
+dap_check_response "launch response" launch $launch_id
+
+dap_wait_for_event_and_check "stopped at main" stopped \
+    "body reason" breakpoint
+
+# Now load the core file by way of a CLI command, sent through a DAP
+# evaluate request.  The "core-file" command attaches a new inferior
+# in stopped state.
+set obj [dap_check_request_and_response "load core via repl" \
+	     evaluate [format {o expression [s "core-file %s"] context [s repl]} \
+			   $corefile]]
+
+# After loading the core, GDB DAP must regard the (new) current
+# inferior as stopped.  Verify by issuing a few standard DAP requests
+# that previously came back as success=false / message="notStopped".
+
+# 1. threads request must succeed.
+set obj [dap_request_and_response threads]
+set response [lindex $obj 0]
+gdb_assert { [dict get $response success] } \
+    "threads request succeeds after core-file via evaluate"
+if {![dict get $response success] && [dict exists $response message]} {
+    gdb_assert { [dict get $response message] != "notStopped" } \
+	"threads message is not notStopped"
+}
+
+# Pick the first reported thread id for the stackTrace request below.
+set threads [dict get $response body threads]
+set tid [dict get [lindex $threads 0] id]
+
+# 2. evaluate("info threads") in the repl context must succeed.
+set obj [dap_request_and_response evaluate \
+	     {o expression [s "info threads"] context [s repl]}]
+set response [lindex $obj 0]
+gdb_assert { [dict get $response success] } \
+    "evaluate 'info threads' succeeds after core-file via evaluate"
+if {![dict get $response success] && [dict exists $response message]} {
+    gdb_assert { [dict get $response message] != "notStopped" } \
+	"evaluate message is not notStopped"
+}
+
+# 3. A backtrace request on a reported thread must succeed.
+set obj [dap_request_and_response stackTrace \
+	     [format {o threadId [i %d]} $tid]]
+set response [lindex $obj 0]
+gdb_assert { [dict get $response success] } \
+    "stackTrace succeeds after core-file via evaluate"
+if {![dict get $response success] && [dict exists $response message]} {
+    gdb_assert { [dict get $response message] != "notStopped" } \
+	"stackTrace message is not notStopped"
+}
+
+dap_shutdown true

--- a/gdb/testsuite/gdb.dap/corefile-cli-preload.exp
+++ b/gdb/testsuite/gdb.dap/corefile-cli-preload.exp
@@ -1,0 +1,91 @@
+# Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Verify initialize succeeds when core is pre-loaded via CLI
+#
+# Two test scenarios are exercised:
+#  1. -ex "core-file <path>" — long-form CLI pre-load
+#  2. -c <path> — short-form CLI pre-load
+#
+# Bug being guarded against: When DAP initializes with an
+# already-attached core inferior, the state tracker thinks nothing is
+# stopped (despite the core being a stopped inferior), so initialize
+# itself is rejected.
+
+require allow_dap_tests
+
+load_lib dap-support.exp
+
+# Reuse the existing corefile.c source from gdb.dap.
+standard_testfile corefile.c
+
+if {[build_executable ${testfile}.exp $testfile $srcfile] == -1} {
+    return
+}
+
+set corefile [core_find $binfile {}]
+if {$corefile == ""} {
+    untested "unable to create or find corefile"
+    return
+}
+
+# A helper that runs one initialize attempt with the given pre-load flag
+# (either "-ex" with a core-file command, or "-c" with the core path).
+# After the attempt, cleanly shut gdb down.
+proc test_preload_initialize {prefix preload_flags} {
+    with_test_prefix $prefix {
+	save_vars ::GDBFLAGS {
+	    append ::GDBFLAGS " $preload_flags \"$::binfile\""
+
+	    if {[dap_gdb_start]} {
+		return
+	    }
+	}
+
+	# Send the initialize request manually so that we can inspect
+	# the response without forcing a pass/fail on success, like in
+	# the case of dap_initialize.
+	set seq [dap_send_request initialize \
+		     {o clientID [s "gdb testsuite"] \
+			  supportsVariableType [l true] \
+			  supportsVariablePaging [l true] \
+			  supportsMemoryReferences [l true]}]
+	set obj [dap_read_response initialize $seq]
+	set response [lindex $obj 0]
+
+	# Check if success comes back false with message "notStopped".
+	gdb_assert { [dict get $response success] } \
+	    "initialize succeeds with core pre-loaded"
+
+	if {![dict get $response success]} {
+	    set msg ""
+	    if {[dict exists $response message]} {
+		set msg [dict get $response message]
+	    }
+	    gdb_assert { $msg != "notStopped" } \
+		"initialize message is not notStopped"
+	}
+
+	dap_shutdown
+    }
+}
+
+# Scenario 1: pre-load via -ex "core-file <core>".
+test_preload_initialize "ex core-file" \
+    "-ex \"core-file $corefile\""
+
+# Scenario 2: pre-load via short form -c <core>
+test_preload_initialize "-c corefile" \
+    "-c \"$corefile\""


### PR DESCRIPTION
Add two tests in gdb.dap/ covering bugs reported against rocgdb 16.3, where GDB DAP's state tracker fell out of sync with the inferior after a core file was loaded.

corefile-cli-preload.exp
  Spawn gdb with a core file already attached on the command line
  (either '-ex "core-file <core>"' or '-c <core>'), then send one DAP
  'initialize' request.  In rocgdb 16.3 the response came back with
  success=false and message="notStopped" because the pre-loaded core
  was not registered as a stopped target.  The test asserts
  success=true; on failure, a follow-up assertion fires to flag
  whether the specific "notStopped" message was returned.

corefile-after-launch.exp
  Launch a binary with stopAtBeginningOfMainSubprogram, wait for the
  stopped event at main, then load a core file by sending the CLI
  command through a DAP 'evaluate' request in the repl context.  The
  evaluate succeeds and the new core inferior reaches stopped state,
  but in rocgdb 16.3 every follow-up DAP request (threads, evaluate,
  stackTrace, ...) returned success=false with message="notStopped"
  because the state tracker missed the CLI-driven inferior switch.
  The test issues 'threads', 'evaluate("info threads")', and
  'stackTrace' and asserts each one succeeds.

Both tests reuse the existing gdb.dap/corefile.c source by setting testfile/srcfile/binfile manually; standard_testfile would otherwise derive the source name from the .exp basename.

The bugs do not reproduce against current trunk (gdb 18.0.50), so the tests pass today and will catch regressions if either bug returns.
