### PR TITLE
[ci] Rename therock-archives target to therock-artifacts

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 54acd32c58aa0b5c2911b42b53bc23b0e0ddd6d6 # 05/05/2026
+  THEROCK_COMMIT_REF: a9fd5ab0f5313ebccf599f3e198cb28b13233c84 # 2026-06-02
 
 jobs:
   therock-build-linux:
@@ -80,17 +80,14 @@ jobs:
       - name: Build therock-dist
         run: cmake --build build
 
-      - name: Build therock-archives
-        run: cmake --build build --target therock-archives
+      - name: Build therock-artifacts
+        run: cmake --build build --target therock-artifacts
 
       - name: Report
         run: |
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm
-          echo "Artifact Archives:"
-          echo "------------------"
-          ls -lh build/artifacts/*.tar.xz
           echo "Artifacts:"
           echo "----------"
           du -h -d 1 build/artifacts
@@ -105,6 +102,13 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-ci-external
+
+      - name: Push artifacts
+        run: |
+          python3 build_tools/artifact_manager.py push \
+            --run-id ${{ github.run_id }} \
+            --build-dir build \
+            --stage all
 
       - name: Post Build Upload
         if: always()

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 54acd32c58aa0b5c2911b42b53bc23b0e0ddd6d6 # 05/05/2026
+  THEROCK_COMMIT_REF: a9fd5ab0f5313ebccf599f3e198cb28b13233c84 # 2026-06-02
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
   THEROCK_BIN_DIR: "./build/bin"


### PR DESCRIPTION
TheRock has replaced the therock-archives CMake target (which produced
*.tar.xz files) with therock-artifacts, and added artifact_manager.py
to push the resulting artifacts. Mirror the rocm-libraries TheRock CI
workflow:

  - bump THEROCK_COMMIT_REF to a9fd5ab0f5313ebccf599f3e198cb28b13233c84
    (2026-06-02) in both therock-ci-linux.yml and
    therock-test-packages.yml,
  - rename the build target from therock-archives to therock-artifacts,
  - drop the now-obsolete *.tar.xz listing from the report step,
  - add a "Push artifacts" step that invokes
    build_tools/artifact_manager.py to push all stages for the current
    run.