### PR TITLE
Wrap mi-attach in with_rocm_gpu_lock

### DIFF
--- a/gdb/testsuite/gdb.rocm/mi-attach.exp
+++ b/gdb/testsuite/gdb.rocm/mi-attach.exp
@@ -25,9 +25,11 @@ if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
     return
 }
 
-set spawn_id [spawn_wait_for_attach $::binfile]
-set prog_pid [spawn_id_get_pid $spawn_id]
+with_rocm_gpu_lock {
+    set spawn_id [spawn_wait_for_attach $::binfile]
+    set prog_pid [spawn_id_get_pid $spawn_id]
 
-mi_clean_restart
+    mi_clean_restart
 
-mi_gdb_test "-target-attach $prog_pid" ".*\\^done.*" "attach \$PROG_PID"
+    mi_gdb_test "-target-attach $prog_pid" ".*\\^done.*" "attach \$PROG_PID"
+}


### PR DESCRIPTION
mi-attach.exp exercises the GPU but did not call with_rocm_gpu_lock,
so it ran without any coordination against the rest of the gdb.rocm
suite under GDB_PARALLEL.  An unlocked GPU-using test can clash with
a concurrently running rocm test that holds the GPU lock, producing
spurious failures driven by contention on kfd/dbgapi rather than by
the code under test.

Wrap the GPU-using portion in with_rocm_gpu_lock so it participates
in the existing per-GPU serialisation like the other rocm tests.