### PR TITLE
Switch to a different cluster label

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -123,5 +123,5 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: linux-gfx942-1gpu-ossci-rocm
+      test_runs_on: linux-gfx942-1gpu-core42-ossci-rocm
       artifact_run_id: ${{ github.run_id }}


### PR DESCRIPTION
The existing cluster label linux-gfx942-1gpu-ossci-rocm is going away EOD May 29th. We need to switch to the new label until end of june, when we'll need to switch again to some other label.