### PR TITLE
gdb/amdgpu-tdep: Handle PROCESS_NONE when querying address significan…

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -74,6 +74,13 @@ amdgpu_get_segment_address_significant_bits (inferior *inf)
     {
       amd_dbgapi_process_id_t process_id = get_amd_dbgapi_process_id (inf);
 
+      if (process_id == AMD_DBGAPI_PROCESS_NONE)
+	{
+	  /* There is no process running for the current inferior, all bits
+	     of a given address are to be considered significant.  */
+	  return ~(amd_dbgapi_segment_address_t {0});
+	}
+
       amd_dbgapi_segment_address_t sb;
       if (amd_dbgapi_process_get_info
 	  (process_id, AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS,


### PR DESCRIPTION
…t bits

When running gdb.base/all-architectures-*.exp, I see a fair amount of failures:

                    === gdb Summary ===

    # of expected passes            34
    # of unexpected failures        286

The failure looks like (repeated for each AMDGPU / OSABI possible pairs):

    (gdb) set osabi none
    (gdb) set architecture amdgcn:gfx90a
    The target architecture is set to "amdgcn:gfx90a".
    (gdb) disassemble 0x100,+4
    amd_dbgapi_process_get_info failed

When running this test, no program is under debug, that is "inferior_ptid == null_ptid".  When doing the disassembly, we eventually neel to build an address from the integer passed as an argument, which calls:

    value_as_address
      gdbarch_integer_to_address
        amdgpu_integer_to_address
          amdgpu_segment_address_to_core_address
            amdgpu_get_segment_address_significant_bits

In amdgpu_get_segment_address_significant_bits (introduced by c4315ba57ab "gdb/amdgcn: Dynamically select which bits to use to hold CORE_ADDR"), we need to query rocm-dbgapi to find what bits can be used by GDB to store address spaces.  This is done by the following code:

    amd_dbgapi_process_id_t process_id = get_amd_dbgapi_process_id (inf);

    amd_dbgapi_segment_address_t sb;
    if (amd_dbgapi_process_get_info
        (process_id, AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS,
         sizeof (sb), &sb)
        != AMD_DBGAPI_STATUS_SUCCESS)
      error (_("amd_dbgapi_process_get_info failed"));

In this particular case, because we do not have a process running, process_id is AMD_DBGAPI_PROCESS_NONE, which is why the call to amd_dbgapi_process_get_info fails.

This patch proposes to fix this by explicitly checking for AMD_DBGAPI_PROCESS_NONE.  If this case is detected, make amdgpu_get_segment_address_significant_bits return that no bit is insignificant.

With this patch, I can run the gdb.base/all-architectures-*.exp testcases and have the expected all-PASS.

Tested on x86-64 Linux + gfx1031.

Change-Id: If89172f41262ffb52c99914750cdec758d0067da

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
