### PR TITLE
gdb/testsuite: fix pipe iteration of gdb.rocm/runtime-core.exp

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -62,7 +62,7 @@ proc do_test { fault core_type output_type } {
     set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
-	set coredump [rocm_core_find $::binfile {} $fault $use_pipe]
+	set coredump [rocm_core_find $::binfile {} $fault "/dev/null" $use_pipe]
     }
 
     if {$coredump eq ""} {

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -569,7 +569,7 @@ proc hip_device_is_less_than { version } {
 proc rocm_core_find_1 {coredir binfile arg output_file \
 		       {use_pipe false}} {
     if { $use_pipe } {
-	set coredump_pattern "|tee $coredir/$binfile"
+	set coredump_pattern "|tee $coredir/gpucore.%p"
     } else {
 	set coredump_pattern "gpucore.%p"
     }


### PR DESCRIPTION
Commit 3829f5d7ce5 ("gdb/testsuite: Extend gdb.rocm/runtime-core.exp with piped GPU coredumps") added a "pipe" output iteration to runtime-core.exp, but the test never actually exercised the pipe path due to two bugs:

1. The call site in runtime-core.exp passes use_pipe as the 4th positional argument to rocm_core_find:

       rocm_core_find $::binfile {} $fault $use_pipe

   but the proc's 4th parameter is output_file, with use_pipe being the 5th:

       proc rocm_core_find {binfile {deletefiles {}} {arg ""} \
                            {output_file "/dev/null"} {use_pipe false}}

   As a result, $use_pipe was bound to output_file, and use_pipe defaulted to false.  The "pipe" iteration silently ran the same code as the "file" iteration.

2. With (1) fixed, the pipe coredump pattern "|tee \$coredir/\$binfile" writes the GPU core to a file named after the binary, but the subsequent search uses "glob gpucore.*" which does not match. The pipe iteration would therefore fail to locate the GPU core and return "", producing UNTESTED.

Fix the call site to pass /dev/null explicitly for output_file, and change the pipe pattern to "|tee \$coredir/gpucore.%p" so the glob finds the resulting file (mirroring the non-pipe pattern).