### PR TITLE
gdb/amdgpu-tdep: Fix assertion in amdgpu_segment_address_to_core_address

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1484,10 +1484,23 @@ amdgpu_segment_address_to_core_address (arch_addr_space_id address_space_id,
   const amd_dbgapi_segment_address_t significant_bits
     = amdgpu_get_segment_address_significant_bits (current_inferior ());
 
-  /* The address must not have bits set outside of the significant bits.  */
-  gdb_assert ((significant_bits & address) == address);
-
   const amd_dbgapi_segment_address_t aspace_id_mask = ~significant_bits;
+
+  /* Handle address_space_id 0 (default address space) as a special case here.
+     In the default (global) address space, high addresses are sign extended
+     (canonical addresses).  To support this, CORE_ADDR with the all-1 value
+     in the aspace_id is considered 0.  The following functions also follow
+     the same convention:
+     - amdgpu_segment_address_from_core_address
+     - amdgpu_address_space_id_from_core_address */
+  if ((aspace_id_mask & address) == aspace_id_mask
+      && address_space_id == ARCH_ADDR_SPACE_ID_DEFAULT)
+    return address;
+
+  if ((significant_bits & address) != address)
+    error (_("Invalid address for address space %s: %s"),
+	   pulongest (address_space_id),
+	   paddress (current_inferior ()->arch (), address));
 
   uint64_t id = address_space_id;
   uint64_t mask = aspace_id_mask;

--- a/gdb/testsuite/gdb.rocm/aspace-user-input.exp
+++ b/gdb/testsuite/gdb.rocm/aspace-user-input.exp
@@ -118,4 +118,16 @@ gdb_test "x/1wx private_lane#0x0" \
     "private_lane#0x0:\[ \t\]+$hex"
 gdb_test "with language fortran -- x/1wx private_lane#0x0" \
     "private_lane#0x0:\[ \t\]+$hex"
+
+if { [istarget "x86_64-*-*"] } {
+    # On x86_64, high address (with the MSB bit set - bit 47 for 4 level page
+    # tables and bit 56 for 5 level page table) are sign extended.
+
+    # Regular high address are correctly handled.
+    gdb_test "x/x ~0ull" ".*Cannot access memory at address 0xffffffffffffffff"
+
+    # However, addresses with inconsistent bit patterns past the MSB (not all-1
+    # nor all-0) are rejected as invalid addresses.
+    gdb_test "x/x (1ull << 63) - 1" ".*Invalid address for address space 0: 0x7fffffffffffffff"
+}
 }


### PR DESCRIPTION
The code in amdgpu_segment_address_to_core_address was assuming that it could not receive an address which had bits already set in the bits where it wants to store the address space ID.  This is an invalid assumption, as a user input can forge any address that gets into this function.

I stumbled onto the issue while looking at sometging else. I wanted to inspect a wave's stack, but used the wrong register for the stack pointer, which ended up causing the assertion to trigger:

    (gdb) x/32x private_wave#$s32
    ../../gdb/amdgpu-tdep.c:1488: internal-error: amdgpu_segment_address_to_core_address: Assertion `(significant_bits & address) == address' failed.
    A problem internal to GDB has been detected,
    further debugging may prove unreliable.

This triggered the invalid expectation in
amdgpu_segment_address_to_core_address.  Because this is expressed as an assertion rather than a test triggering an error, this is not handled gracefully.

This patch fixes this by changing the assert into a "if (invalid_pred) errer (_(msg))" to gracefully handle invalid input.  While at it, the patch also improved on the check to ensure that canonical addresses (where the address is sign-extended past the significant bits).

This also adds a test that exercises consuming invalid input as well as consuming sign extended addresses.

Change-Id: I3281f68b65eb817e949378f5548169c95cbf277c