### PR TITLE
gdb, amdgpu: use segment address in amdgpu_get_watchable_aliases

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1832,9 +1832,10 @@ amdgpu_get_watchable_aliases (struct gdbarch *gdbarch,
 			      ptid_t ptid, int simd_lane,
 			      addr_range range)
 {
-  CORE_ADDR addr = range.addr;
+  CORE_ADDR addr
+    = amdgpu_segment_address_from_core_address (range.addr);
   arch_addr_space_id addr_space_id
-    = amdgpu_address_space_id_from_core_address (addr);
+    = amdgpu_address_space_id_from_core_address (range.addr);
   size_t size = range.size;
 
   /* Addresses from the default address space are always watchable.  */


### PR DESCRIPTION
When converting an address to an alias, pass the segment address to dbgapi.  The original core address potentially contains address space bits and it should not be used verbatim.

A regression test could not be included with this patch because the bug is exposed when using a generic address that points to the global address space, and another bug in dbgapi prevents converting such addresses correctly.  However, gdb.rocm/aspace-watchpoint.exp contains tests that will cover the change introduced by this patch when address space information at the type level is handled by GDB.  So, we will have coverage.

## Motivation

Fixing a potential bug.

## Technical Details

See the description.

## Test Plan

There is future coverage.

