### PR TITLE
gdb/dwarf: Fix dwarf_register::read overflow

### DIFF
--- a/gdb/aarch64-tdep.c
+++ b/gdb/aarch64-tdep.c
@@ -3283,7 +3283,7 @@ aarch64_sme_pseudo_register_read (gdbarch *gdbarch, const frame_info_ptr &next_f
     {
       int src_offset = offsets.starting_offset + chunks * offsets.stride_size;
       int dst_offset = chunks * offsets.chunk_size;
-      za_value->contents_copy (result, dst_offset, src_offset, 0,
+      za_value->contents_copy (result, dst_offset, src_offset,
 			       offsets.chunk_size);
     }
 

--- a/gdb/ada-lang.c
+++ b/gdb/ada-lang.c
@@ -545,7 +545,7 @@ coerce_unspec_val_to_type (struct value *val, struct type *type)
       else
 	{
 	  result = value::allocate (type);
-	  val->contents_copy (result, 0, 0, 0, type->length ());
+	  val->contents_copy (result, 0, 0, type->length ());
 	}
       result->set_component_location (val);
       result->set_bitsize (val->bitsize ());

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -1518,7 +1518,7 @@ dwarf_register::to_gdb_value (const frame_info_ptr &initial_frame,
 	 return a generic optimized out value instead, so that we show
 	 <optimized out> instead of <not saved>.  */
       value *temp = value::allocate (subobj_type);
-      retval->contents_copy (temp, 0, 0, 0, subobj_type->length ());
+      retval->contents_copy (temp, 0, 0, subobj_type->length ());
       retval = temp;
     }
 

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -1378,6 +1378,17 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (frame == NULL)
     internal_error (_("invalid frame information"));
 
+  /* Check that the read will not try to access past the end of the register.
+     If it does, consider that some bits of the read are optimized out.  Since
+     we do not have a better granularity during the register read, report the
+     entire read as optimized out even if we could read a few bits.  */
+  if (total_bits_to_skip + bit_size > reg_bits)
+    {
+      *optimized = true;
+      *unavailable = false;
+      return;
+    }
+
   /* Populate or refresh the cache if needed.  */
   if (m_storage->m_read_cache.has_value ()
       && m_storage->m_read_cache->outdated (frame))

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -541,13 +541,16 @@ public:
 
      Note that some location types can be read without a FRAME context.
 
-     If the location is optimized out or unavailable, the OPTIMIZED and
-     UNAVAILABLE outputs are set accordingly.  */
+     If the location is optimized out or unavailable (entirely or
+     partially), the affected ranges will be appended to OPTIMIZED and
+     UNAVAILABLE as necessary.  OPTIMIZED or UNAVAILABLE are left unchanged
+     if the location is not optimized or unavailable.  The ranges will
+     reference regions relative to BITS_TO_SKIP.  */
   virtual void read (const frame_info_ptr &frame, gdb_byte *buf,
 		     int buf_bit_offset, size_t bit_size,
 		     LONGEST bits_to_skip, size_t location_bit_limit,
-		     bool big_endian, bool *optimized,
-		     bool *unavailable) const = 0;
+		     bool big_endian, std::vector<range> &optimized_ranges,
+		     std::vector<range> &unavailable) const = 0;
 
   /* Write contents to a described location.
 
@@ -710,20 +713,20 @@ dwarf_location::deref (const frame_info_ptr &frame,
      from the type length, we need to zero-extend it.  */
   gdb::byte_vector read_buf (type->length (), 0);
   gdb_byte *buf_ptr = read_buf.data ();
-  bool optimized, unavailable;
+  std::vector<range> optimized, unavailable;
 
   if (big_endian)
     buf_ptr += type->length () - actual_size;
 
   this->read (frame, buf_ptr, 0, actual_size * HOST_CHAR_BIT,
-	      0, 0, big_endian, &optimized, &unavailable);
+	      0, 0, big_endian, optimized, unavailable);
 
-  if (optimized)
+  if (!optimized.empty ())
     throw_error (OPTIMIZED_OUT_ERROR,
 		 _("Can't do read-modify-write to "
 		   "update bitfield; containing word "
 		   "has been optimized out"));
-  if (unavailable)
+  if (!unavailable.empty ())
     throw_error (NOT_AVAILABLE_ERROR,
 		 _("Can't dereference "
 		   "update bitfield; containing word "
@@ -764,17 +767,19 @@ dwarf_location::write_to_gdb_value (const frame_info_ptr &frame,
 				    LONGEST bits_to_skip, size_t bit_size,
 				    size_t location_bit_limit)
 {
-  bool optimized, unavailable;
+  std::vector<range> optimized, unavailable;
   bool big_endian = type_byte_order (value->type ()) == BFD_ENDIAN_BIG;
 
   this->read (frame, value->contents_raw ().data (), value_bit_offset,
 	      bit_size, bits_to_skip, location_bit_limit,
-	      big_endian, &optimized, &unavailable);
+	      big_endian, optimized, unavailable);
 
-  if (optimized)
-    value->mark_bits_optimized_out (value_bit_offset, bit_size);
-  if (unavailable)
-    value->mark_bits_unavailable (value_bit_offset, bit_size);
+  for (auto &&optimized_range : optimized)
+    value->mark_bits_optimized_out
+      (value_bit_offset + optimized_range.offset, optimized_range.length);
+  for (auto &&unavailable_range : unavailable)
+    value->mark_bits_unavailable
+      (value_bit_offset + unavailable_range.offset, unavailable_range.length);
 }
 
 /* Value entry found on a DWARF expression evaluation stack.  */
@@ -931,11 +936,10 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, bool *optimized,
-	     bool *unavailable) const override
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override
   {
-    *unavailable = false;
-    *optimized = true;
+    optimized.push_back ({0, bit_size});
   }
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
@@ -1005,7 +1009,8 @@ public:
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip,
 	     size_t location_bit_limit, bool big_endian,
-	     bool *optimized, bool *unavailable) const override;
+	     std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1054,7 +1059,8 @@ void
 dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
 		    int buf_bit_offset, size_t bit_size,
 		    LONGEST bits_to_skip, size_t location_bit_limit,
-		    bool big_endian, bool *optimized, bool *unavailable) const
+		    bool big_endian, std::vector<range> &optimized,
+		    std::vector<range> &unavailable) const
 {
   LONGEST total_bits_to_skip = bits_to_skip;
   CORE_ADDR start_address
@@ -1065,7 +1071,6 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
     = gdbarch_segment_address_to_core_address (m_arch, m_address_space,
 					       start_address);
 
-  *optimized = false;
   total_bits_to_skip += m_bit_suboffset;
 
   if (total_bits_to_skip % HOST_CHAR_BIT == 0
@@ -1073,9 +1078,12 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
       && buf_bit_offset % HOST_CHAR_BIT == 0)
     {
       /* Everything is byte-aligned, no buffer needed.  */
+      bool is_unavailable;
       read_from_memory (start_address,
 			buf + buf_bit_offset / HOST_CHAR_BIT,
-			bit_size / HOST_CHAR_BIT, m_stack, unavailable);
+			bit_size / HOST_CHAR_BIT, m_stack, &is_unavailable);
+      if (is_unavailable)
+	unavailable.push_back ({0, bit_size});
     }
   else
     {
@@ -1084,13 +1092,16 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
 
       /* Can only read from memory on byte granularity so an
 	 additional buffer is required.  */
+      bool is_unavailable;
       read_from_memory (start_address, temp_buf.data (), this_size,
-			m_stack, unavailable);
+			m_stack, &is_unavailable);
 
-      if (!*unavailable)
+      if (!is_unavailable)
 	copy_bitwise (buf, buf_bit_offset, temp_buf.data (),
 		      total_bits_to_skip % HOST_CHAR_BIT,
 		      bit_size, big_endian);
+      else
+	unavailable.push_back ({0, bit_size});
     }
 }
 
@@ -1198,17 +1209,17 @@ dwarf_memory::deref (const frame_info_ptr &frame,
     }
   else
     {
-      bool optimized, unavailable;
+      std::vector<range> optimized, unavailable;
 
       this->read (frame, buf_ptr, 0, size_in_bits, 0, 0,
-		  big_endian, &optimized, &unavailable);
+		  big_endian, optimized, unavailable);
 
-      if (optimized)
+      if (!optimized.empty ())
 	throw_error (OPTIMIZED_OUT_ERROR,
 		     _("Can't do read-modify-write to "
 		     "update bitfield; containing word "
 		     "has been optimized out"));
-      if (unavailable)
+      if (!unavailable.empty ())
 	throw_error (NOT_AVAILABLE_ERROR,
 		     _("Can't dereference "
 		     "update bitfield; containing word "
@@ -1268,8 +1279,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, bool *optimized,
-	     bool *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1347,8 +1358,8 @@ void
 dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
 		      int buf_bit_offset, size_t bit_size,
 		      LONGEST bits_to_skip, size_t location_bit_limit,
-		      bool big_endian, bool *optimized,
-		      bool *unavailable) const
+		      bool big_endian, std::vector<range> &optimized,
+		      std::vector<range> &unavailable) const
 {
   frame_info_ptr frame = initial_frame;
   LONGEST total_bits_to_skip = bits_to_skip;
@@ -1378,17 +1389,6 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (frame == NULL)
     internal_error (_("invalid frame information"));
 
-  /* Check that the read will not try to access past the end of the register.
-     If it does, consider that some bits of the read are optimized out.  Since
-     we do not have a better granularity during the register read, report the
-     entire read as optimized out even if we could read a few bits.  */
-  if (total_bits_to_skip + bit_size > reg_bits)
-    {
-      *optimized = true;
-      *unavailable = false;
-      return;
-    }
-
   /* Populate or refresh the cache if needed.  */
   if (m_storage->m_read_cache.has_value ()
       && m_storage->m_read_cache->outdated (frame))
@@ -1397,13 +1397,39 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (!m_storage->m_read_cache.has_value ())
     m_storage->m_read_cache.emplace (arch, frame, reg);
 
-  *optimized = m_storage->m_read_cache->optimized_out ();
-  *unavailable = m_storage->m_read_cache->unavailable ();
+  if (m_storage->m_read_cache->optimized_out ())
+    optimized.push_back ({0, bit_size});
 
-  if (!*optimized && !*unavailable)
-    copy_bitwise (buf, buf_bit_offset,
-		  m_storage->m_read_cache->data ().data (),
-		  total_bits_to_skip, bit_size, big_endian);
+  if (m_storage->m_read_cache->unavailable ())
+    unavailable.push_back ({0, bit_size});
+
+  if (!m_storage->m_read_cache->optimized_out ()
+      && !m_storage->m_read_cache->unavailable ())
+    {
+      if (total_bits_to_skip > reg_bits)
+	{
+	  /* The read is completely past the register, mark everything as
+	     optimized out.  */
+	  optimized.push_back ({0, bit_size});
+	}
+      else
+	{
+	  if (total_bits_to_skip + bit_size > reg_bits)
+	    {
+	      /* The access goes past the end of the register.  Mark this part
+		 as optimized out, and read the rest.  */
+	      optimized.push_back
+		({static_cast<LONGEST> (reg_bits) - total_bits_to_skip,
+		  (static_cast<LONGEST> (bit_size) + total_bits_to_skip
+		   - reg_bits)});
+	      bit_size = reg_bits - total_bits_to_skip;
+	    }
+
+	  copy_bitwise (buf, buf_bit_offset,
+			m_storage->m_read_cache->data ().data (),
+			total_bits_to_skip, bit_size, big_endian);
+	}
+    }
 
 }
 
@@ -1504,14 +1530,14 @@ dwarf_register::is_optimized_out (const frame_info_ptr &frame, bool big_endian,
 				  LONGEST bits_to_skip, size_t bit_size,
 				  size_t location_bit_limit) const
 {
-  bool optimized, unavailable;
+  std::vector<range> optimized, unavailable;
   gdb::byte_vector temp_buf (bit_size);
 
   this->read (frame, temp_buf.data (), 0, bit_size,
 	      bits_to_skip, location_bit_limit,
-	      big_endian, &optimized, &unavailable);
+	      big_endian, optimized, unavailable);
 
-  return optimized;
+  return !optimized.empty ();
 }
 
 /* Implicit location description entry.  Describes a location
@@ -1551,8 +1577,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, bool *optimized,
-	     bool *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size,
@@ -1583,15 +1609,12 @@ void
 dwarf_implicit::read (const frame_info_ptr &frame, gdb_byte *buf,
 		      int buf_bit_offset, size_t bit_size,
 		      LONGEST bits_to_skip, size_t location_bit_limit,
-		      bool big_endian, bool *optimized,
-		      bool *unavailable) const
+		      bool big_endian, std::vector<range> &optimized,
+		      std::vector<range> &unavailable) const
 {
   ULONGEST implicit_bit_size = HOST_CHAR_BIT * m_size;
   LONGEST total_bits_to_skip = bits_to_skip;
   size_t read_bit_limit = location_bit_limit;
-
-  *optimized = false;
-  *unavailable = false;
 
   /* Cut off at the end of the implicit value.  */
   if (m_byte_order == BFD_ENDIAN_BIG)
@@ -1608,12 +1631,17 @@ dwarf_implicit::read (const frame_info_ptr &frame, gdb_byte *buf,
 
   if (total_bits_to_skip >= implicit_bit_size)
     {
-      (*unavailable) = 1;
+      optimized.push_back ({0, bit_size});
       return;
     }
 
   if (bit_size > implicit_bit_size - total_bits_to_skip)
-    bit_size = implicit_bit_size - total_bits_to_skip;
+    {
+      optimized.push_back
+	({static_cast<LONGEST> (implicit_bit_size - total_bits_to_skip),
+	  bit_size + total_bits_to_skip - implicit_bit_size});
+      bit_size = implicit_bit_size - total_bits_to_skip;
+    }
 
   copy_bitwise (buf, buf_bit_offset, m_contents.get (),
 		total_bits_to_skip, bit_size, big_endian);
@@ -1679,7 +1707,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, bool *optimized, bool *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1738,8 +1767,8 @@ void
 dwarf_implicit_pointer::read (const frame_info_ptr &frame, gdb_byte *buf,
 			      int buf_bit_offset, size_t bit_size,
 			      LONGEST bits_to_skip, size_t location_bit_limit,
-			      bool big_endian, bool *optimized,
-			      bool *unavailable) const
+			      bool big_endian, std::vector<range> &optimized,
+			      std::vector<range> &unavailable) const
 {
   frame_info_ptr actual_frame = frame;
   LONGEST total_bits_to_skip = bits_to_skip + m_bit_suboffset;
@@ -1852,8 +1881,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, bool *optimized,
-	     bool *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1976,17 +2005,25 @@ void
 dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
 		       int buf_bit_offset, size_t bit_size,
 		       LONGEST bits_to_skip, size_t location_bit_limit,
-		       bool big_endian, bool *optimized,
-		       bool *unavailable) const
+		       bool big_endian, std::vector<range> &optimized,
+		       std::vector<range> &unavailable) const
 {
   unsigned int pieces_num = m_pieces.size ();
   LONGEST total_bits_to_skip = bits_to_skip;
+  LONGEST range_bit_offset = 0;
   unsigned int i;
 
   if (!m_completed)
     ill_formed_expression ();
 
   total_bits_to_skip += m_offset * HOST_CHAR_BIT + m_bit_suboffset;
+
+  /* The range_bit_offset (bit offset that we need to add to any
+     optimized / unavailable range) can start negative if the current
+     location has an offset.  However, as we skip over pieces not
+     covered by the read / the beginning of the first covered piece,
+     this will get back to a positive or null value.  */
+  range_bit_offset -= m_offset * HOST_CHAR_BIT + m_bit_suboffset;
 
   /* Skip pieces covered by the read offset.  */
   for (i = 0; i < pieces_num; i++)
@@ -1997,10 +2034,12 @@ dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
 	break;
 
       total_bits_to_skip -= piece_bit_size;
+      range_bit_offset += piece_bit_size;
     }
 
   for (; i < pieces_num; i++)
     {
+      std::vector<range> piece_optimized, piece_unavailable;
       LONGEST piece_bit_size = m_pieces[i].m_size;
       LONGEST actual_bit_size = piece_bit_size;
 
@@ -2010,13 +2049,23 @@ dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
       m_pieces[i].m_location->read (frame, buf, buf_bit_offset,
 				    actual_bit_size, total_bits_to_skip,
 				    piece_bit_size, big_endian,
-				    optimized, unavailable);
+				    piece_optimized, piece_unavailable);
 
-      if (bit_size == actual_bit_size || *optimized || *unavailable)
+      for (auto &&piece_range : piece_optimized)
+	optimized.push_back ({(range_bit_offset + piece_range.offset),
+			      piece_range.length});
+
+      for (auto &&piece_range : piece_unavailable)
+	unavailable.push_back ({(range_bit_offset + piece_range.offset),
+				piece_range.length});
+
+      if (bit_size == actual_bit_size)
 	break;
 
       buf_bit_offset += actual_bit_size;
       bit_size -= actual_bit_size;
+      range_bit_offset += actual_bit_size - total_bits_to_skip;
+      total_bits_to_skip = 0;
     }
 }
 

--- a/gdb/eval.c
+++ b/gdb/eval.c
@@ -2545,7 +2545,7 @@ unop_extract_operation::evaluate (struct type *expect_type,
     error (_("length type is larger than the value type"));
 
   struct value *result = value::allocate (type);
-  old_value->contents_copy (result, 0, 0, 0, type->length ());
+  old_value->contents_copy (result, 0, 0, type->length ());
   return result;
 }
 

--- a/gdb/f-lang.c
+++ b/gdb/f-lang.c
@@ -143,7 +143,7 @@ fortran_bounds_all_dims (bool lbound_p,
       gdb_assert (dst_offset + v->type ()->length ()
 		  <= result->type ()->length ());
       gdb_assert (v->type ()->length () == elm_len);
-      v->contents_copy (result, dst_offset, 0, 0, elm_len);
+      v->contents_copy (result, dst_offset, 0, elm_len);
 
       /* Peel another dimension of the array.  */
       array_type = array_type->target_type ();
@@ -265,7 +265,7 @@ protected:
      available offset.  */
   void copy_element_to_dest (struct value *elt)
   {
-    elt->contents_copy (m_dest, m_dest_offset, 0, 0, elt->type ()->length ());
+    elt->contents_copy (m_dest, m_dest_offset, 0, elt->type ()->length ());
     m_dest_offset += elt->type ()->length ();
   }
 
@@ -727,7 +727,7 @@ fortran_array_shape (struct gdbarch *gdbarch, const language_defn *lang,
       gdb_assert (dst_offset + v->type ()->length ()
 		  <= result->type ()->length ());
       gdb_assert (v->type ()->length () == elm_len);
-      v->contents_copy (result, dst_offset, 0, 0, elm_len);
+      v->contents_copy (result, dst_offset, 0, elm_len);
 
       /* Peel another dimension of the array.  */
       val_type = val_type->target_type ();

--- a/gdb/findvar.c
+++ b/gdb/findvar.c
@@ -599,41 +599,34 @@ read_frame_register_value (value *value)
   gdb_assert (next_frame != nullptr);
 
   gdbarch *gdbarch = frame_unwind_arch (next_frame);
-  LONGEST offset = 0;
   LONGEST reg_offset = value->offset ();
   LONGEST bit_offset = value->bitpos ();
+  LONGEST reg_bit_offset = reg_offset * unit_size * HOST_CHAR_BIT + bit_offset;
   int regnum = value->regnum ();
-  int len = type_length_units (check_typedef (value->type ()));
+  LONGEST len = check_typedef (value->type ())->length () * HOST_CHAR_BIT;
 
-  /* Skip registers wholly inside of REG_OFFSET.  */
-  while (reg_offset >= register_size (gdbarch, regnum))
+  /* We try to read past the end of the register.  */
+  if (reg_bit_offset >= register_size (gdbarch, regnum) * HOST_CHAR_BIT)
     {
-      reg_offset -= register_size (gdbarch, regnum);
-      regnum++;
+      value->mark_bits_optimized_out (0, len);
+      return;
     }
 
-  /* Copy the data.  */
-  while (len > 0)
+  struct value *regval = frame_unwind_register_value (next_frame, regnum);
+  LONGEST reg_len
+    = regval->type ()->length () * HOST_CHAR_BIT - reg_bit_offset;
+
+  /* Truncate the read to not go past the end of the register.  */
+  if (reg_len > len)
+    reg_len = len;
+
+  if (len > reg_len)
     {
-      struct value *regval = frame_unwind_register_value (next_frame, regnum);
-      int reg_len = type_length_units (regval->type ()) - reg_offset;
-
-      /* If the register length is larger than the number of bytes
-	 remaining to copy, then only copy the appropriate bytes.  */
-      if (reg_len > len)
-	reg_len = len;
-
-      regval->contents_copy_bitwise (value,
-				     offset * unit_size * HOST_CHAR_BIT,
-				     (reg_offset * unit_size * HOST_CHAR_BIT
-				      + bit_offset),
-				     reg_len * unit_size * HOST_CHAR_BIT);
-
-      offset += reg_len;
-      len -= reg_len;
-      reg_offset = 0;
-      regnum++;
+      /* Mark bits past the end of the register as optimized out.  */
+      value->mark_bits_optimized_out (reg_len, len - reg_len);
     }
+
+  regval->contents_copy_bitwise (value, 0, reg_bit_offset, reg_len);
 }
 
 /* See value.h.  */

--- a/gdb/findvar.c
+++ b/gdb/findvar.c
@@ -593,6 +593,7 @@ void
 read_frame_register_value (value *value)
 {
   gdb_assert (value->lval () == lval_register);
+  int unit_size = gdbarch_addressable_memory_unit_size (value->arch ());
 
   frame_info_ptr next_frame = frame_find_by_id (value->next_frame_id ());
   gdb_assert (next_frame != nullptr);
@@ -622,7 +623,11 @@ read_frame_register_value (value *value)
       if (reg_len > len)
 	reg_len = len;
 
-      regval->contents_copy (value, offset, reg_offset, bit_offset, reg_len);
+      regval->contents_copy_bitwise (value,
+				     offset * unit_size * HOST_CHAR_BIT,
+				     (reg_offset * unit_size * HOST_CHAR_BIT
+				      + bit_offset),
+				     reg_len * unit_size * HOST_CHAR_BIT);
 
       offset += reg_len;
       len -= reg_len;

--- a/gdb/s390-tdep.c
+++ b/gdb/s390-tdep.c
@@ -2342,8 +2342,8 @@ s390_unwind_pseudo_register (const frame_info_ptr &this_frame, int regnum)
       struct value *val2
 	= frame_unwind_register_value (this_frame, S390_V0_LOWER_REGNUM + reg);
 
-      val1->contents_copy (val, 0, 0, 0, 8);
-      val2->contents_copy (val, 8, 0, 0, 8);
+      val1->contents_copy (val, 0, 0, 8);
+      val2->contents_copy (val, 8, 0, 8);
 
       return value_cast (type, val);
     }

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This test exercises the case where a DWARF expression leads the dwarf
+# machinery to try to read past a given register's end.  This should be
+# handled gracefully by GDB.
+
+load_lib "dwarf.exp"
+
+require dwarf2_support
+
+# This test will store a 128 bits variable in a register too small to
+# contain the entire value.  Select a suitable register which is less
+# than 128 bits in size.
+if { [is_amd64_regs_target] } {
+    # Use RAX, a 64 bits register.
+    set dwarf_regnum 0
+} else {
+    verbose "Skipping ${gdb_test_file_name} for current architecture."
+    unsupported "$gdb_test_file_name"
+    return
+}
+
+standard_testfile main.c -dw.S
+set dwarf_file [standard_output_file $srcfile2]
+
+Dwarf::assemble $dwarf_file {
+    get_func_info main
+
+    cu {} {
+	DW_TAG_compile_unit {
+	    DW_AT_language @DW_LANG_C
+	    DW_AT_name $::srcfile
+	    DW_AT_comp_dir /tmp
+	} {
+	    declare_labels int_label foo_t_label
+
+	    int_label: DW_TAG_base_type {
+		DW_AT_name int
+		DW_AT_byte_size 4 DW_FORM_udata
+		DW_AT_encoding @DW_ATE_signed
+	    }
+
+	    foo_t_label: DW_TAG_structure_type {
+		DW_AT_name foo_t
+		DW_AT_byte_size 16 DW_FORM_sdata
+	    } {
+		DW_TAG_member {
+		    DW_AT_name a
+		    DW_AT_data_member_location 0 DW_FORM_data1
+		    DW_AT_type :$int_label
+		}
+		DW_TAG_member {
+		    DW_AT_name b
+		    DW_AT_data_member_location 4 DW_FORM_data1
+		    DW_AT_type :$int_label
+		}
+		DW_TAG_member {
+		    DW_AT_name c
+		    DW_AT_data_member_location 8 DW_FORM_data1
+		    DW_AT_type :$int_label
+		}
+		DW_TAG_member {
+		    DW_AT_name d
+		    DW_AT_data_member_location 12 DW_FORM_data1
+		    DW_AT_type :$int_label
+		}
+	    }
+
+	    DW_TAG_subprogram {
+		DW_AT_name main
+		DW_AT_low_pc $main_start DW_FORM_addr
+		DW_AT_high_pc $main_end DW_FORM_addr
+		DW_AT_type :$int_label
+	    } {
+		DW_TAG_variable {
+		    DW_AT_name foo
+		    DW_AT_type :$foo_t_label
+		    DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_piece 16
+		    } SPECIAL_expr
+		}
+	    }
+	}
+    }
+}
+
+if { [prepare_for_testing "failed to prepare" $testfile \
+	[list $srcfile $dwarf_file] {nodebug}] } {
+    return
+}
+
+if { ![runto_main] } {
+    return
+}
+
+gdb_test "p/x foo" "= <optimized out>"

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -47,7 +47,7 @@ Dwarf::assemble $dwarf_file {
 	    DW_AT_name $::srcfile
 	    DW_AT_comp_dir /tmp
 	} {
-	    declare_labels int_label foo_t_label
+	    declare_labels int_label foo_t_label bitfield_t_label
 
 	    int_label: DW_TAG_base_type {
 		DW_AT_name int
@@ -81,6 +81,42 @@ Dwarf::assemble $dwarf_file {
 		}
 	    }
 
+	    bitfield_t_label: DW_TAG_structure_type {
+		DW_AT_name bitfield_t
+		DW_AT_byte_size 1 DW_FORM_sdata
+	    } {
+		DW_TAG_member {
+		    DW_AT_name a
+		    DW_AT_type :$int_label
+		    DW_AT_bit_size 1 DW_FORM_sdata
+		    DW_AT_data_bit_offset 0 DW_FORM_sdata
+		}
+		DW_TAG_member {
+		    DW_AT_name b
+		    DW_AT_type :$int_label
+		    DW_AT_bit_size 1 DW_FORM_sdata
+		    DW_AT_data_bit_offset 1 DW_FORM_sdata
+		}
+		DW_TAG_member {
+		    DW_AT_name c
+		    DW_AT_type :$int_label
+		    DW_AT_bit_size 1 DW_FORM_sdata
+		    DW_AT_data_bit_offset 2 DW_FORM_sdata
+		}
+		DW_TAG_member {
+		    DW_AT_name d
+		    DW_AT_type :$int_label
+		    DW_AT_bit_size 1 DW_FORM_sdata
+		    DW_AT_data_bit_offset 3 DW_FORM_sdata
+		}
+		DW_TAG_member {
+		    DW_AT_name e
+		    DW_AT_type :$int_label
+		    DW_AT_bit_size 1 DW_FORM_sdata
+		    DW_AT_data_bit_offset 4 DW_FORM_sdata
+		}
+	    }
+
 	    DW_TAG_subprogram {
 		DW_AT_name main
 		DW_AT_low_pc $main_start DW_FORM_addr
@@ -93,6 +129,34 @@ Dwarf::assemble $dwarf_file {
 		    DW_AT_location {
 			DW_OP_regx $::dwarf_regnum
 			DW_OP_piece 16
+		    } SPECIAL_expr
+		}
+
+		DW_TAG_variable {
+		    DW_AT_name var_reg
+		    DW_AT_type :$foo_t_label
+		    DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+		    } SPECIAL_expr
+		}
+
+		DW_TAG_variable {
+		    DW_AT_name var_reg_past_the_end
+		    DW_AT_type :$foo_t_label
+		    DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_constu 8
+			DW_OP_LLVM_offset
+		    } SPECIAL_expr
+		}
+
+		DW_TAG_variable {
+		    DW_AT_name var_bitfield
+		    DW_AT_type :$bitfield_t_label
+		    DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_constu 62
+			DW_OP_LLVM_bit_offset
 		    } SPECIAL_expr
 		}
 	    }
@@ -113,3 +177,14 @@ if { ![runto_main] } {
 set regsize [get_sizeof "\$$regname" ""]
 gdb_assert {$regsize == 8} "ensure register size"
 gdb_test "p/x var_piece" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"
+
+# Read a variable larger than the register holding it, with a simple register
+# location description.
+gdb_test "p/x var_reg" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"
+
+# Read a value fully past the end of the register.
+gdb_test "p/x var_reg_past_the_end" "= <optimized out>"
+
+# Read a 1-byte value 2 bits away from the end of the register.  GDB needs
+# to be able to read less than one byte (2 bits), bits 2-7 are optimized out.
+gdb_test "p/x var_bitfield" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>, e = <optimized out>}"

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -28,6 +28,7 @@ require dwarf2_support
 if { [is_amd64_regs_target] } {
     # Use RAX, a 64 bits register.
     set dwarf_regnum 0
+    set regname "rax"
 } else {
     verbose "Skipping ${gdb_test_file_name} for current architecture."
     unsupported "$gdb_test_file_name"
@@ -87,7 +88,7 @@ Dwarf::assemble $dwarf_file {
 		DW_AT_type :$int_label
 	    } {
 		DW_TAG_variable {
-		    DW_AT_name foo
+		    DW_AT_name var_piece
 		    DW_AT_type :$foo_t_label
 		    DW_AT_location {
 			DW_OP_regx $::dwarf_regnum
@@ -108,4 +109,7 @@ if { ![runto_main] } {
     return
 }
 
-gdb_test "p/x foo" "= <optimized out>"
+# The test assumes a register size of 64 bits, ensure we have this.
+set regsize [get_sizeof "\$$regname" ""]
+gdb_assert {$regsize == 8} "ensure register size"
+gdb_test "p/x var_piece" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"

--- a/gdb/testsuite/gdb.dwarf2/dw2-op-out-param.exp
+++ b/gdb/testsuite/gdb.dwarf2/dw2-op-out-param.exp
@@ -46,7 +46,7 @@ gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?int_param_single_
 
 # (2) struct_param_single_reg_loc
 gdb_continue_to_breakpoint "Stop in breakpt for struct_param_single_reg_loc"
-gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?struct_param_single_reg_loc \\(operand0={a = 0xdeadbe00deadbe01, b = <optimized out>}, operand1={a = <optimized out>, b = 0xdeadbe04deadbe05}, operand2=<optimized out>\\)\r\n#2  ($hex in )?main \\(\\)" "backtrace for test struct_param_single_reg_loc"
+gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?struct_param_single_reg_loc \\(operand0={a = 0xdeadbe00deadbe01, b = <optimized out>}, operand1=<optimized out>, operand2=<optimized out>\\)\r\n#2  ($hex in )?main \\(\\)" "backtrace for test struct_param_single_reg_loc"
 
 # (3) struct_param_two_reg_pieces
 gdb_continue_to_breakpoint "Stop in breakpt for struct_param_two_reg_pieces"

--- a/gdb/valops.c
+++ b/gdb/valops.c
@@ -1749,7 +1749,7 @@ value_array (int lowbound, gdb::array_view<struct value *> elemvec)
     {
       val = value::allocate (arraytype);
       for (idx = 0; idx < elemvec.size (); idx++)
-	elemvec[idx]->contents_copy (val, idx * typelength, 0, 0, typelength);
+	elemvec[idx]->contents_copy (val, idx * typelength, 0, typelength);
       return val;
     }
 
@@ -1758,7 +1758,7 @@ value_array (int lowbound, gdb::array_view<struct value *> elemvec)
 
   val = value::allocate (arraytype);
   for (idx = 0; idx < elemvec.size (); idx++)
-    elemvec[idx]->contents_copy (val, idx * typelength, 0, 0, typelength);
+    elemvec[idx]->contents_copy (val, idx * typelength, 0, typelength);
   return val;
 }
 
@@ -4103,7 +4103,7 @@ value_slice (struct value *array, LONGEST lowbound, LONGEST length)
     else
       {
 	slice = value::allocate (slice_type);
-	array->contents_copy (slice, 0, offset, 0,
+	array->contents_copy (slice, 0, offset,
 			     type_length_units (slice_type));
       }
 

--- a/gdb/value.c
+++ b/gdb/value.c
@@ -1235,8 +1235,7 @@ value::ranges_copy_adjusted (struct value *dst, int dst_bit_offset,
 
 void
 value::contents_copy_raw (struct value *dst, LONGEST dst_offset,
-			  LONGEST src_offset, LONGEST src_bit_offset,
-			  LONGEST length)
+			  LONGEST src_offset, LONGEST length)
 {
   LONGEST src_total_bit_offset, dst_total_bit_offset, bit_length;
   int unit_size = gdbarch_addressable_memory_unit_size (arch ());
@@ -1272,19 +1271,10 @@ value::contents_copy_raw (struct value *dst, LONGEST dst_offset,
     = this->contents_all_raw ().slice (src_offset * unit_size,
 				       copy_length * unit_size);
 
-  if (src_bit_offset)
-    {
-      bool big_endian = type_byte_order (dst->type ()) == BFD_ENDIAN_BIG;
-
-      copy_bitwise (dst_contents.data (), 0, src_contents.data (),
-		    src_bit_offset, bit_length, big_endian);
-    }
-  else
-    gdb::copy (src_contents, dst_contents);
+  gdb::copy (src_contents, dst_contents);
 
   /* Copy the meta-data, adjusted.  */
-  src_total_bit_offset = src_offset * unit_size * HOST_CHAR_BIT
-			 + src_bit_offset;
+  src_total_bit_offset = src_offset * unit_size * HOST_CHAR_BIT;
   dst_total_bit_offset = dst_offset * unit_size * HOST_CHAR_BIT;
 
   ranges_copy_adjusted (dst, dst_total_bit_offset, src_total_bit_offset,
@@ -1335,12 +1325,24 @@ value::contents_copy_raw_bitwise (struct value *dst, LONGEST dst_bit_offset,
 
 void
 value::contents_copy (struct value *dst, LONGEST dst_offset, LONGEST src_offset,
-		      LONGEST src_bit_offset, LONGEST length)
+		      LONGEST length)
 {
   if (m_lazy)
     fetch_lazy ();
 
-  contents_copy_raw (dst, dst_offset, src_offset, src_bit_offset, length);
+  contents_copy_raw (dst, dst_offset, src_offset, length);
+}
+
+/* See value.h.  */
+
+void
+value::contents_copy_bitwise (struct value *dst, LONGEST dst_bit_offset,
+			      LONGEST src_bit_offset, LONGEST bit_length)
+{
+  if (m_lazy)
+    fetch_lazy ();
+
+  contents_copy_raw_bitwise (dst, dst_bit_offset, src_bit_offset, bit_length);
 }
 
 gdb::array_view<const gdb_byte>
@@ -3154,7 +3156,7 @@ value::primitive_field (LONGEST offset, int fieldno, struct type *arg_type)
       else
 	{
 	  v = value::allocate (enclosing_type ());
-	  contents_copy_raw (v, 0, 0, 0, enclosing_type ()->length ());
+	  contents_copy_raw (v, 0, 0, enclosing_type ()->length ());
 	}
       v->deprecated_set_type (type);
       v->set_offset (this->offset ());
@@ -3187,7 +3189,7 @@ value::primitive_field (LONGEST offset, int fieldno, struct type *arg_type)
 	{
 	  v = value::allocate (type);
 	  contents_copy_raw (v, v->embedded_offset (),
-			     embedded_offset () + offset, 0,
+			     embedded_offset () + offset,
 			     type_length_units (type));
 	}
       v->set_offset (this->offset () + offset + embedded_offset ());
@@ -3830,7 +3832,7 @@ value_from_component (struct value *whole, struct type *type, LONGEST offset)
       v = value::allocate (type);
       whole->contents_copy (v, v->embedded_offset (),
 			    whole->embedded_offset () + offset,
-			    0, type_length_units (type));
+			    type_length_units (type));
     }
   v->set_offset (whole->offset () + offset + whole->embedded_offset ());
   v->set_component_location (whole);
@@ -4056,6 +4058,7 @@ value::fetch_lazy_register ()
 {
   struct type *type = check_typedef (this->type ());
   struct value *new_val = this;
+  int unit_size = gdbarch_addressable_memory_unit_size (arch ());
 
   scoped_value_mark mark;
 
@@ -4105,9 +4108,11 @@ value::fetch_lazy_register ()
   /* Copy the contents and the unavailability/optimized-out
      meta-data from NEW_VAL to VAL.  */
   set_lazy (false);
-  new_val->contents_copy (this, embedded_offset (),
-			  new_val->embedded_offset () + offset (),
-			  bitpos (), type_length_units (type));
+  new_val->contents_copy_bitwise
+    (this, embedded_offset () * unit_size * HOST_CHAR_BIT,
+     (((new_val->embedded_offset () + offset ()) * unit_size * HOST_CHAR_BIT)
+      + bitpos ()),
+     type_length_units (type) * unit_size * HOST_CHAR_BIT);
 
   if (frame_debug)
     {
@@ -4200,7 +4205,7 @@ pseudo_from_raw_part (const frame_info_ptr &next_frame, int pseudo_reg_num,
   value *pseudo_reg_val
     = value::allocate_register (next_frame, pseudo_reg_num);
   value *raw_reg_val = value_of_register (raw_reg_num, next_frame);
-  raw_reg_val->contents_copy (pseudo_reg_val, 0, raw_offset, 0,
+  raw_reg_val->contents_copy (pseudo_reg_val, 0, raw_offset,
 			      pseudo_reg_val->type ()->length ());
   return pseudo_reg_val;
 }
@@ -4233,12 +4238,12 @@ pseudo_from_concat_raw (const frame_info_ptr &next_frame, int pseudo_reg_num,
   int dst_offset = 0;
 
   value *raw_reg_1_val = value_of_register (raw_reg_1_num, next_frame);
-  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,  0,
+  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_1_val->type ()->length ());
   dst_offset += raw_reg_1_val->type ()->length ();
 
   value *raw_reg_2_val = value_of_register (raw_reg_2_num, next_frame);
-  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_2_val->type ()->length ());
   dst_offset += raw_reg_2_val->type ()->length ();
 
@@ -4282,17 +4287,17 @@ pseudo_from_concat_raw (const frame_info_ptr &next_frame, int pseudo_reg_num,
   int dst_offset = 0;
 
   value *raw_reg_1_val = value_of_register (raw_reg_1_num, next_frame);
-  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_1_val->type ()->length ());
   dst_offset += raw_reg_1_val->type ()->length ();
 
   value *raw_reg_2_val = value_of_register (raw_reg_2_num, next_frame);
-  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_2_val->type ()->length ());
   dst_offset += raw_reg_2_val->type ()->length ();
 
   value *raw_reg_3_val = value_of_register (raw_reg_3_num, next_frame);
-  raw_reg_3_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_3_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_3_val->type ()->length ());
   dst_offset += raw_reg_3_val->type ()->length ();
 

--- a/gdb/value.h
+++ b/gdb/value.h
@@ -628,8 +628,19 @@ public:
      It is assumed the contents of DST in the [DST_OFFSET,
      DST_OFFSET+LENGTH) range are wholly available.  */
   void contents_copy (struct value *dst, LONGEST dst_offset,
-		      LONGEST src_offset, LONGEST src_bit_offset,
-		      LONGEST length);
+		      LONGEST src_offset, LONGEST length);
+
+  /* Copy BIT_LENGTH bits of this value's content starting at
+     SRC_BIT_OFFSET bits into DST value's contents, starting at
+     DST_BIT_OFFSET bits.  If unavailable contents are being copied
+     from this value, the corresponding DST contents are marked
+     unavailable accordingly.  DST must not be lazy.  If this value
+     is lazy, it will be fetched now.
+
+     It is assumed the contents of DST in the [DST_BIT_OFFSET,
+     DST_BIT_OFFSET+BIT_LENGTH) range are wholly available.  */
+  void contents_copy_bitwise (struct value *dst, LONGEST dst_bit_offset,
+			      LONGEST src_bit_offset, LONGEST bit_length);
 
   /* Given a value (offset by OFFSET bytes)
      of a struct or union type ARG_TYPE,
@@ -901,8 +912,7 @@ private:
      It is assumed the contents of DST in the [DST_OFFSET,
      DST_OFFSET+LENGTH) range are wholly available.  */
   void contents_copy_raw (struct value *dst, LONGEST dst_offset,
-			  LONGEST src_offset, LONGEST src_bit_offset,
-			  LONGEST length);
+			  LONGEST src_offset, LONGEST length);
 
   /* A helper for value_from_component_bitsize that copies bits from
      this value to DEST.  */


### PR DESCRIPTION

The recent change f204e6a13ac "gdb/dwarf2/expr: Cache the register
reads" introduced a regression where the DWARF expression evaluator can
end-up reading past the end of a buffer.  This can happen if we try to
read past the end of a register.

Prior to this change, all register reads ended up calling into
dwarf2/expr.c:read_from_register which has this guard:

    /* If a register is wholly inside the OFFSET, skip it.  */
    if (frame == NULL || !regsize
        || offset + length > regsize || numregs < regnum)
      {
        *optimized = false;
        *unavailable = true;
        return;
      }

The refactored code assumes that the read is always within the bounds of
the register, but this does not has to be true.

This patch fixes this issue by doing the necessary bounds check.  If the
read tries to go past the end of the register, we consider the
inaccessible part has been optimized out (those bits do not exist).
Because we do not have a better granularity, we report the entire value
read from the register as optimized out, not just the bits past the end
of the register.

This patch also adds a test that exercises the issue.
