### PR TITLE
gdb/testsuite: Extend gdb.rocm/runtime-core.exp with piped GPU coredumps

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -33,17 +33,22 @@ if { [build_executable "failed to prepare" ${testfile} ${srcfile} \
     return -1
 }
 
-# do_test FAULT CORE_TYPE
-#   Run the test exercising generation of a core dump on fault FAULT.
+# do_test FAULT CORE_TYPE OUTPUT_TYPE
+#   Run the test exercising generation of a core dump on fault FAULT
+#   using a file or a pipe.
 #
 # FAULT is one of "page", "abort",  or "assert", and selects which
 #   fault the application should generate.
 #
 # CORE_TYPE is one of "full" or "lightweight".
-proc do_test { fault core_type } {
+#
+# OUTPUT_TYPE is one of "file" of "pipe".
+#
+proc do_test { fault core_type output_type } {
+    set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
-	set coredump [rocm_core_find $::binfile {} $fault]
+	set coredump [rocm_core_find $::binfile {} $fault $use_pipe]
     }
 
     if {$coredump eq ""} {
@@ -53,7 +58,7 @@ proc do_test { fault core_type } {
 
     check_sparse $coredump "core is sparse"
 
-    set corename "${coredump}-${fault}-${core_type}"
+    set corename "${coredump}-${fault}-${core_type}-${output_type}"
 
     remote_exec build "mv $coredump $corename"
 
@@ -132,9 +137,17 @@ proc do_test { fault core_type } {
 }
 
 with_rocm_gpu_lock {
-    foreach_with_prefix core_type {full lightweight} {
-	foreach_with_prefix fault {pagefault abort assert} {
-	    do_test $fault $core_type
+    # Check the runtime can configure the core dump generation based
+    # on env variables.
+    foreach_with_prefix output_type { file pipe } {
+	foreach_with_prefix core_type {full lightweight} {
+	    do_test pagefault $core_type $output_type
 	}
+    }
+
+    # Check that various GPU events can cause a core dump.
+    # "pagefault" was covered by previous cases already.
+    foreach_with_prefix fault {abort assert} {
+      do_test $fault lightweight file
     }
 }

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -438,14 +438,20 @@ proc hip_device_is_less_than { version } {
 
 # Helper function for rocm_core_find.
 
-proc rocm_core_find_1 {coredir binfile arg output_file} {
+proc rocm_core_find_1 {coredir binfile arg output_file \
+		       {use_pipe false}} {
+    if { $use_pipe } {
+	set coredump_pattern "|tee $coredir/$binfile"
+    } else {
+	set coredump_pattern "gpucore.%p"
+    }
     # If we don't set the pattern here, on ROCm 7.3+ runtimes,
     # we will end up with "core.<pid>.gpu".  The "core_find {}"
     # procedure in "lib/gdb.exp" does not like that.  It expects
     # only one hit for the glob pattern "core.*".  Without this
     # pattern, there will be 2 hits: core.<pid> and core.<pid>.gpu
     save_vars { ::env(HSA_COREDUMP_PATTERN) } {
-	set ::env(HSA_COREDUMP_PATTERN) "gpucore.%p"
+	set ::env(HSA_COREDUMP_PATTERN) $coredump_pattern
 	set destcore [core_find_1 $coredir $binfile $arg $output_file]
     }
     set gpucore "$binfile.gpucore"
@@ -484,9 +490,10 @@ proc rocm_core_find_1 {coredir binfile arg output_file} {
 # dump and merges it with the CPU core dump found by core_find.  If either
 # of the GPU and host core dump is missing, return an empty string.
 
-proc rocm_core_find {binfile {deletefiles {}} {arg ""} {output_file "/dev/null"}} {
+proc rocm_core_find {binfile {deletefiles {}} {arg ""} {output_file "/dev/null"} \
+			      {use_pipe false}} {
     return [with_tmpdir coredir $deletefiles rocm_core_find_1 $binfile $arg \
-	    $output_file]
+	    $output_file $use_pipe]
 }
 
 # Helper function calling "generate-core-file COREFILE_PATH".


### PR DESCRIPTION
The ROCr runtime had recently introduced the HSA_COREDUMP_PATTERN to configure how/where to save a core dump.  It follows the kernel model for kernel.core_pattern.  The pattern can either describe a file name where the core dump should be created, or if it starts with |, it indicates that the core dump should be sent through a pipe to a custom command.

This change extends the runtime-core.exp test case to exercise the piped version of core dump.