### PR TITLE
gdb.rocm/update-thread-list.exp: Drop "patch" from elevation keyword list

### DIFF
--- a/gdb/testsuite/gdb.rocm/update-thread-list.exp
+++ b/gdb/testsuite/gdb.rocm/update-thread-list.exp
@@ -27,9 +27,9 @@ standard_testfile .cpp
 
 # Don't use $testfile as the executable name, because Windows'
 # installer detection heuristic refuses to launch executables whose
-# name contains "update" (and a few other keywords like "setup",
-# "install", "patch") without elevation, failing with
-# ERROR_ELEVATION_REQUIRED (740).
+# name contains "update" (and a few other keywords like "setup" and
+# "install") without elevation, failing with ERROR_ELEVATION_REQUIRED
+# (740).
 set executable "test"
 
 if {[prepare_for_testing "failed to prepare ${testfile}" $executable $srcfile {debug hip}]} {


### PR DESCRIPTION
## Motivation

Commit 5003a3aee79 ("gdb.rocm/update-thread-list.exp: Avoid "update" in exe name") listed "patch" among the keywords that trigger Windows' installer-detection heuristic.  That was based on documentation floating around the web, but it turns out to be wrong: an executable whose name contains "patch" runs fine.

Remove "patch" from the comment to avoid confusion.

## Technical Details

Just a comment change.

## Test Plan

Make sure gdb.rocm/update-thread-list.exp still passes.

## Test Result

It still passes.
