### PR TITLE
gdb.rocm/names.exp: build test program with optimizations

### DIFF
--- a/gdb/testsuite/gdb.rocm/names.exp
+++ b/gdb/testsuite/gdb.rocm/names.exp
@@ -21,7 +21,10 @@ require allow_hipcc_tests
 
 standard_testfile .cpp
 
-if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {
+# Optimize: at -O0 the kernels use scratch memory, which limits GPU
+# concurrency below what wait_all_kernels needs and causes a deadlock.
+if {[build_executable "failed to prepare" $testfile $srcfile \
+	 {debug hip optimize=-O2}]} {
     return
 }
 
@@ -69,7 +72,7 @@ set all_kernels_info {
     {long_kernel_name_0123456789                  long_kernel-0245 {long_kernel_name_0123456789 ()}}
     {long_kernel_name_abcdefghijklmnopqrstuvwxyz  long_kernel-479c {long_kernel_name_abcdefghijklmnopqrstuvwxyz ()}}
     {templ_non_type                               templ_non_type   {templ_non_type<(E)0> ()}}
-    {templ_type                                   templ_type       {templ_type<int, long> (args=1, args=2)}}
+    {templ_type                                   templ_type       {templ_type<int, long> (args=<optimized out>, args=<optimized out>)}}
 }
 
 # By default, the runtime allows 4 hardware queues max, which limits


### PR DESCRIPTION
When running on gfx90a, the test program for gdb.rocm/names.exp hangs when running all kernels:

    $ GPU_MAX_HW_QUEUES=32 testsuite/outputs/gdb.rocm/names/names all
    *hangs*

When debugging with GDB, I see 4 running waves waiting in function wait_all_kernels, and kernels_seen is 4, meaning that the other kernels didn't start.  I noticed that if I compiled the test program at -O2, it ran fine.  Claude identified this as a resource issue:

    ● I extracted the kernel metadata from both binaries to compare. Here's the cause:

      names-0 (-O0), per kernel:
      - vgpr_count: 43, sgpr_count: 42
      - private_segment_fixed_size: 72 (or 88/104)
      - uses_dynamic_stack: true

      names-2 (-O2), per kernel:
      - vgpr_count: 3, sgpr_count: 9
      - private_segment_fixed_size: 0
      - uses_dynamic_stack: false

      At -O2 each kernel uses 3 VGPRs and no scratch, so the GPU happily
      runs all 9 waves concurrently and they unblock each other. At -O0 every
      kernel needs a scratch frame (private_segment_fixed_size > 0,
      uses_dynamic_stack: true) — HIP/ROCm has to allocate a scratch buffer
      per queue, sized for the max possible occupancy. On gfx90a with 9
      streams all demanding scratch (plus the higher VGPR/SGPR footprint), the
      runtime can only get 4 waves resident at a time. The thread state you
      posted confirms exactly that: 4 waves spinning at wait_all_kernels, the
      other 5 never get launched, kernels_seen plateaus at 4, deadlock.

      Why -O0 brought scratch in: with optimization off, the small
      locals in wait_all_kernels plus the call frame for the non-inlined call
      don't fit in registers, so the compiler spills to private memory and the
      kernel becomes a "real" call frame (dynamic stack) instead of a leaf
      with everything in registers.

Build with -O2 so all kernels can be in flight concurrently.

At -O2, the argument values appear to be optimized out, so update the expected frame function string.  I don't think that it matters for this test that we are losing the actual argument values.  I just hope that they will indeed always be optimized out.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
