### PR TITLE
Backport Windows UTF-8 fixes

### DIFF
--- a/gdb/NEWS
+++ b/gdb/NEWS
@@ -35,6 +35,15 @@
 
 * Support for the binary file format dbx has been removed.
 
+* When running on the Windows Terminal console, GDB now supports
+  true-color 24-bit colors.
+
+* When running on the Windows Terminal console whose output codepage
+  is 65001, GDB now supports emoji styling and display of UTF-8
+  encoded text in general.  The host charset in that case will be
+  automatically set to UTF-8.  (Users can use the Windows 'chcp'
+  command to change the output codepage of the console.)
+
 * New targets
 
 GNU/Linux/MicroBlaze (gdbserver) microblazeel-*linux*

--- a/gdb/charset.c
+++ b/gdb/charset.c
@@ -19,6 +19,7 @@
 
 #include "charset.h"
 #include "cli/cli-cmds.h"
+#include "cli/cli-style.h"
 #include "gdbsupport/gdb_obstack.h"
 #include "gdbsupport/gdb_wait.h"
 #include "charset-list.h"
@@ -1009,11 +1010,28 @@ INIT_GDB_FILE (charset)
   {
     /* "CP" + x<=5 digits + paranoia.  */
     static char w32_host_default_charset[16];
+    unsigned codepage = mingw_get_codeset ();
 
-    snprintf (w32_host_default_charset, sizeof w32_host_default_charset,
-	      "CP%d", GetACP());
+    /* The rest of the code expects a literal "UTF-8" and doesn't know
+       anything about codepage 65001.  */
+    if (codepage == 65001)
+      {
+	strcpy (w32_host_default_charset, "UTF-8");
+	/* This is needed to force Windows CRT output functions treat
+	   output as simple stream of bytes, instead of trying to
+	   interpret it as encoded non-ASCII text, which will fail if
+	   the system locale's codeset is NOT UTF-8.  */
+	setlocale (LC_CTYPE, "C");
+      }
+    else
+      snprintf (w32_host_default_charset, sizeof w32_host_default_charset,
+		"CP%u", codepage);
     auto_host_charset_name = w32_host_default_charset;
     auto_target_charset_name = auto_host_charset_name;
+
+    /* Windows Terminal supports Emoji when using UTF-8 output.  */
+    if (strcmp (w32_host_default_charset, "UTF-8") != 0)
+      no_emojis ();
   }
 #endif
 #endif

--- a/gdb/charset.h
+++ b/gdb/charset.h
@@ -165,4 +165,8 @@ char host_letter_to_control_character (char c);
 #define HOST_UTF32 "UTF-32LE"
 #endif
 
+#ifdef __MINGW32__
+  unsigned int mingw_get_codeset ();
+#endif
+
 #endif /* GDB_CHARSET_H */

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -30954,8 +30954,9 @@ Show the current state of styling.
 Enable or disable the use of emoji.  On most hosts, the default is
 @samp{auto}, meaning that emoji will only be used if the host
 character set is @samp{UTF-8}; however, on Windows the default is
-@samp{off} when using the console.  Note that disabling styling as a
-whole will also prevent emoji display.
+@samp{off} when using the console, unless the console's output
+codepage is 65001, the Windows UTF-8 codepage.  Note that disabling
+styling as a whole will also prevent emoji display.
 
 Currently, emoji are printed whenever @value{GDBN} reports an error or
 a warning.

--- a/gdb/mingw-hdep.c
+++ b/gdb/mingw-hdep.c
@@ -18,7 +18,9 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include "main.h"
+#include "top.h"
 #include "serial.h"
+#include "gdb_curses.h"
 #include "gdbsupport/event-loop.h"
 #include "gdbsupport/gdb_select.h"
 #include "inferior.h"
@@ -209,14 +211,23 @@ rgb_to_16colors (const ui_file_style::color &color)
   return retval;
 }
 
-/* Zero if not yet initialized, 1 if stdout is a console device, else -1.  */
-static int mingw_console_initialized;
+/* Zero if not yet initialized, 1 if using legacy console APIs (as
+   opposed to stdio writes to the console), else -1.  */
+static int mingw_use_console_color_apis;
 
 /* Handle to stdout . */
 static HANDLE hstdout = INVALID_HANDLE_VALUE;
 
 /* Text attribute to use for normal text (the "none" pseudo-color).  */
 static SHORT norm_attr;
+
+/* Original console output mode as found at startup.  */
+static DWORD orig_console_mode;
+
+/* Console output mode flags we need for processing Virtual Terminal
+   Sequences, including colors and bold/dim attributes.  */
+static DWORD virt_mode_flags
+  = (ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 
 /* Initialize settings related to the console.  */
 
@@ -231,14 +242,60 @@ windows_initialize_console ()
       && GetConsoleMode (hstdout, &cmode) != 0
       && GetConsoleScreenBufferInfo (hstdout, &csbi))
     {
+      if (!orig_console_mode)
+	orig_console_mode = cmode;
       norm_attr = csbi.wAttributes;
-      mingw_console_initialized = 1;
+      /* Default to Virtual Terminal Sequences for colors etc.  */
+      mingw_use_console_color_apis = -1;
+      /* Windows Terminal already sets these flags by default, but the
+	 legacy ConHost doesn't.  */
+      if ((cmode & virt_mode_flags) != virt_mode_flags)
+	{
+	  cmode |= virt_mode_flags;
+	  if (!SetConsoleMode (hstdout, cmode))
+	    mingw_use_console_color_apis = 1; /* use older console APIs */
+	}
     }
   else if (hstdout != INVALID_HANDLE_VALUE)
-    mingw_console_initialized = -1; /* valid, but not a console device */
+    mingw_use_console_color_apis = -1; /* valid, but not a console device */
 
-  if (mingw_console_initialized > 0)
+  if (mingw_use_console_color_apis > 0)
     no_emojis ();
+}
+
+void
+mingw_deinitialize_console ()
+{
+  if (mingw_use_console_color_apis != 0
+      && hstdout != INVALID_HANDLE_VALUE
+      && orig_console_mode != 0)
+    SetConsoleMode (hstdout, orig_console_mode);
+}
+
+/* Replacement for a direct tgetnum ("Co") call to get the number of
+   colors supported by the terminal where GDB is running.  */
+int
+gdb_get_ncolors ()
+{
+  /* ncurses versions prior to 6.1 (and other curses
+     implementations) declare the tgetnum argument to be
+     'char *', so we need the const_cast, since C++ will not
+     implicitly convert.  */
+  int nc = tgetnum (const_cast<char*> ("Co"));
+  /* MS-Windows terminal generally doesn't have "Co" in its terminfo,
+     but always supports at least 8 colors.  */
+  if (nc <= 0)
+    {
+      nc = 8;
+      /* If we are using Virtual Terminal Sequences, we can support
+	 true-color 24-bit colors.  */
+      if (mingw_use_console_color_apis < 0
+	  && hstdout != INVALID_HANDLE_VALUE
+	  && orig_console_mode != 0)
+	nc = 16777216;
+    }
+
+  return nc;
 }
 
 /* The most recently applied style.  */
@@ -252,7 +309,7 @@ gdb_console_fputs (const char *linebuf, FILE *fstream)
 {
   /* If our stdout is not a console device, let the default 'fputs'
      handle the task. */
-  if (mingw_console_initialized <= 0)
+  if (mingw_use_console_color_apis <= 0)
     return 0;
 
   /* Mapping between 8 ANSI colors and Windows console attributes.  */

--- a/gdb/posix-hdep.c
+++ b/gdb/posix-hdep.c
@@ -20,6 +20,8 @@
 #include "gdbsupport/event-loop.h"
 #include "gdbsupport/gdb_select.h"
 #include "inferior.h"
+#include "ui-style.h"
+#include "gdb_curses.h"
 #include <signal.h>
 
 /* Wrapper for select.  Nothing special needed on POSIX platforms.  */
@@ -37,6 +39,18 @@ int
 gdb_console_fputs (const char *buf, FILE *f)
 {
   return 0;
+}
+
+/* Host-dependent method to get the number of colors supported by the
+   terminal where GDB is run.  Posix platforms simply call 'tgetnum'.  */
+int
+gdb_get_ncolors ()
+{
+  /* ncurses versions prior to 6.1 (and other curses
+     implementations) declare the tgetnum argument to be
+     'char *', so we need the const_cast, since C++ will not
+     implicitly convert.  */
+  return tgetnum (const_cast<char*> ("Co"));
 }
 
 /* See inferior.h.  */

--- a/gdb/top.c
+++ b/gdb/top.c
@@ -1724,6 +1724,10 @@ undo_terminal_modifications_before_exit (void)
 #endif
   gdb_disable_readline ();
 
+#ifdef __MINGW32__
+  mingw_deinitialize_console ();
+#endif
+
   current_ui = saved_top_level;
 }
 

--- a/gdb/top.h
+++ b/gdb/top.h
@@ -133,4 +133,8 @@ extern bool check_quiet_mode ();
 
 extern void unbuffer_stream (FILE *stream);
 
+#ifdef __MINGW32__
+extern void mingw_deinitialize_console ();
+#endif
+
 #endif /* GDB_TOP_H */

--- a/gdb/ui-style.c
+++ b/gdb/ui-style.c
@@ -594,11 +594,7 @@ colorsupport ()
     {
       std::vector<color_space> result = {color_space::MONOCHROME};
 
-      /* ncurses versions prior to 6.1 (and other curses
-	 implementations) declare the tgetnum argument to be
-	 'char *', so we need the const_cast, since C++ will not
-	 implicitly convert.  */
-      int colors = tgetnum (const_cast<char*> ("Co"));
+      int colors = gdb_get_ncolors ();
 #ifdef __MINGW32__
       /* MS-Windows terminal generally doesn't have "Co" in its
 	 terminfo, but always supports at least 8 colors.  */
@@ -613,8 +609,10 @@ colorsupport ()
 	result.push_back (color_space::XTERM_256COLOR);
 
       const char *colorterm = getenv ("COLORTERM");
-      if (colorterm != nullptr && (!strcmp (colorterm, "truecolor")
-	  || !strcmp (colorterm, "24bit")))
+      if (colors >= 16777216
+	  || (colorterm != nullptr
+	      && (!strcmp (colorterm, "truecolor")
+		  || !strcmp (colorterm, "24bit"))))
 	result.push_back (color_space::RGB_24BIT);
 
       return result;

--- a/gdb/ui-style.c
+++ b/gdb/ui-style.c
@@ -599,6 +599,12 @@ colorsupport ()
 	 'char *', so we need the const_cast, since C++ will not
 	 implicitly convert.  */
       int colors = tgetnum (const_cast<char*> ("Co"));
+#ifdef __MINGW32__
+      /* MS-Windows terminal generally doesn't have "Co" in its
+	 terminfo, but always supports at least 8 colors.  */
+      if (colors <= 0)
+	colors = 8;
+#endif
       if (colors >= 8)
 	result.push_back (color_space::ANSI_8COLOR);
       if (colors >= 16)

--- a/gdb/ui-style.h
+++ b/gdb/ui-style.h
@@ -51,6 +51,9 @@ extern const char * color_space_name (color_space c);
 /* Cast C to RESULT and return true if it's value is valid; false otherwise.  */
 extern bool color_space_safe_cast (color_space *result, long c);
 
+/* Get the number of colors supported by the terminal where GDB is running.  */
+extern int gdb_get_ncolors ();
+
 /* Styles that can be applied to a ui_file.  */
 struct ui_file_style
 {


### PR DESCRIPTION
## Motivation

Fix problems like:

```
 Thread 7 "kernel" hit Hardware watchpoint 3: array
 Old value = \<error reading variable: Converting character sets: Invalid argument.\>
 New value = \<error reading variable: Converting character sets: Invalid argument.\>
```

... when the Windows codepage is UTF-8 (65001).

## Technical Details

Pick fixes from upstream.  See commit logs for details.

The main fix is in commit "gdb: Support UTF-8 output on MS-Windows terminal".
The other commits are dependencies of that one.

(And yes, one of the commits does not have a proper subject, it was already like that upstream.)

## Test Plan

Run gdb.rocm/ tests on Windows.

## Test Result

Codepage problems went away.  Results look as good as with a non-UTF-8 codepage.