### PR TITLE
gdb/amd-dbgapi-target: fix compilation error on gcc 16

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -4752,7 +4752,7 @@ info_dispatches_command (const char *args, int from_tty)
 	    else if (acquire == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_SYSTEM)
 	      ss << "As";
 
-	    if ((barrier | acquire) && release)
+	    if ((barrier || acquire) && release)
 	      ss << "|";
 
 	    if (release == AMD_DBGAPI_DISPATCH_FENCE_SCOPE_AGENT)


### PR DESCRIPTION
## Motivation

GCC 16 and up emit deprecation warnings when performing a bitwise operation between different enum types. Since ROCgdb builds with -Werror, compilation fails in amd-dbgapi-target.c :

```
  ../../gdb/amd-dbgapi-target.c:4656:26: error: bitwise operation between different enumeration types
   'amd_dbgapi_dispatch_barrier_t' and 'amd_dbgapi_dispatch_fence_scope_t' is deprecated
  [-Werror=deprecated-enum-enum-conversion]
   4656 |             if ((barrier | acquire) && release)
        |                  ~~~~~~~^~~~~~~~~~
```

## Technical Details

This commit fixes the compilation error by replacing the bitwise OR with a logical OR (`||`). The intent behind the operation is checking whether `barrier` or `acquire` have any flags set. The logical OR operation thus is the most appropriate.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
