### PR TITLE
gdb.rocm/update-thread-list.exp: Avoid "update" in exe name

### DIFF
--- a/gdb/testsuite/gdb.rocm/update-thread-list.exp
+++ b/gdb/testsuite/gdb.rocm/update-thread-list.exp
@@ -25,7 +25,14 @@ require allow_hipcc_tests
 
 standard_testfile .cpp
 
-if {[prepare_for_testing "failed to prepare ${testfile}" $testfile $srcfile {debug hip}]} {
+# Don't use $testfile as the executable name, because Windows'
+# installer detection heuristic refuses to launch executables whose
+# name contains "update" (and a few other keywords like "setup",
+# "install", "patch") without elevation, failing with
+# ERROR_ELEVATION_REQUIRED (740).
+set executable "test"
+
+if {[prepare_for_testing "failed to prepare ${testfile}" $executable $srcfile {debug hip}]} {
     return -1
 }
 


### PR DESCRIPTION
Running gdb.rocm/update-thread-list.exp on Windows 11 fails because GDB cannot spawn the inferior:

 (gdb) run
 Starting program: .../gdb.rocm/update-thread-list/update-thread-list
 Error creating process .../update-thread-list (error 740): The requested operation requires elevation.

Error 740 is ERROR_ELEVATION_REQUIRED.

Windows has an "installer detection" heuristic that refuses to launch executables whose filename contains keywords like "update", "setup", "install" or "patch" without elevation (admin rights), unless the PE embeds a manifest declaring requestedExecutionLevel="asInvoker".

I found some older Microsoft documentation claiming that the heuristic only applies to 32-bit binaries, but what I observe is that:

 - It still triggers with 64-bit PEs on current Windows.

 - Matches "update" as a substring anywhere in the filename (not just as a prefix).

 - Is not drive-dependent.  I thought moving the process to a dev drive might suppress it, but it does not.

Fix it by passing an explicit executable name to prepare_for_testing, so the on-disk binary is "test" instead of "update-thread-list".

Change-Id: I974616de4c08d702671a8316d822360398dfdf85

## Motivation

One fewer testcase failing on Windows.

## Technical Details

See commit log.

## Test Plan

Tested on Linux & Windows.

## Test Result

Happiness.

## Submission Checklist

- [x] Onions.