### PR TITLE
[amd-staging-rocgdb-16] 2026-06-12 cherry-picks

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: a9fd5ab0f5313ebccf599f3e198cb28b13233c84 # 2026-06-02
+  THEROCK_COMMIT_REF: 25083b016c475a65cbea46ae7326104680bff1d5 # 2026-06-08
 
 jobs:
   therock-build-linux:
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:48492540591673fdc8d51beb89bde41e7ba13cbb528f643c0a481ba42c4058f2 # 2026-04-17T00:02:57.922524016Z
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:f9fa413c34844c17684f4f5f5abb6192491153b5a2dd2ec8adcba55943ff6f49 # 2026-06-04
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -29,7 +29,6 @@ env:
   THEROCK_COMMIT_REF: 25083b016c475a65cbea46ae7326104680bff1d5 # 2026-06-08
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
-  THEROCK_BIN_DIR: "./build/bin"
 
 jobs:
   rocgdb-tests:
@@ -68,4 +67,4 @@ jobs:
 
       - name: Run rocgdb tests
         run: |
-          python build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+          python ${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: a9fd5ab0f5313ebccf599f3e198cb28b13233c84 # 2026-06-02
+  THEROCK_COMMIT_REF: 25083b016c475a65cbea46ae7326104680bff1d5 # 2026-06-08
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
   THEROCK_BIN_DIR: "./build/bin"

--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -10,6 +10,9 @@ Full documentation for ROCgdb is available at
 - Dumping core of AMD GPU programs with the "gcore" command is now
   significantly faster, particularly for kernels that use small
   amounts of VRAM.
+- New "catch hiperr" command that stops the inferior when a HIP API
+  call returns an error.  The convenience variable `$_hiperr` holds
+  the error code at the catchpoint.
 
 ## ROCgdb-16-3 for ROCm-7.13
 

--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -10,9 +10,6 @@ Full documentation for ROCgdb is available at
 - Dumping core of AMD GPU programs with the "gcore" command is now
   significantly faster, particularly for kernels that use small
   amounts of VRAM.
-- New "catch hiperr" command that stops the inferior when a HIP API
-  call returns an error.  The convenience variable `$_hiperr` holds
-  the error code at the catchpoint.
 
 ## ROCgdb-16-3 for ROCm-7.13
 

--- a/gdb/Makefile.in
+++ b/gdb/Makefile.in
@@ -1048,6 +1048,7 @@ COMMON_SFILES = \
 	blockframe.c \
 	break-catch-exec.c \
 	break-catch-fork.c \
+	break-catch-hiperr.c \
 	break-catch-load.c \
 	break-catch-sig.c \
 	break-catch-syscall.c \

--- a/gdb/aarch64-tdep.c
+++ b/gdb/aarch64-tdep.c
@@ -3221,7 +3221,7 @@ aarch64_sme_pseudo_register_read (gdbarch *gdbarch, const frame_info_ptr &next_f
     {
       int src_offset = offsets.starting_offset + chunks * offsets.stride_size;
       int dst_offset = chunks * offsets.chunk_size;
-      za_value->contents_copy (result, dst_offset, src_offset, 0,
+      za_value->contents_copy (result, dst_offset, src_offset,
 			       offsets.chunk_size);
     }
 

--- a/gdb/ada-lang.c
+++ b/gdb/ada-lang.c
@@ -569,7 +569,7 @@ coerce_unspec_val_to_type (struct value *val, struct type *type)
       else
 	{
 	  result = value::allocate (type);
-	  val->contents_copy (result, 0, 0, 0, type->length ());
+	  val->contents_copy (result, 0, 0, type->length ());
 	}
       result->set_component_location (val);
       result->set_bitsize (val->bitsize ());

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -1828,6 +1828,17 @@ amd64_linux_remove_non_address_bits_watchpoint (gdbarch *gdbarch,
   return (addr & amd64_linux_lam_untag_mask ());
 }
 
+/* The AMD64 Linux ABI version of fetch_hiperr_parameters.  */
+
+static std::optional<hiperr_parameters>
+amd64_linux_fetch_hiperr_parameters (frame_info_ptr frame)
+{
+  CORE_ADDR struct_addr
+    = value_as_address (value_of_register (AMD64_RDI_REGNUM, frame));
+
+  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+}
+
 static void
 amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
 			    int num_disp_step_buffers)
@@ -1882,6 +1893,10 @@ amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
 
   set_gdbarch_remove_non_address_bits_watchpoint
     (gdbarch, amd64_linux_remove_non_address_bits_watchpoint);
+
+  /* Extract hiperr parameters for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_parameters
+    (gdbarch, amd64_linux_fetch_hiperr_parameters);
 }
 
 static void

--- a/gdb/amd64-tdep.c
+++ b/gdb/amd64-tdep.c
@@ -41,6 +41,7 @@
 #include "i387-tdep.h"
 #include "gdbsupport/x86-xstate.h"
 #include <algorithm>
+#include <string>
 #include "target-descriptions.h"
 #include "arch/amd64.h"
 #include "producer.h"
@@ -1059,6 +1060,81 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
   return sp + 16;
 }
 
+
+/* Extract HIP error parameters from the STRUCT_ADDR which is
+   a struct address passed to "__hipOnError ()" as an argument.
+
+   Only when all the parameters are retrieved successfully, return
+   them as the result.  Otherwise [1], return an std::nullopt.
+
+   [1]
+   - The "version" was not expected
+   - Not all the fields were read successfully
+   - Not all the strings were read successfully
+*/
+
+std::optional<hiperr_parameters>
+amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
+{
+  /* The HIP error parameters are packed in a struct with the following format:
+
+     struct {
+	uint32_t version;
+	uint32_t err_no;
+	const char *err_name;
+	const char *err_str;
+     };
+
+    The "version" is bumped when more fields are added to the structure.
+    Newer versions must keep backward compatibility with the previous ones,
+    by only tacking new fields at the end of the structure, so that older
+    clients can still extract the parameters they know.
+  */
+
+  /* Cover the version (4), number (4) and two pointers (2*8).  */
+  constexpr size_t buf_size = 24;
+  gdb_byte buf[buf_size];
+  CORE_ADDR addr;
+  uint32_t version, err_no;
+  gdb::unique_xmalloc_ptr<char> str, err_name, err_str;
+  enum bfd_endian byte_order = gdbarch_byte_order (get_frame_arch (frame));
+
+  /* Read the whole struct in one go.  */
+  if (target_read_memory (struct_addr, buf, buf_size) != 0)
+    return std::nullopt;
+
+  /* Get the version.  */
+  version = extract_unsigned_integer (buf, 4, byte_order);
+  /* Use less-than because versioning is designed to be ABI backwards
+     compatible.  See note above.  */
+  if (version < 1)
+    {
+      warning (_("version '%s' for HIP error parameters is not supported."),
+	       pulongest (version));
+      return std::nullopt;
+    }
+
+  /* The error code.  */
+  err_no = extract_unsigned_integer (buf + 4, 4, byte_order);
+
+  /* The error name.  */
+  addr = extract_unsigned_integer (buf + 8, 8, byte_order);
+  str = target_read_string (addr, -1);
+  if (str == nullptr)
+    return std::nullopt;
+  err_name = std::move (str);
+
+  /* The error description.  */
+  addr = extract_unsigned_integer (buf + 16, 8, byte_order);
+  str = target_read_string (addr, -1);
+  if (str == nullptr)
+    return std::nullopt;
+  err_str = std::move (str);
+
+  return hiperr_parameters {err_no, std::move (err_name), std::move (err_str)};
+}
+
+
 /* Displaced instruction handling.  */
 
 /* A partially decoded instruction.

--- a/gdb/amd64-tdep.h
+++ b/gdb/amd64-tdep.h
@@ -133,6 +133,12 @@ extern void amd64_collect_fxsave (const struct regcache *regcache, int regnum,
 /* Similar to amd64_collect_fxsave, but use XSAVE extended state.  */
 extern void amd64_collect_xsave (const struct regcache *regcache,
 				 int regnum, void *xsave, int gcore);
+
+/* Helper routine to fetch error parameters of a HIP error from the
+   STRUCT_ADDR within the FRAME context.  */
+
+extern std::optional<hiperr_parameters> amd64_fetch_hiperr_parameters
+  (frame_info_ptr frame, CORE_ADDR struct_addr);
 
 /* Floating-point register set. */
 extern const struct regset amd64_fpregset;

--- a/gdb/amd64-windows-tdep.c
+++ b/gdb/amd64-windows-tdep.c
@@ -1280,6 +1280,17 @@ amd64_windows_auto_wide_charset (void)
   return "UTF-16";
 }
 
+/* The AMD64 Windows ABI version of fetch_hiperr_parameters.  */
+
+static std::optional<hiperr_parameters>
+amd64_windows_fetch_hiperr_parameters (frame_info_ptr frame)
+{
+  CORE_ADDR struct_addr
+    = value_as_address (value_of_register (AMD64_RCX_REGNUM, frame));
+
+  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+}
+
 /* Common parts for gdbarch initialization for Windows and Cygwin on AMD64.  */
 
 static void
@@ -1323,6 +1334,10 @@ amd64_windows_init_abi_common (gdbarch_info info, struct gdbarch *gdbarch)
   set_gdbarch_core_pid_to_str (gdbarch, windows_core_pid_to_str);
 
   set_gdbarch_auto_wide_charset (gdbarch, amd64_windows_auto_wide_charset);
+
+  /* Extract hiperr parameters for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_parameters
+    (gdbarch, amd64_windows_fetch_hiperr_parameters);
 }
 
 /* gdbarch initialization for Windows on AMD64.  */

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1835,9 +1835,10 @@ amdgpu_get_watchable_aliases (struct gdbarch *gdbarch,
 			      ptid_t ptid, int simd_lane,
 			      addr_range range)
 {
-  CORE_ADDR addr = range.addr;
+  CORE_ADDR addr
+    = amdgpu_segment_address_from_core_address (range.addr);
   arch_addr_space_id addr_space_id
-    = amdgpu_address_space_id_from_core_address (addr);
+    = amdgpu_address_space_id_from_core_address (range.addr);
   size_t size = range.size;
 
   /* Addresses from the default address space are always watchable.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -1,0 +1,298 @@
+/* Everything about catching HIP API errors ("catch hiperr").
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc.  All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include "annotate.h"
+#include "arch-utils.h"
+#include "breakpoint.h"
+#include "cli/cli-decode.h"
+#include "extract-store-integer.h"
+#include "inferior.h"
+#include "gdbarch.h"
+#include "progspace.h"
+#include "language.h"
+#include "stack.h"
+#include "valprint.h"
+
+struct hiperr_catchpoint : public code_breakpoint
+{
+  hiperr_catchpoint (struct gdbarch *gdbarch, bool temp,
+		     const char *cond_string)
+    : code_breakpoint (gdbarch, bp_catchpoint, temp, cond_string)
+  {
+    /* Make sure "locspec" is initialized, irrespective of the
+       "__hipOnError ()" symbol being found.  This allows listing the
+       breakpoint as a pending one when the binary is not loaded yet.
+       Otherwise, "info breakpoints" is going to trigger an assert.  */
+    locspec = new_explicit_location_spec_function ("__hipOnError");
+    pspace = current_program_space;
+    re_set (nullptr);
+  }
+
+  bp_location *allocate_location () override;
+  void re_set (program_space *pspace) override;
+  bool print_one (const bp_location **last_loc) const override;
+  void print_mention () const override;
+  void print_recreate (struct ui_file *fp) const override;
+  enum print_stop_action print_it (const bpstat *bs) const override;
+};
+
+/* Implement the "allocate_location" method for hiperr catchpoint.  */
+
+bp_location *
+hiperr_catchpoint::allocate_location ()
+{
+  return new bp_location (this, bp_loc_software_breakpoint);
+}
+
+/* Implement the "re_set" method for hiperr catchpoint.  It is used
+   when a breakpoint must be re-evaluated, like at symbols change.  */
+
+void
+hiperr_catchpoint::re_set (program_space * /*ps*/)
+{
+  std::vector<symtab_and_line> sals;
+
+  try
+    {
+      sals = this->decode_location_spec (this->locspec.get (),
+					 current_program_space);
+    }
+  catch (const gdb_exception_error &ex)
+    {
+      /* NOT_FOUND_ERROR is the result of a pending breakpoint.
+	 Anything else, must be rethrown.  */
+      if (ex.error != NOT_FOUND_ERROR)
+	throw;
+    }
+  update_breakpoint_locations (this, current_program_space, sals, {});
+}
+
+/* Implement the "print_one" method for hiperr catchpoint.  It
+   displays information about the breakpoint ("info breakpoints").  */
+
+bool
+hiperr_catchpoint::print_one (const bp_location **last_loc) const
+{
+  struct value_print_options opts;
+  struct ui_out *uiout = current_uiout;
+
+  get_user_print_options (&opts);
+
+  if (opts.addressprint)
+    uiout->field_skip ("addr");
+  annotate_field (5);
+
+  uiout->field_string ("what", "catch hiperr");
+  if (uiout->is_mi_like_p ())
+    uiout->field_string ("catch-type", "hiperr");
+
+  return true;
+}
+
+/* Message printed when the breakpoint is set.  */
+
+void
+hiperr_catchpoint::print_mention () const
+{
+  struct ui_out *uiout = current_uiout;
+  const char *bp_type = "Catchpoint";
+
+  if (disposition == disp_del)
+    bp_type = "Temporary catchpoint";
+
+  uiout->message ("%s %d (HIP error)", _(bp_type), number);
+}
+
+/* Implement the "print_recreate" method for catch hiperr.
+   It's used for saving the breakpoints.  */
+
+void
+hiperr_catchpoint::print_recreate (struct ui_file *fp) const
+{
+  bool bp_temp = (disposition == disp_del);
+  gdb_printf (fp, bp_temp ? "tcatch hiperr" : "catch hiperr");
+  /* The condition, if any, is read from the object's "cond_string".  */
+  print_recreate_thread (fp);
+}
+
+/* Check if FRAME is the "__hipOnError ()" frame.  */
+
+static bool
+hiperr_frame_p (frame_info_ptr frame)
+{
+  enum language func_lang;
+
+  gdb::unique_xmalloc_ptr<char> func_name
+    = find_frame_funname (frame, &func_lang, nullptr);
+  if (func_name == nullptr || strcmp (func_name.get (), "__hipOnError") != 0)
+    return false;
+
+  return true;
+}
+
+/* Format the HIP error info as a string (with newline) for printing.
+   Returns an empty string if the parameters cannot be fetched.  */
+
+static std::string
+hiperr_info_string (struct gdbarch *gdbarch)
+{
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+    return std::string ();
+
+  std::optional<hiperr_parameters> err_params
+    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+
+  if (!err_params.has_value ())
+    return std::string ();
+
+  return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
+			err_params->err_name.get (),
+			err_params->err_no,
+			err_params->err_str.get ());
+}
+
+/* Message printed when the breakpoint is hit.  */
+
+enum print_stop_action
+hiperr_catchpoint::print_it (const bpstat *bs) const
+{
+  struct ui_out *uiout = current_uiout;
+  const char *bp_type = "Catchpoint ";
+
+  annotate_catchpoint (number);
+  maybe_print_thread_hit_breakpoint (uiout);
+
+  if (disposition == disp_del)
+    bp_type = "Temporary catchpoint ";
+  uiout->text (bp_type);
+
+  print_num_locno (bs, uiout);
+  uiout->text (" (HIP error)\n");
+
+  const std::string hiperr_info
+    = hiperr_info_string (bs->bp_location_at->gdbarch);
+  if (!hiperr_info.empty ())
+    {
+      uiout->text (hiperr_info.c_str ());
+      uiout->text
+	("\nThe $_hiperr convenience variable holds the error number.\n");
+    }
+  else
+    uiout->text ("\nwarning: failed to extract HIP error information.\n");
+
+  if (uiout->is_mi_like_p ())
+    {
+      uiout->field_string ("reason",
+			   async_reason_lookup (EXEC_ASYNC_BREAKPOINT_HIT));
+      uiout->field_string ("disp", bpdisp_text (disposition));
+    }
+
+  return PRINT_NOTHING;
+}
+
+/* Implementation of "catch hiperr" command.  */
+
+static void
+catch_hiperr_command (const char *arg,
+		      int /*from_tty*/,
+		      struct cmd_list_element *command)
+{
+  bool tempflag = command->context () == CATCH_TEMPORARY;
+  const char *cond_string = nullptr;
+
+  if (arg == nullptr)
+    arg = "";
+  arg = skip_spaces (arg);
+  cond_string = ep_parse_optional_if_clause (&arg);
+
+  if ((*arg != '\0') && !isspace (*arg))
+    error (_("Junk at the end of arguments."));
+
+  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
+						  tempflag, cond_string);
+
+  install_breakpoint (0, std::move (hcp), 1);
+}
+
+
+
+/* Implement the 'make_value' method for the $_hiperr internalvar.  */
+
+static struct value *
+compute_hiperr (struct gdbarch *gdbarch,
+		struct internalvar * /*var*/,
+		void * /*ignore*/)
+{
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+    return value::allocate (builtin_type (gdbarch)->builtin_void);
+
+  std::optional<hiperr_parameters> err_params
+    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+
+  if (!err_params.has_value ())
+    return value::allocate (builtin_type (gdbarch)->builtin_void);
+
+  /* If there's a "hipError_t" type in the debug symbols that is
+     a 4-byte enum, use it.  */
+  struct block_symbol bs
+    = lookup_symbol ("hipError_t", nullptr, SEARCH_TYPE_DOMAIN, nullptr);
+  if (bs.symbol != nullptr
+      && bs.symbol->type ()->length () == 4
+      && bs.symbol->type ()->code () == TYPE_CODE_ENUM)
+    {
+      gdb_byte err_no[4];
+      const bfd_endian byte_order = gdbarch_byte_order (gdbarch);
+      store_unsigned_integer (err_no, 4, byte_order, err_params->err_no);
+      return value_from_contents (bs.symbol->type (), err_no);
+    }
+
+  /* Return hiperr as an unsigned int.  */
+  return value_from_ulongest (builtin_type (gdbarch)->builtin_uint32,
+			      err_params->err_no);
+}
+
+/* Implementation of the '$_hiperr' variable.  */
+
+static const struct internalvar_funcs hiperr_funcs =
+{
+  compute_hiperr,
+  nullptr,
+};
+
+
+
+void _initialize_break_catch_hiperr ();
+void
+_initialize_break_catch_hiperr ()
+{
+  /* Add "(t)catch hiperr" sub-command.  */
+  add_catch_command ("hiperr",
+		     _("Catch a HIP error."),
+		     catch_hiperr_command,
+		     nullptr,
+		     CATCH_PERMANENT,
+		     CATCH_TEMPORARY);
+
+  create_internalvar_type_lazy ("_hiperr", &hiperr_funcs, nullptr);
+}

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -5727,6 +5727,16 @@ However, whether the signal is still delivered to the inferior depends
 on the @code{pass} setting; this can be changed in the catchpoint's
 commands.
 
+@anchor{catch hiperr}
+@item hiperr
+@kindex catch hiperr
+The failure of a HIP API.  This catchpoint catches any HIP API error
+that is returned by the HIP runtime.  You can combine it with an
+@var{if condition@dots{}} clause that uses the @samp{$_hiperr}
+convenience variable to stop on specific HIP errors.
+@xref{Conditions,,Break Conditions}, and
+@ref{HIP error convenience variable}.
+
 @end table
 
 @item tcatch @var{event}
@@ -13130,6 +13140,9 @@ The heterogeneous work-group position string of the current thread or
 heterogeneous lane respectively, or the empty string if not associated
 with a heterogeneous dispatch.  @xref{Heterogeneous Debugging}.
 
+@item $_hiperr
+The current HIP API error.  @xref{HIP error convenience variable}.
+
 @end table
 
 @node Convenience Funs
@@ -19893,6 +19906,48 @@ The size of the wavefront for the dispatch that the current kernel
 belongs to.
 
 @end table
+
+@node HIP Runtime Errors
+@subsubsection HIP Runtime Errors
+@cindex HIP runtime error
+If the HIP runtime library provides the necessary means, @value{GDBN}
+can stop the program when a HIP API error is returned.  To catch such
+errors, use the @samp{catch hiperr} command.  @xref{catch hiperr},
+for details.
+
+@smallexample
+(@value{GDBP}) catch hiperr
+Catchpoint 1 (HIP error)
+
+(@value{GDBP}) run
+...
+Thread 1 "prog" hit Catchpoint 1 (HIP error)
+HIP API call failed with error hipErrorInvalidDevice (101): invalid device ordinal
+
+The $_hiperr convenience variable holds the error number.
+(@value{GDBP}) p $_hiperr
+$1 = hipErrorInvalidDevice
+(@value{GDBP}) p/d $_hiperr
+$2 = 101
+@end smallexample
+
+@anchor{HIP error convenience variable}
+@cindex HIP runtime error convenience variable
+@vindex $_hiperr@r{, convenience variable}
+There's also a convenience variable named @samp{$_hiperr} that represents
+the error.  If the @samp{hipError_t} type is known to @value{GDBN}, then
+@samp{$_hiperr} is printed as that type, else it is printed as a number.
+One common use-case of this convenience variable is to set conditional
+catchpoints.
+
+@smallexample
+(@value{GDBP}) catch hiperr if $_hiperr == hipErrorInvalidDevice
+Catchpoint 1 (HIP error)
+(@value{GDBP}) info breakpoints
+Num     Type           Disp Enb Address    What
+1       catchpoint     keep y              catch hiperr
+        stop only if $_hiperr == hipErrorInvalidDevice
+@end smallexample
 
 @c TODO: Add any language specific differences.
 

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -1378,6 +1378,17 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (frame == NULL)
     internal_error (_("invalid frame information"));
 
+  /* Check that the read will not try to access past the end of the register.
+     If it does, consider that some bits of the read are optimized out.  Since
+     we do not have a better granularity during the register read, report the
+     entire read as optimized out even if we could read a few bits.  */
+  if (total_bits_to_skip + bit_size > reg_bits)
+    {
+      *optimized = true;
+      *unavailable = false;
+      return;
+    }
+
   /* Populate or refresh the cache if needed.  */
   if (m_storage->m_read_cache.has_value ()
       && m_storage->m_read_cache->outdated (frame))

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -1520,7 +1520,7 @@ dwarf_register::to_gdb_value (const frame_info_ptr &initial_frame,
 	 return a generic optimized out value instead, so that we show
 	 <optimized out> instead of <not saved>.  */
       value *temp = value::allocate (subobj_type);
-      retval->contents_copy (temp, 0, 0, 0, subobj_type->length ());
+      retval->contents_copy (temp, 0, 0, subobj_type->length ());
       retval = temp;
     }
 

--- a/gdb/dwarf2/expr.c
+++ b/gdb/dwarf2/expr.c
@@ -542,13 +542,16 @@ public:
 
      Note that some location types can be read without a FRAME context.
 
-     If the location is optimized out or unavailable, the OPTIMIZED and
-     UNAVAILABLE outputs are set accordingly.  */
+     If the location is optimized out or unavailable (entirely or
+     partially), the affected ranges will be appended to OPTIMIZED and
+     UNAVAILABLE as necessary.  OPTIMIZED or UNAVAILABLE are left unchanged
+     if the location is not optimized or unavailable.  The ranges will
+     reference regions relative to BITS_TO_SKIP.  */
   virtual void read (const frame_info_ptr &frame, gdb_byte *buf,
 		     int buf_bit_offset, size_t bit_size,
 		     LONGEST bits_to_skip, size_t location_bit_limit,
-		     bool big_endian, int *optimized,
-		     int *unavailable) const = 0;
+		     bool big_endian, std::vector<range> &optimized_ranges,
+		     std::vector<range> &unavailable) const = 0;
 
   /* Write contents to a described location.
 
@@ -711,20 +714,20 @@ dwarf_location::deref (const frame_info_ptr &frame,
      from the type length, we need to zero-extend it.  */
   gdb::byte_vector read_buf (type->length (), 0);
   gdb_byte *buf_ptr = read_buf.data ();
-  int optimized, unavailable;
+  std::vector<range> optimized, unavailable;
 
   if (big_endian)
     buf_ptr += type->length () - actual_size;
 
   this->read (frame, buf_ptr, 0, actual_size * HOST_CHAR_BIT,
-	      0, 0, big_endian, &optimized, &unavailable);
+	      0, 0, big_endian, optimized, unavailable);
 
-  if (optimized)
+  if (!optimized.empty ())
     throw_error (OPTIMIZED_OUT_ERROR,
 		 _("Can't do read-modify-write to "
 		   "update bitfield; containing word "
 		   "has been optimized out"));
-  if (unavailable)
+  if (!unavailable.empty ())
     throw_error (NOT_AVAILABLE_ERROR,
 		 _("Can't dereference "
 		   "update bitfield; containing word "
@@ -765,17 +768,19 @@ dwarf_location::write_to_gdb_value (const frame_info_ptr &frame,
 				    LONGEST bits_to_skip, size_t bit_size,
 				    size_t location_bit_limit)
 {
-  int optimized, unavailable;
+  std::vector<range> optimized, unavailable;
   bool big_endian = type_byte_order (value->type ()) == BFD_ENDIAN_BIG;
 
   this->read (frame, value->contents_raw ().data (), value_bit_offset,
 	      bit_size, bits_to_skip, location_bit_limit,
-	      big_endian, &optimized, &unavailable);
+	      big_endian, optimized, unavailable);
 
-  if (optimized)
-    value->mark_bits_optimized_out (value_bit_offset, bit_size);
-  if (unavailable)
-    value->mark_bits_unavailable (value_bit_offset, bit_size);
+  for (auto &&optimized_range : optimized)
+    value->mark_bits_optimized_out
+      (value_bit_offset + optimized_range.offset, optimized_range.length);
+  for (auto &&unavailable_range : unavailable)
+    value->mark_bits_unavailable
+      (value_bit_offset + unavailable_range.offset, unavailable_range.length);
 }
 
 /* Value entry found on a DWARF expression evaluation stack.  */
@@ -932,10 +937,10 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, int *optimized, int *unavailable) const override
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override
   {
-    *unavailable = 0;
-    *optimized = 1;
+    optimized.push_back ({0, bit_size});
   }
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
@@ -1004,7 +1009,8 @@ public:
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip,
 	     size_t location_bit_limit, bool big_endian,
-	     int *optimized, int *unavailable) const override;
+	     std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1053,7 +1059,8 @@ void
 dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
 		    int buf_bit_offset, size_t bit_size,
 		    LONGEST bits_to_skip, size_t location_bit_limit,
-		    bool big_endian, int *optimized, int *unavailable) const
+		    bool big_endian, std::vector<range> &optimized,
+		    std::vector<range> &unavailable) const
 {
   LONGEST total_bits_to_skip = bits_to_skip;
   CORE_ADDR start_address
@@ -1064,7 +1071,6 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
     = gdbarch_segment_address_to_core_address (m_arch, m_address_space,
 					       start_address);
 
-  *optimized = 0;
   total_bits_to_skip += m_bit_suboffset;
 
   if (total_bits_to_skip % HOST_CHAR_BIT == 0
@@ -1072,9 +1078,12 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
       && buf_bit_offset % HOST_CHAR_BIT == 0)
     {
       /* Everything is byte-aligned, no buffer needed.  */
+      int is_unavailable;
       read_from_memory (start_address,
 			buf + buf_bit_offset / HOST_CHAR_BIT,
-			bit_size / HOST_CHAR_BIT, m_stack, unavailable);
+			bit_size / HOST_CHAR_BIT, m_stack, &is_unavailable);
+      if (is_unavailable)
+	unavailable.push_back ({0, bit_size});
     }
   else
     {
@@ -1083,13 +1092,16 @@ dwarf_memory::read (const frame_info_ptr &frame, gdb_byte *buf,
 
       /* Can only read from memory on byte granularity so an
 	 additional buffer is required.  */
+      int is_unavailable;
       read_from_memory (start_address, temp_buf.data (), this_size,
-			m_stack, unavailable);
+			m_stack, &is_unavailable);
 
-      if (!*unavailable)
+      if (!is_unavailable)
 	copy_bitwise (buf, buf_bit_offset, temp_buf.data (),
 		      total_bits_to_skip % HOST_CHAR_BIT,
 		      bit_size, big_endian);
+      else
+	unavailable.push_back ({0, bit_size});
     }
 }
 
@@ -1197,17 +1209,17 @@ dwarf_memory::deref (const frame_info_ptr &frame,
     }
   else
     {
-      int optimized, unavailable;
+      std::vector<range> optimized, unavailable;
 
       this->read (frame, buf_ptr, 0, size_in_bits, 0, 0,
-		  big_endian, &optimized, &unavailable);
+		  big_endian, optimized, unavailable);
 
-      if (optimized)
+      if (!optimized.empty ())
 	throw_error (OPTIMIZED_OUT_ERROR,
 		     _("Can't do read-modify-write to "
 		     "update bitfield; containing word "
 		     "has been optimized out"));
-      if (unavailable)
+      if (!unavailable.empty ())
 	throw_error (NOT_AVAILABLE_ERROR,
 		     _("Can't dereference "
 		     "update bitfield; containing word "
@@ -1267,7 +1279,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, int *optimized, int *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1348,7 +1361,8 @@ void
 dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
 		      int buf_bit_offset, size_t bit_size,
 		      LONGEST bits_to_skip, size_t location_bit_limit,
-		      bool big_endian, int *optimized, int *unavailable) const
+		      bool big_endian, std::vector<range> &optimized,
+		      std::vector<range> &unavailable) const
 {
   frame_info_ptr frame = initial_frame;
   LONGEST total_bits_to_skip = bits_to_skip;
@@ -1378,17 +1392,6 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (frame == NULL)
     internal_error (_("invalid frame information"));
 
-  /* Check that the read will not try to access past the end of the register.
-     If it does, consider that some bits of the read are optimized out.  Since
-     we do not have a better granularity during the register read, report the
-     entire read as optimized out even if we could read a few bits.  */
-  if (total_bits_to_skip + bit_size > reg_bits)
-    {
-      *optimized = true;
-      *unavailable = false;
-      return;
-    }
-
   /* Populate or refresh the cache if needed.  */
   if (m_storage->m_read_cache.has_value ()
       && m_storage->m_read_cache->outdated (frame))
@@ -1397,13 +1400,39 @@ dwarf_register::read (const frame_info_ptr &initial_frame, gdb_byte *buf,
   if (!m_storage->m_read_cache.has_value ())
     m_storage->m_read_cache.emplace (arch, frame, reg);
 
-  *optimized = m_storage->m_read_cache->optimized_out ();
-  *unavailable = m_storage->m_read_cache->unavailable ();
+  if (m_storage->m_read_cache->optimized_out ())
+    optimized.push_back ({0, bit_size});
 
-  if (!*optimized && !*unavailable)
-    copy_bitwise (buf, buf_bit_offset,
-		  m_storage->m_read_cache->data ().data (),
-		  total_bits_to_skip, bit_size, big_endian);
+  if (m_storage->m_read_cache->unavailable ())
+    unavailable.push_back ({0, bit_size});
+
+  if (!m_storage->m_read_cache->optimized_out ()
+      && !m_storage->m_read_cache->unavailable ())
+    {
+      if (total_bits_to_skip > reg_bits)
+	{
+	  /* The read is completely past the register, mark everything as
+	     optimized out.  */
+	  optimized.push_back ({0, bit_size});
+	}
+      else
+	{
+	  if (total_bits_to_skip + bit_size > reg_bits)
+	    {
+	      /* The access goes past the end of the register.  Mark this part
+		 as optimized out, and read the rest.  */
+	      optimized.push_back
+		({static_cast<LONGEST> (reg_bits) - total_bits_to_skip,
+		  (static_cast<LONGEST> (bit_size) + total_bits_to_skip
+		   - reg_bits)});
+	      bit_size = reg_bits - total_bits_to_skip;
+	    }
+
+	  copy_bitwise (buf, buf_bit_offset,
+			m_storage->m_read_cache->data ().data (),
+			total_bits_to_skip, bit_size, big_endian);
+	}
+    }
 
 }
 
@@ -1503,17 +1532,14 @@ dwarf_register::is_optimized_out (const frame_info_ptr &frame, bool big_endian,
 				  LONGEST bits_to_skip, size_t bit_size,
 				  size_t location_bit_limit) const
 {
-  int optimized, unavailable;
+  std::vector<range> optimized, unavailable;
   gdb::byte_vector temp_buf (bit_size);
 
   this->read (frame, temp_buf.data (), 0, bit_size,
 	      bits_to_skip, location_bit_limit,
-	      big_endian, &optimized, &unavailable);
+	      big_endian, optimized, unavailable);
 
-  if (optimized)
-    return true;
-
-  return false;
+  return !optimized.empty ();
 }
 
 /* Implicit location description entry.  Describes a location
@@ -1553,7 +1579,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, int *optimized, int *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size,
@@ -1583,14 +1610,12 @@ void
 dwarf_implicit::read (const frame_info_ptr &frame, gdb_byte *buf,
 		      int buf_bit_offset, size_t bit_size,
 		      LONGEST bits_to_skip, size_t location_bit_limit,
-		      bool big_endian, int *optimized, int *unavailable) const
+		      bool big_endian, std::vector<range> &optimized,
+		      std::vector<range> &unavailable) const
 {
   ULONGEST implicit_bit_size = HOST_CHAR_BIT * m_size;
   LONGEST total_bits_to_skip = bits_to_skip;
   size_t read_bit_limit = location_bit_limit;
-
-  *optimized = 0;
-  *unavailable = 0;
 
   /* Cut off at the end of the implicit value.  */
   if (m_byte_order == BFD_ENDIAN_BIG)
@@ -1607,12 +1632,17 @@ dwarf_implicit::read (const frame_info_ptr &frame, gdb_byte *buf,
 
   if (total_bits_to_skip >= implicit_bit_size)
     {
-      (*unavailable) = 1;
+      optimized.push_back ({0, bit_size});
       return;
     }
 
   if (bit_size > implicit_bit_size - total_bits_to_skip)
-    bit_size = implicit_bit_size - total_bits_to_skip;
+    {
+      optimized.push_back
+	({static_cast<LONGEST> (implicit_bit_size - total_bits_to_skip),
+	  bit_size + total_bits_to_skip - implicit_bit_size});
+      bit_size = implicit_bit_size - total_bits_to_skip;
+    }
 
   copy_bitwise (buf, buf_bit_offset, m_contents.get (),
 		total_bits_to_skip, bit_size, big_endian);
@@ -1678,7 +1708,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, int *optimized, int *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1736,9 +1767,9 @@ private:
 void
 dwarf_implicit_pointer::read (const frame_info_ptr &frame, gdb_byte *buf,
 			      int buf_bit_offset, size_t bit_size,
-                              LONGEST bits_to_skip, size_t location_bit_limit,
-			      bool big_endian, int *optimized,
-			      int *unavailable) const
+			      LONGEST bits_to_skip, size_t location_bit_limit,
+			      bool big_endian, std::vector<range> &optimized,
+			      std::vector<range> &unavailable) const
 {
   frame_info_ptr actual_frame = frame;
   LONGEST total_bits_to_skip = bits_to_skip + m_bit_suboffset;
@@ -1851,7 +1882,8 @@ public:
 
   void read (const frame_info_ptr &frame, gdb_byte *buf, int buf_bit_offset,
 	     size_t bit_size, LONGEST bits_to_skip, size_t location_bit_limit,
-	     bool big_endian, int *optimized, int *unavailable) const override;
+	     bool big_endian, std::vector<range> &optimized,
+	     std::vector<range> &unavailable) const override;
 
   void write (const frame_info_ptr &frame, const gdb_byte *buf,
 	      int buf_bit_offset, size_t bit_size, LONGEST bits_to_skip,
@@ -1974,16 +2006,25 @@ void
 dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
 		       int buf_bit_offset, size_t bit_size,
 		       LONGEST bits_to_skip, size_t location_bit_limit,
-		       bool big_endian, int *optimized, int *unavailable) const
+		       bool big_endian, std::vector<range> &optimized,
+		       std::vector<range> &unavailable) const
 {
   unsigned int pieces_num = m_pieces.size ();
   LONGEST total_bits_to_skip = bits_to_skip;
+  LONGEST range_bit_offset = 0;
   unsigned int i;
 
   if (!m_completed)
     ill_formed_expression ();
 
   total_bits_to_skip += m_offset * HOST_CHAR_BIT + m_bit_suboffset;
+
+  /* The range_bit_offset (bit offset that we need to add to any
+     optimized / unavailable range) can start negative if the current
+     location has an offset.  However, as we skip over pieces not
+     covered by the read / the beginning of the first covered piece,
+     this will get back to a positive or null value.  */
+  range_bit_offset -= m_offset * HOST_CHAR_BIT + m_bit_suboffset;
 
   /* Skip pieces covered by the read offset.  */
   for (i = 0; i < pieces_num; i++)
@@ -1994,10 +2035,12 @@ dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
         break;
 
       total_bits_to_skip -= piece_bit_size;
+      range_bit_offset += piece_bit_size;
     }
 
   for (; i < pieces_num; i++)
     {
+      std::vector<range> piece_optimized, piece_unavailable;
       LONGEST piece_bit_size = m_pieces[i].m_size;
       LONGEST actual_bit_size = piece_bit_size;
 
@@ -2007,13 +2050,23 @@ dwarf_composite::read (const frame_info_ptr &frame, gdb_byte *buf,
       m_pieces[i].m_location->read (frame, buf, buf_bit_offset,
 				    actual_bit_size, total_bits_to_skip,
 				    piece_bit_size, big_endian,
-				    optimized, unavailable);
+				    piece_optimized, piece_unavailable);
 
-      if (bit_size == actual_bit_size || *optimized || *unavailable)
+      for (auto &&piece_range : piece_optimized)
+	optimized.push_back ({(range_bit_offset + piece_range.offset),
+			      piece_range.length});
+
+      for (auto &&piece_range : piece_unavailable)
+	unavailable.push_back ({(range_bit_offset + piece_range.offset),
+				piece_range.length});
+
+      if (bit_size == actual_bit_size)
 	break;
 
       buf_bit_offset += actual_bit_size;
       bit_size -= actual_bit_size;
+      range_bit_offset += actual_bit_size - total_bits_to_skip;
+      total_bits_to_skip = 0;
     }
 }
 

--- a/gdb/eval.c
+++ b/gdb/eval.c
@@ -2567,7 +2567,7 @@ unop_extract_operation::evaluate (struct type *expect_type,
     error (_("length type is larger than the value type"));
 
   struct value *result = value::allocate (type);
-  old_value->contents_copy (result, 0, 0, 0, type->length ());
+  old_value->contents_copy (result, 0, 0, type->length ());
   return result;
 }
 

--- a/gdb/f-lang.c
+++ b/gdb/f-lang.c
@@ -170,7 +170,7 @@ fortran_bounds_all_dims (bool lbound_p,
       gdb_assert (dst_offset + v->type ()->length ()
 		  <= result->type ()->length ());
       gdb_assert (v->type ()->length () == elm_len);
-      v->contents_copy (result, dst_offset, 0, 0, elm_len);
+      v->contents_copy (result, dst_offset, 0, elm_len);
 
       /* Peel another dimension of the array.  */
       array_type = array_type->target_type ();
@@ -292,7 +292,7 @@ protected:
      available offset.  */
   void copy_element_to_dest (struct value *elt)
   {
-    elt->contents_copy (m_dest, m_dest_offset, 0, 0, elt->type ()->length ());
+    elt->contents_copy (m_dest, m_dest_offset, 0, elt->type ()->length ());
     m_dest_offset += elt->type ()->length ();
   }
 
@@ -754,7 +754,7 @@ fortran_array_shape (struct gdbarch *gdbarch, const language_defn *lang,
       gdb_assert (dst_offset + v->type ()->length ()
 		  <= result->type ()->length ());
       gdb_assert (v->type ()->length () == elm_len);
-      v->contents_copy (result, dst_offset, 0, 0, elm_len);
+      v->contents_copy (result, dst_offset, 0, elm_len);
 
       /* Peel another dimension of the array.  */
       val_type = val_type->target_type ();

--- a/gdb/findvar.c
+++ b/gdb/findvar.c
@@ -573,6 +573,7 @@ void
 read_frame_register_value (value *value)
 {
   gdb_assert (value->lval () == lval_register);
+  int unit_size = gdbarch_addressable_memory_unit_size (value->arch ());
 
   frame_info_ptr next_frame = frame_find_by_id (value->next_frame_id ());
   gdb_assert (next_frame != nullptr);
@@ -602,7 +603,11 @@ read_frame_register_value (value *value)
       if (reg_len > len)
 	reg_len = len;
 
-      regval->contents_copy (value, offset, reg_offset, bit_offset, reg_len);
+      regval->contents_copy_bitwise (value,
+				     offset * unit_size * HOST_CHAR_BIT,
+				     (reg_offset * unit_size * HOST_CHAR_BIT
+				      + bit_offset),
+				     reg_len * unit_size * HOST_CHAR_BIT);
 
       offset += reg_len;
       len -= reg_len;

--- a/gdb/findvar.c
+++ b/gdb/findvar.c
@@ -579,41 +579,34 @@ read_frame_register_value (value *value)
   gdb_assert (next_frame != nullptr);
 
   gdbarch *gdbarch = frame_unwind_arch (next_frame);
-  LONGEST offset = 0;
   LONGEST reg_offset = value->offset ();
   LONGEST bit_offset = value->bitpos ();
+  LONGEST reg_bit_offset = reg_offset * unit_size * HOST_CHAR_BIT + bit_offset;
   int regnum = value->regnum ();
-  int len = type_length_units (check_typedef (value->type ()));
+  LONGEST len = check_typedef (value->type ())->length () * HOST_CHAR_BIT;
 
-  /* Skip registers wholly inside of REG_OFFSET.  */
-  while (reg_offset >= register_size (gdbarch, regnum))
+  /* We try to read past the end of the register.  */
+  if (reg_bit_offset >= register_size (gdbarch, regnum) * HOST_CHAR_BIT)
     {
-      reg_offset -= register_size (gdbarch, regnum);
-      regnum++;
+      value->mark_bits_optimized_out (0, len);
+      return;
     }
 
-  /* Copy the data.  */
-  while (len > 0)
+  struct value *regval = frame_unwind_register_value (next_frame, regnum);
+  LONGEST reg_len
+    = regval->type ()->length () * HOST_CHAR_BIT - reg_bit_offset;
+
+  /* Truncate the read to not go past the end of the register.  */
+  if (reg_len > len)
+    reg_len = len;
+
+  if (len > reg_len)
     {
-      struct value *regval = frame_unwind_register_value (next_frame, regnum);
-      int reg_len = type_length_units (regval->type ()) - reg_offset;
-
-      /* If the register length is larger than the number of bytes
-	 remaining to copy, then only copy the appropriate bytes.  */
-      if (reg_len > len)
-	reg_len = len;
-
-      regval->contents_copy_bitwise (value,
-				     offset * unit_size * HOST_CHAR_BIT,
-				     (reg_offset * unit_size * HOST_CHAR_BIT
-				      + bit_offset),
-				     reg_len * unit_size * HOST_CHAR_BIT);
-
-      offset += reg_len;
-      len -= reg_len;
-      reg_offset = 0;
-      regnum++;
+      /* Mark bits past the end of the register as optimized out.  */
+      value->mark_bits_optimized_out (reg_len, len - reg_len);
     }
+
+  regval->contents_copy_bitwise (value, 0, reg_bit_offset, reg_len);
 }
 
 /* See value.h.  */

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -184,6 +184,7 @@ struct gdbarch
   gdbarch_address_class_name_to_type_flags_ftype *address_class_name_to_type_flags = nullptr;
   gdbarch_register_reggroup_p_ftype *register_reggroup_p = default_register_reggroup_p;
   gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument = nullptr;
+  gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters = nullptr;
   gdbarch_iterate_over_regset_sections_ftype *iterate_over_regset_sections = nullptr;
   gdbarch_make_corefile_notes_ftype *make_corefile_notes = nullptr;
   gdbarch_find_memory_regions_ftype *find_memory_regions = nullptr;
@@ -472,6 +473,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of address_class_name_to_type_flags, has predicate.  */
   /* Skip verify of register_reggroup_p, invalid_p == 0.  */
   /* Skip verify of fetch_pointer_argument, has predicate.  */
+  /* Skip verify of fetch_hiperr_parameters, has predicate.  */
   /* Skip verify of iterate_over_regset_sections, has predicate.  */
   /* Skip verify of make_corefile_notes, has predicate.  */
   /* Skip verify of find_memory_regions, has predicate.  */
@@ -1097,6 +1099,12 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
   gdb_printf (file,
 	      "gdbarch_dump: fetch_pointer_argument = <%s>\n",
 	      host_address_to_string (gdbarch->fetch_pointer_argument));
+  gdb_printf (file,
+	      "gdbarch_dump: gdbarch_fetch_hiperr_parameters_p() = %d\n",
+	      gdbarch_fetch_hiperr_parameters_p (gdbarch));
+  gdb_printf (file,
+	      "gdbarch_dump: fetch_hiperr_parameters = <%s>\n",
+	      host_address_to_string (gdbarch->fetch_hiperr_parameters));
   gdb_printf (file,
 	      "gdbarch_dump: gdbarch_iterate_over_regset_sections_p() = %d\n",
 	      gdbarch_iterate_over_regset_sections_p (gdbarch));
@@ -4044,6 +4052,30 @@ set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch,
 				    gdbarch_fetch_pointer_argument_ftype fetch_pointer_argument)
 {
   gdbarch->fetch_pointer_argument = fetch_pointer_argument;
+}
+
+bool
+gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch)
+{
+  gdb_assert (gdbarch != NULL);
+  return gdbarch->fetch_hiperr_parameters != NULL;
+}
+
+std::optional<hiperr_parameters>
+gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame)
+{
+  gdb_assert (gdbarch != NULL);
+  gdb_assert (gdbarch->fetch_hiperr_parameters != NULL);
+  if (gdbarch_debug >= 2)
+    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_parameters called\n");
+  return gdbarch->fetch_hiperr_parameters (frame);
+}
+
+void
+set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch,
+				     gdbarch_fetch_hiperr_parameters_ftype fetch_hiperr_parameters)
+{
+  gdbarch->fetch_hiperr_parameters = fetch_hiperr_parameters;
 }
 
 bool

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1040,6 +1040,16 @@ typedef CORE_ADDR (gdbarch_fetch_pointer_argument_ftype) (const frame_info_ptr &
 extern CORE_ADDR gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, const frame_info_ptr &frame, int argi, struct type *type);
 extern void set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument);
 
+/* Fetch HIP error parameters from the FRAME's function arguments.
+   FRAME is the frame of a "__hipOnError ()" function.  On a successful
+   run, return the parameters.  Otherwise, return a std::nullopt. */
+
+extern bool gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch);
+
+typedef std::optional<hiperr_parameters> (gdbarch_fetch_hiperr_parameters_ftype) (frame_info_ptr frame);
+extern std::optional<hiperr_parameters> gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame);
+extern void set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters);
+
 /* Iterate over all supported register notes in a core file.  For each
    supported register note section, the iterator must call CB and pass
    CB_DATA unchanged.  If REGCACHE is not NULL, the iterator can limit

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -152,6 +152,20 @@ enum call_dummy_location_type
   AT_ENTRY_POINT,
 };
 
+/* The data structure holding the HIP error parameters.  */
+
+struct hiperr_parameters
+{
+  /* The error number.  */
+  uint32_t err_no;
+
+  /* The string representing the error name.  */
+  gdb::unique_xmalloc_ptr<char> err_name;
+
+  /* The string describing the error name.  */
+  gdb::unique_xmalloc_ptr<char> err_str;
+};
+
 #include "gdbarch-gen.h"
 
 /* An internal function that should _only_ be called from gdbarch_tdep.

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -1779,6 +1779,20 @@ Fetch the pointer to the ith function argument.
     predicate=True,
 )
 
+Function(
+    comment="""
+Fetch HIP error parameters from the FRAME's function arguments.
+FRAME is the frame of a "__hipOnError ()" function.  On a successful
+run, return the parameters.  Otherwise, return a std::nullopt.
+""",
+    type="std::optional<hiperr_parameters>",
+    name="fetch_hiperr_parameters",
+    params=[
+        ("frame_info_ptr", "frame"),
+    ],
+    predicate=True,
+)
+
 Method(
     comment="""
 Iterate over all supported register notes in a core file.  For each

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -28,6 +28,7 @@ require dwarf2_support
 if { [is_amd64_regs_target] } {
     # Use RAX, a 64 bits register.
     set dwarf_regnum 0
+    set regname "rax"
 } else {
     verbose "Skipping ${gdb_test_file_name} for current architecture."
     unsupported "$gdb_test_file_name"
@@ -87,7 +88,7 @@ Dwarf::assemble $dwarf_file {
 		{DW_AT_type :$int_label}
 	    } {
 		DW_TAG_variable {
-		    DW_AT_name foo
+		    {DW_AT_name var_piece}
 		    {DW_AT_type :$foo_t_label}
 		    {DW_AT_location {
 			DW_OP_regx $::dwarf_regnum
@@ -108,4 +109,7 @@ if { ![runto_main] } {
     return
 }
 
-gdb_test "p/x foo" "= <optimized out>"
+# The test assumes a register size of 64 bits, ensure we have this.
+set regsize [get_sizeof "\$$regname" ""]
+gdb_assert {$regsize == 8} "ensure register size"
+gdb_test "p/x var_piece" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -47,7 +47,7 @@ Dwarf::assemble $dwarf_file {
 	    {DW_AT_name $::srcfile}
 	    {DW_AT_comp_dir /tmp}
 	} {
-	    declare_labels int_label foo_t_label
+	    declare_labels int_label foo_t_label bitfield_t_label
 
 	    int_label: DW_TAG_base_type {
 		{DW_AT_name int}
@@ -81,6 +81,42 @@ Dwarf::assemble $dwarf_file {
 		}
 	    }
 
+	    bitfield_t_label: DW_TAG_structure_type {
+		{DW_AT_name bitfield_t}
+		{DW_AT_byte_size 1 DW_FORM_sdata}
+	    } {
+		DW_TAG_member {
+		    {DW_AT_name a}
+		    {DW_AT_type :$int_label}
+		    {DW_AT_bit_size 1 DW_FORM_sdata}
+		    {DW_AT_data_bit_offset 0 DW_FORM_sdata}
+		}
+		DW_TAG_member {
+		    {DW_AT_name b}
+		    {DW_AT_type :$int_label}
+		    {DW_AT_bit_size 1 DW_FORM_sdata}
+		    {DW_AT_data_bit_offset 1 DW_FORM_sdata}
+		}
+		DW_TAG_member {
+		    {DW_AT_name c}
+		    {DW_AT_type :$int_label}
+		    {DW_AT_bit_size 1 DW_FORM_sdata}
+		    {DW_AT_data_bit_offset 2 DW_FORM_sdata}
+		}
+		DW_TAG_member {
+		    {DW_AT_name d}
+		    {DW_AT_type :$int_label}
+		    {DW_AT_bit_size 1 DW_FORM_sdata}
+		    {DW_AT_data_bit_offset 3 DW_FORM_sdata}
+		}
+		DW_TAG_member {
+		    {DW_AT_name e}
+		    {DW_AT_type :$int_label}
+		    {DW_AT_bit_size 1 DW_FORM_sdata}
+		    {DW_AT_data_bit_offset 4 DW_FORM_sdata}
+		}
+	    }
+
 	    DW_TAG_subprogram {
 		{DW_AT_name main}
 		{DW_AT_low_pc $main_start DW_FORM_addr}
@@ -93,6 +129,34 @@ Dwarf::assemble $dwarf_file {
 		    {DW_AT_location {
 			DW_OP_regx $::dwarf_regnum
 			DW_OP_piece 16
+		    } SPECIAL_expr}
+		}
+
+		DW_TAG_variable {
+		    {DW_AT_name var_reg}
+		    {DW_AT_type :$foo_t_label}
+		    {DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+		    } SPECIAL_expr}
+		}
+
+		DW_TAG_variable {
+		    {DW_AT_name var_reg_past_the_end}
+		    {DW_AT_type :$foo_t_label}
+		    {DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_constu 8
+			DW_OP_LLVM_offset
+		    } SPECIAL_expr}
+		}
+
+		DW_TAG_variable {
+		    {DW_AT_name var_bitfield}
+		    {DW_AT_type :$bitfield_t_label}
+		    {DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_constu 62
+			DW_OP_LLVM_bit_offset
 		    } SPECIAL_expr}
 		}
 	    }
@@ -113,3 +177,14 @@ if { ![runto_main] } {
 set regsize [get_sizeof "\$$regname" ""]
 gdb_assert {$regsize == 8} "ensure register size"
 gdb_test "p/x var_piece" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"
+
+# Read a variable larger than the register holding it, with a simple register
+# location description.
+gdb_test "p/x var_reg" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>}"
+
+# Read a value fully past the end of the register.
+gdb_test "p/x var_reg_past_the_end" "= <optimized out>"
+
+# Read a 1-byte value 2 bits away from the end of the register.  GDB needs
+# to be able to read less than one byte (2 bits), bits 2-7 are optimized out.
+gdb_test "p/x var_bitfield" "= {a = $::hex, b = $::hex, c = <optimized out>, d = <optimized out>, e = <optimized out>}"

--- a/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
+++ b/gdb/testsuite/gdb.dwarf2/access-past-end-reg.exp
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This test exercises the case where a DWARF expression leads the dwarf
+# machinery to try to read past a given register's end.  This should be
+# handled gracefully by GDB.
+
+load_lib "dwarf.exp"
+
+require dwarf2_support
+
+# This test will store a 128 bits variable in a register too small to
+# contain the entire value.  Select a suitable register which is less
+# than 128 bits in size.
+if { [is_amd64_regs_target] } {
+    # Use RAX, a 64 bits register.
+    set dwarf_regnum 0
+} else {
+    verbose "Skipping ${gdb_test_file_name} for current architecture."
+    unsupported "$gdb_test_file_name"
+    return
+}
+
+standard_testfile main.c -dw.S
+set dwarf_file [standard_output_file $srcfile2]
+
+Dwarf::assemble $dwarf_file {
+    get_func_info main
+
+    cu {} {
+	DW_TAG_compile_unit {
+	    {DW_AT_language @DW_LANG_C}
+	    {DW_AT_name $::srcfile}
+	    {DW_AT_comp_dir /tmp}
+	} {
+	    declare_labels int_label foo_t_label
+
+	    int_label: DW_TAG_base_type {
+		{DW_AT_name int}
+		{DW_AT_byte_size 4 DW_FORM_udata}
+		{DW_AT_encoding @DW_ATE_signed}
+	    }
+
+	    foo_t_label: DW_TAG_structure_type {
+		{DW_AT_name foo_t}
+		{DW_AT_byte_size 16 DW_FORM_sdata}
+	    } {
+		DW_TAG_member {
+		    {DW_AT_name a}
+		    {DW_AT_data_member_location 0 DW_FORM_data1}
+		    {DW_AT_type :$int_label}
+		}
+		DW_TAG_member {
+		    {DW_AT_name b}
+		    {DW_AT_data_member_location 4 DW_FORM_data1}
+		    {DW_AT_type :$int_label}
+		}
+		DW_TAG_member {
+		    {DW_AT_name c}
+		    {DW_AT_data_member_location 8 DW_FORM_data1}
+		    {DW_AT_type :$int_label}
+		}
+		DW_TAG_member {
+		    {DW_AT_name d}
+		    {DW_AT_data_member_location 12 DW_FORM_data1}
+		    {DW_AT_type :$int_label}
+		}
+	    }
+
+	    DW_TAG_subprogram {
+		{DW_AT_name main}
+		{DW_AT_low_pc $main_start DW_FORM_addr}
+		{DW_AT_high_pc $main_end DW_FORM_addr}
+		{DW_AT_type :$int_label}
+	    } {
+		DW_TAG_variable {
+		    DW_AT_name foo
+		    {DW_AT_type :$foo_t_label}
+		    {DW_AT_location {
+			DW_OP_regx $::dwarf_regnum
+			DW_OP_piece 16
+		    } SPECIAL_expr}
+		}
+	    }
+	}
+    }
+}
+
+if { [prepare_for_testing "failed to prepare" $testfile \
+	[list $srcfile $dwarf_file] {nodebug}] } {
+    return
+}
+
+if { ![runto_main] } {
+    return
+}
+
+gdb_test "p/x foo" "= <optimized out>"

--- a/gdb/testsuite/gdb.dwarf2/dw2-op-out-param.exp
+++ b/gdb/testsuite/gdb.dwarf2/dw2-op-out-param.exp
@@ -46,7 +46,7 @@ gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?int_param_single_
 
 # (2) struct_param_single_reg_loc
 gdb_continue_to_breakpoint "Stop in breakpt for struct_param_single_reg_loc"
-gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?struct_param_single_reg_loc \\(operand0={a = 0xdeadbe00deadbe01, b = <optimized out>}, operand1={a = <optimized out>, b = 0xdeadbe04deadbe05}, operand2=<optimized out>\\)\r\n#2  ($hex in )?main \\(\\)" "backtrace for test struct_param_single_reg_loc"
+gdb_test "bt" "#0  ($hex in )?breakpt \\(\\)\r\n#1  ($hex in )?struct_param_single_reg_loc \\(operand0={a = 0xdeadbe00deadbe01, b = <optimized out>}, operand1=<optimized out>, operand2=<optimized out>\\)\r\n#2  ($hex in )?main \\(\\)" "backtrace for test struct_param_single_reg_loc"
 
 # (3) struct_param_two_reg_pieces
 gdb_continue_to_breakpoint "Stop in breakpt for struct_param_two_reg_pieces"

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -1,0 +1,151 @@
+/* This testcase is part of GDB, the GNU debugger.
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <iostream>
+#include <cassert>
+#include <hip/hip_runtime.h>
+#include "rocm-test-utils.h"
+
+/* If set, the "hip_* ()" functions will record the error parameters.  */
+static bool gen_ref = false;
+
+struct hiperr_params_ref
+{
+  int no;
+  const char *name;
+  const char *str;
+
+  void save (hipError_t err_no)
+  {
+    no = static_cast <int> (err_no);
+    name = hipGetErrorName (err_no);
+    str = hipGetErrorString (err_no);
+  }
+};
+
+/* Reference values for the test.  */
+static hiperr_params_ref hip_set_device_err;
+static hiperr_params_ref hip_get_device_err;
+static hiperr_params_ref hip_launch_kernel_err;
+
+/* Get the maximum number of threads per block.  */
+
+static size_t
+get_max_block ()
+{
+  static size_t max_block = 0;
+
+  if (max_block == 0)
+    {
+      int deviceId;
+      CHECK (hipGetDevice (&deviceId));
+      hipDeviceProp_t props;
+      CHECK (hipGetDeviceProperties (&props, deviceId));
+      max_block = props.maxThreadsPerBlock;
+    }
+
+  return max_block;
+}
+
+/* An empty kernel used for an oversized dispatch.  */
+
+__global__ void
+kernel ()
+{
+}
+
+/* The purpose of these "hip_* ()" functions is to produce some errors
+   and have the error parameters recorded.  GDB can use these recorded
+   values as references to verify the catchpoints outputs.  */
+
+/* Dispatch a kernel via the triple chevron syntax with an oversized
+   dimension, which in turn launches the kernel using HIP APIs.  */
+
+static void
+hip_launch_kernel ()
+{
+  size_t max_block = get_max_block ();
+  assert (max_block != 0);
+  kernel<<<1, max_block + 1>>> ();
+  hipError_t err = hipGetLastError ();
+  assert (hipErrorInvalidConfiguration == err);
+
+  if (gen_ref)
+    hip_launch_kernel_err.save (err);
+}
+
+/* Set a device with bad ID.  */
+
+static void
+hip_set_device ()
+{
+  constexpr int bogus = 87654321;
+  hipError_t err = hipSetDevice (bogus);
+  assert (hipErrorInvalidDevice == err);
+
+  if (gen_ref)
+    hip_set_device_err.save (err);
+}
+
+/* Get a device with nullptr.  */
+
+static void
+hip_get_device ()
+{
+  hipError_t err = hipGetDevice (nullptr);
+  assert (hipErrorInvalidValue == err);
+
+  if (gen_ref)
+    hip_get_device_err.save (err);
+}
+
+int
+main (int argc, const char **argv)
+{
+  if (argc != 2)
+    {
+      std::cerr << "Usage: " << argv[0] << " ref|one|two|launch" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  const std::string test (argv[1]);
+  if (test == "ref")
+    {
+      gen_ref = true;
+      hip_set_device ();
+      hip_get_device ();
+      hip_launch_kernel ();
+      /* Break after reference initialization.  */
+    }
+  else if (test == "one")
+    hip_set_device ();
+  else if (test == "two")
+    {
+      hip_set_device ();
+      hip_get_device ();
+    }
+  else if (test == "launch")
+    hip_launch_kernel ();
+  else
+    {
+      std::cerr << "Unsupported test " << test << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -1,0 +1,332 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test catching HIP's API errors:
+#
+# 1. The executable is loaded and started.
+# 2. The executable is loaded but not started.
+# 3. There's no executable set yet.
+# 4. Two API errors are returned and caught.
+# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
+# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
+# 7. Temporary catch of the first error, while there are 2 errors.
+# 8. $_hiperr is printed correctly when debug symbols are available.
+# 9. $_hiperr is printed correctly without debug symbols.
+#    This one checks if "catch hiperr" works without debug symbols as well.
+
+load_lib rocm.exp
+
+require allow_hipcc_tests
+
+standard_testfile .cpp
+
+if {[prepare_for_testing "failed to prepare debug version of ${testfile}" \
+	${::testfile}.dbg ${::srcfile} {debug hip}]} {
+    return -1
+}
+
+if {[prepare_for_testing "failed to prepare non-debug version of ${testfile}" \
+	${::testfile}.nodbg ${::srcfile} {hip}]} {
+    return -1
+}
+
+# Reference error parameters for HIP API calls:
+#   hipSetDevice (...)
+#   hipGetDevice (...)
+#   hipLaunchKernel (...)
+#
+# See init_reference_hip_errors.
+
+set hip_set_device_err_no ""
+set hip_set_device_err_name ""
+set hip_set_device_err_str ""
+set hip_get_device_err_no ""
+set hip_get_device_err_name ""
+set hip_get_device_err_str ""
+set hip_launch_kernel_err_no ""
+set hip_launch_kernel_err_name ""
+set hip_launch_kernel_err_str ""
+
+# Retrieve the value of EXP in the inferior, as a string value
+# (using "print /s").  DEFAULT is used as fallback if print fails.
+
+proc get_string_valueof {exp default} {
+    set val ${default}
+    gdb_test_multiple "print /s ${exp}" "get string value of \"${exp}\"" {
+	-re -wrap "^${::valnum_re} = $::hex \"(\[^\"\]*)\"" {
+	    set val $expect_out(1,string)
+	    pass $gdb_test_name
+	}
+    }
+    return ${val}
+}
+
+# Get the reference values from the program (which is run with "ref" argument)
+
+proc init_reference_hip_errors {} {
+    foreach func {set_device get_device launch_kernel} {
+	set ::hip_${func}_err_no [get_integer_valueof "hip_${func}_err.no" bad]
+	gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
+	    "hip_${func}_err_no initialized"
+
+	set ::hip_${func}_err_name [get_string_valueof "hip_${func}_err.name" bad]
+	gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
+	    "hip_${func}_err_name initialized"
+
+	set ::hip_${func}_err_str [get_string_valueof "hip_${func}_err.str" bad]
+	gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
+	    "hip_${func}_err_str initialized"
+    }
+}
+
+# Set a hiperr catchpoint and check if it set accordingly.  If TEMP is
+# true, then a temporary version (tcatch) is used.  Differences between the
+# permanent and temporary are:
+#
+# catch hiperr                 vs. tcatch hiperr
+# Catchpoint <number> ...      vs. Temporary catchpoint <number> ...
+# info breakpoints
+# <number> catchpoint keep ... vs. <number> catchpoint del ...
+
+proc catch_hiperr {{temp false}} {
+    if {!$temp} {
+	set cmd "catch hiperr"
+	set type "Catchpoint"
+	set catch_test_name "set catchpoint"
+	set disp "keep"
+    } else {
+	set cmd "tcatch hiperr"
+	set type "Temporary catchpoint"
+	set catch_test_name "set temporary catchpoint"
+	set disp "del"
+    }
+
+    gdb_test "$cmd" "$type $::decimal \\(HIP error\\)" "$catch_test_name"
+
+    gdb_test "info break" \
+	"$::decimal\[ \t\]+catchpoint\[ \t\]+$disp\[ \t\]+y\[ \t\]+catch hiperr" \
+	"check breakpoints"
+}
+
+# Set a conditional "catch hiperr" that checks the error number is NUMBER.
+
+proc catch_hiperr_cond {number} {
+    gdb_test "catch hiperr if \$_hiperr == $number" \
+	"Catchpoint $::decimal \\(HIP error\\)" \
+	"set conditional catchpoint"
+}
+
+# Execute CMD (e.g. "run" or "cont") and look for two lines
+# in the output:
+#
+# Thread 1 "hip" hit Catchpoint 1 (HIP error)
+# (...) hipErrorInvalidDevice (101): invalid device ordinal
+#       ^^^^^^^^^^^^^^^^^^^^^  ^^^   ^^^^^^^^^^^^^^^^^^^^^^
+#               NAME          NUMBER STR
+#
+# As the last step, also check that $_hiperr is equal to NUMBER.
+# If TEMP is true, the catchpoint is temporary.
+
+proc check_hiperr_is_caught {cmd number name str {temp false}} {
+    if {!$temp} {
+	set type "Catchpoint"
+    } else {
+	set type "Temporary catchpoint"
+    }
+    set hit_line "Thread $::decimal .* hit $type $::decimal \\(HIP error\\)"
+    set err_line "HIP API call failed with error $name \\($number\\): $str\r\n.*"
+
+    gdb_test "$cmd" "${hit_line}\r\n${err_line}" "caught $name"
+    gdb_test "p/d \$_hiperr" "= $number" "\$_hiperr must be $number"
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for hipSetDevice (...).  TEMP, if true, indicates
+# the catchpoint must be a temporary one.
+
+proc check_hip_set_device_err {cmd {temp false}} {
+    check_hiperr_is_caught $cmd \
+	$::hip_set_device_err_no \
+	$::hip_set_device_err_name \
+	$::hip_set_device_err_str \
+	$temp
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for hipGetDevice (...).
+
+proc check_hip_get_device_err {cmd} {
+    check_hiperr_is_caught $cmd \
+	$::hip_get_device_err_no \
+	$::hip_get_device_err_name \
+	$::hip_get_device_err_str
+}
+
+# Execute CMD and check the reported hiperr catchpoint against the
+# reference values for kernel<<<...>>> ().
+
+proc check_hip_launch_kernel_err {cmd} {
+    check_hiperr_is_caught $cmd \
+	$::hip_launch_kernel_err_no \
+	$::hip_launch_kernel_err_name \
+	$::hip_launch_kernel_err_str
+}
+
+proc do_test {} {
+    with_rocm_gpu_lock {
+
+	clean_restart ${::testfile}.dbg
+	if {![runto_main]} {
+	    return
+	}
+	gdb_test_multiple "info symbol __hipOnError" \
+	    "check if __hipOnError symbol exists" {
+	    -re -wrap "^__hipOnError in section .text of .*" {
+		pass $gdb_test_name
+	    }
+	    -re -wrap ".*" {
+		unsupported "no __hipOnError symbol was found"
+		return
+	    }
+	}
+
+	# Let all the errors occur and their values be recorded by the program.
+	with_test_prefix "getting reference values" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args ref"
+	    if {![runto [gdb_get_line_number \
+			    "Break after reference initialization"]]} {
+		return
+	    }
+	    init_reference_hip_errors
+	}
+
+	with_test_prefix "after starting" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    runto_main
+	    catch_hiperr
+	    check_hip_set_device_err "cont"
+	}
+
+	with_test_prefix "after loading" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    catch_hiperr
+	    check_hip_set_device_err "run"
+	}
+
+	with_test_prefix "before loading" {
+	    clean_restart
+	    catch_hiperr
+	    gdb_load ${::binfile}.dbg
+	    gdb_test_no_output "set args one"
+	    check_hip_set_device_err "run"
+	}
+
+	with_test_prefix "two catchpoints" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr
+	    check_hip_set_device_err "run"
+	    check_hip_get_device_err "cont"
+	}
+
+	with_test_prefix "stub kernel launch" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args launch"
+	    catch_hiperr
+	    check_hip_launch_kernel_err "run"
+	    gdb_test "backtrace" \
+		".*__hipOnError.*hipLaunchKernel.*__device_stub__kernel.*" \
+		"call stack"
+	}
+
+	with_test_prefix "conditional catchpoint" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr_cond $::hip_get_device_err_no
+	    check_hip_get_device_err "run"
+	}
+
+	with_test_prefix "temporary catchpoint" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args two"
+	    catch_hiperr true
+	    check_hip_set_device_err "run" true
+	    gdb_test "continue" \
+		"Inferior $::decimal .* exited normally.*" \
+		"no more catches"
+	}
+
+	# With the debug symbols (with "hipError_t" type), $_hiperr
+	# must be printed as an enum like hipErrorSomething.
+	with_test_prefix "prints of \$_hiperr with debug symbols" {
+	    clean_restart ${::testfile}.dbg
+	    gdb_test_no_output "set args one"
+	    runto_main
+	    # Without any error, "$_hiperr" must be "void".
+	    gdb_test "p \$_hiperr" " = void" "not in scope"
+
+	    # Check "hipError_t" type is known.
+	    set type_found false
+	    gdb_test_multiple "info types hipError_t" \
+		"check if hipError_t type exists" {
+		-re ".*File \[^\r\n\]+:\r\n" {
+		    set type_found true
+		    exp_continue
+		}
+		-re "$::gdb_prompt $" {
+		    gdb_assert {$type_found} $gdb_test_name
+		}
+	    }
+
+	    catch_hiperr
+	    gdb_test "cont" ".*call failed.*$::hip_set_device_err_name.*" \
+		"caught $::hip_set_device_err_name"
+	    gdb_test "p \$_hiperr" " = $::hip_set_device_err_name" \
+		"print as $::hip_set_device_err_name"
+	}
+
+	# Without the debug symbols (no "hipError_t" type),
+	# $_hiperr must be printed as a number.
+	with_test_prefix "print \$_hiperr without debug symbols" {
+	    clean_restart ${::testfile}.nodbg
+	    gdb_test_no_output "set args launch"
+	    runto_main
+
+	    # Check "hipError_t" type is not detected.
+	    set type_found true
+	    gdb_test_multiple "info types hipError_t" \
+		"check hipError_t type existence" {
+		-re -wrap "\r\nAll types matching regular expression \"hipError_t\":" {
+		    set type_found false
+		    pass $gdb_test_name
+		}
+	    }
+	    gdb_assert {!$type_found} "there must be no hipError_t"
+
+	    catch_hiperr
+	    check_hip_launch_kernel_err "cont"
+	    gdb_test "p \$_hiperr" " = $::hip_launch_kernel_err_no" \
+		"print as $::hip_launch_kernel_err_no"
+	}
+    }
+}
+
+do_test

--- a/gdb/testsuite/gdb.rocm/names.cpp
+++ b/gdb/testsuite/gdb.rocm/names.cpp
@@ -35,21 +35,14 @@
 	}                                                                    \
     } while (0)
 
-/* All kernels call this.  */
-
-__device__ static void
-wait_forever ()
-{
-  while (1)
-    __builtin_amdgcn_s_sleep (1);
-}
+__device__ static void wait_all_kernels ();
 
 /* A kernel with a name longer than GDB's longest possible name.  */
 
 __global__ void
 long_kernel_name_abcdefghijklmnopqrstuvwxyz ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* A kernel with a name longer than GDB's longest possible name.  */
@@ -57,7 +50,7 @@ long_kernel_name_abcdefghijklmnopqrstuvwxyz ()
 __global__ void
 long_kernel_name_0123456789 ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* A kernel with a normal, short name.  */
@@ -65,7 +58,7 @@ long_kernel_name_0123456789 ()
 __global__ void
 kern ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* Same, but with some parameters.  */
@@ -73,7 +66,7 @@ kern ()
 __global__ void
 kern (int)
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* A kernel with extern "C" linkage, which doesn't include an argument
@@ -82,7 +75,7 @@ kern (int)
 extern "C" __global__ void
 c_kern ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* A kernel in a namespace.  */
@@ -92,7 +85,7 @@ namespace NS {
 __global__ void
 kern_ns ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 }
@@ -104,7 +97,7 @@ namespace {
 __global__ void
 anonymous ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 }
@@ -120,14 +113,14 @@ template<E val>
 __global__ void
 templ_non_type ()
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 template<typename... Args>
 __global__ void
 templ_type (Args... args)
 {
-  wait_forever ();
+  wait_all_kernels ();
 }
 
 /* List of kernel names and a callback that launches the named
@@ -205,6 +198,36 @@ static struct
   },
 };
 
+/* Number of kernels seen so far by wait_all_kernels.  */
+__device__ static int kernels_seen = 0;
+
+/* Number of kernels expected to be seen by wait_all_kernels.  */
+__device__ static int number_kernels = 0;
+
+/* Wait until every kernel has reached here, so that they are all
+   running concurrently before any of them exits.  */
+
+__device__ static void
+wait_all_kernels ()
+{
+  atomicAdd (&kernels_seen, 1);
+  while (atomicAdd (&kernels_seen, 0) < number_kernels)
+    {
+      /* Sleep a bit to avoid hogging the GPU.  */
+      __builtin_amdgcn_s_sleep (64);
+    }
+}
+
+/* True if we want to run the kernel named KERNEL.  ARG is the
+   argument passed to the program.  Either a kernel name, or
+   "all".  */
+
+static bool
+should_run_kernel (const char *arg, const char *kernel)
+{
+  return strcmp (arg, "all") == 0 || strcmp (arg, kernel) == 0;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -218,13 +241,22 @@ main (int argc, char **argv)
       return EXIT_FAILURE;
     }
 
+  int h_number_kernels = 0;
+  for (auto &k : kernels)
+    {
+      if (should_run_kernel (argv[1], k.kernel))
+	h_number_kernels++;
+    }
+  CHECK (hipMemcpyToSymbol (HIP_SYMBOL (number_kernels), &h_number_kernels,
+			    sizeof (int)));
+
   /* Launch each kernel on its own stream, so they can all run
      concurrently.  */
   std::vector<hipStream_t> streams;
 
   for (auto &k : kernels)
     {
-      if (strcmp (argv[1], "all") == 0 || strcmp (argv[1], k.kernel) == 0)
+      if (should_run_kernel (argv[1], k.kernel))
 	{
 	  hipStream_t st;
 	  CHECK (hipStreamCreate (&st));

--- a/gdb/testsuite/gdb.rocm/names.exp
+++ b/gdb/testsuite/gdb.rocm/names.exp
@@ -72,6 +72,11 @@ set all_kernels_info {
     {templ_type                                   templ_type       {templ_type<int, long> (args=2, args=2)}}
 }
 
+# By default, the runtime allows 4 hardware queues max, which limits
+# us to 4 concurrent streams/kernels.  Launching all kernels at the
+# same time needs more than that, so when testing "all", bump it up.
+set inferior_env "GPU_MAX_HW_QUEUES=32"
+
 # KERNEL is the kernel to launch.  It is either the name of a kernel
 # as listed in ALL_KERNELS_INFO, or "all", to launch all.
 
@@ -85,10 +90,7 @@ proc do_test {kernel} {
     gdb_test "set args $kernel"
 
     if {$kernel == "all"} {
-	# By default, the runtime allows 4 hardware queues max, which
-	# limits us to 4 concurrent streams/kernels.  Launching all
-	# kernels at the same time needs than that, so bump it up.
-	gdb_test_no_output "set environment GPU_MAX_HW_QUEUES=32"
+	gdb_test_no_output "set environment $::inferior_env"
     }
 
     with_rocm_gpu_lock {
@@ -208,5 +210,11 @@ foreach entry $all_kernels_info {
     do_test_prefix $func
 }
 
-# Test running and debugging all kernels at once.
+# Test running all kernels at once outside the debugger first, to make
+# sure the runtime respects GPU_MAX_HW_QUEUES properly.
+set result [remote_exec target "env $inferior_env $binfile all"]
+set status [lindex $result 0]
+gdb_assert {$status == 0} "runs correctly outside debugger"
+
+# Now inside the debugger.
 do_test_prefix "all"

--- a/gdb/testsuite/gdb.rocm/update-thread-list.exp
+++ b/gdb/testsuite/gdb.rocm/update-thread-list.exp
@@ -25,7 +25,14 @@ require allow_hipcc_tests
 
 standard_testfile .cpp
 
-if {[prepare_for_testing "failed to prepare ${testfile}" $testfile $srcfile {debug hip}]} {
+# Don't use $testfile as the executable name, because Windows'
+# installer detection heuristic refuses to launch executables whose
+# name contains "update" (and a few other keywords like "setup",
+# "install", "patch") without elevation, failing with
+# ERROR_ELEVATION_REQUIRED (740).
+set executable "test"
+
+if {[prepare_for_testing "failed to prepare ${testfile}" $executable $srcfile {debug hip}]} {
     return -1
 }
 

--- a/gdb/valops.c
+++ b/gdb/valops.c
@@ -1753,7 +1753,7 @@ value_array (int lowbound, gdb::array_view<struct value *> elemvec)
     {
       val = value::allocate (arraytype);
       for (idx = 0; idx < elemvec.size (); idx++)
-	elemvec[idx]->contents_copy (val, idx * typelength, 0, 0, typelength);
+	elemvec[idx]->contents_copy (val, idx * typelength, 0, typelength);
       return val;
     }
 
@@ -1762,7 +1762,7 @@ value_array (int lowbound, gdb::array_view<struct value *> elemvec)
 
   val = value::allocate (arraytype);
   for (idx = 0; idx < elemvec.size (); idx++)
-    elemvec[idx]->contents_copy (val, idx * typelength, 0, 0, typelength);
+    elemvec[idx]->contents_copy (val, idx * typelength, 0, typelength);
   return val;
 }
 
@@ -4115,7 +4115,7 @@ value_slice (struct value *array, int lowbound, int length)
     else
       {
 	slice = value::allocate (slice_type);
-	array->contents_copy (slice, 0, offset, 0,
+	array->contents_copy (slice, 0, offset,
 			     type_length_units (slice_type));
       }
 

--- a/gdb/value.c
+++ b/gdb/value.c
@@ -1220,8 +1220,7 @@ value::ranges_copy_adjusted (struct value *dst, int dst_bit_offset,
 
 void
 value::contents_copy_raw (struct value *dst, LONGEST dst_offset,
-			  LONGEST src_offset, LONGEST src_bit_offset,
-			  LONGEST length)
+			  LONGEST src_offset, LONGEST length)
 {
   LONGEST src_total_bit_offset, dst_total_bit_offset, bit_length;
   int unit_size = gdbarch_addressable_memory_unit_size (arch ());
@@ -1257,19 +1256,10 @@ value::contents_copy_raw (struct value *dst, LONGEST dst_offset,
     = this->contents_all_raw ().slice (src_offset * unit_size,
 				       copy_length * unit_size);
 
-  if (src_bit_offset)
-    {
-      bool big_endian = type_byte_order (dst->type ()) == BFD_ENDIAN_BIG;
-
-      copy_bitwise (dst_contents.data (), 0, src_contents.data (),
-		    src_bit_offset, bit_length, big_endian);
-    }
-  else
-    gdb::copy (src_contents, dst_contents);
+  gdb::copy (src_contents, dst_contents);
 
   /* Copy the meta-data, adjusted.  */
-  src_total_bit_offset = src_offset * unit_size * HOST_CHAR_BIT
-			 + src_bit_offset;
+  src_total_bit_offset = src_offset * unit_size * HOST_CHAR_BIT;
   dst_total_bit_offset = dst_offset * unit_size * HOST_CHAR_BIT;
 
   ranges_copy_adjusted (dst, dst_total_bit_offset, src_total_bit_offset,
@@ -1320,12 +1310,24 @@ value::contents_copy_raw_bitwise (struct value *dst, LONGEST dst_bit_offset,
 
 void
 value::contents_copy (struct value *dst, LONGEST dst_offset, LONGEST src_offset,
-		      LONGEST src_bit_offset, LONGEST length)
+		      LONGEST length)
 {
   if (m_lazy)
     fetch_lazy ();
 
-  contents_copy_raw (dst, dst_offset, src_offset, src_bit_offset, length);
+  contents_copy_raw (dst, dst_offset, src_offset, length);
+}
+
+/* See value.h.  */
+
+void
+value::contents_copy_bitwise (struct value *dst, LONGEST dst_bit_offset,
+			      LONGEST src_bit_offset, LONGEST bit_length)
+{
+  if (m_lazy)
+    fetch_lazy ();
+
+  contents_copy_raw_bitwise (dst, dst_bit_offset, src_bit_offset, bit_length);
 }
 
 gdb::array_view<const gdb_byte>
@@ -3133,7 +3135,7 @@ value::primitive_field (LONGEST offset, int fieldno, struct type *arg_type)
       else
 	{
 	  v = value::allocate (enclosing_type ());
-	  contents_copy_raw (v, 0, 0, 0, enclosing_type ()->length ());
+	  contents_copy_raw (v, 0, 0, enclosing_type ()->length ());
 	}
       v->deprecated_set_type (type);
       v->set_offset (this->offset ());
@@ -3166,7 +3168,7 @@ value::primitive_field (LONGEST offset, int fieldno, struct type *arg_type)
 	{
 	  v = value::allocate (type);
 	  contents_copy_raw (v, v->embedded_offset (),
-			     embedded_offset () + offset, 0,
+			     embedded_offset () + offset,
 			     type_length_units (type));
 	}
       v->set_offset (this->offset () + offset + embedded_offset ());
@@ -3806,7 +3808,7 @@ value_from_component (struct value *whole, struct type *type, LONGEST offset)
       v = value::allocate (type);
       whole->contents_copy (v, v->embedded_offset (),
 			    whole->embedded_offset () + offset,
-			    0, type_length_units (type));
+			    type_length_units (type));
     }
   v->set_offset (whole->offset () + offset + whole->embedded_offset ());
   v->set_component_location (whole);
@@ -4032,6 +4034,7 @@ value::fetch_lazy_register ()
 {
   struct type *type = check_typedef (this->type ());
   struct value *new_val = this;
+  int unit_size = gdbarch_addressable_memory_unit_size (arch ());
 
   scoped_value_mark mark;
 
@@ -4081,9 +4084,11 @@ value::fetch_lazy_register ()
   /* Copy the contents and the unavailability/optimized-out
      meta-data from NEW_VAL to VAL.  */
   set_lazy (false);
-  new_val->contents_copy (this, embedded_offset (),
-			  new_val->embedded_offset () + offset (),
-			  bitpos (), type_length_units (type));
+  new_val->contents_copy_bitwise
+    (this, embedded_offset () * unit_size * HOST_CHAR_BIT,
+     (((new_val->embedded_offset () + offset ()) * unit_size * HOST_CHAR_BIT)
+      + bitpos ()),
+     type_length_units (type) * unit_size * HOST_CHAR_BIT);
 
   if (frame_debug)
     {
@@ -4176,7 +4181,7 @@ pseudo_from_raw_part (const frame_info_ptr &next_frame, int pseudo_reg_num,
   value *pseudo_reg_val
     = value::allocate_register (next_frame, pseudo_reg_num);
   value *raw_reg_val = value_of_register (raw_reg_num, next_frame);
-  raw_reg_val->contents_copy (pseudo_reg_val, 0, raw_offset, 0,
+  raw_reg_val->contents_copy (pseudo_reg_val, 0, raw_offset,
 			      pseudo_reg_val->type ()->length ());
   return pseudo_reg_val;
 }
@@ -4209,12 +4214,12 @@ pseudo_from_concat_raw (const frame_info_ptr &next_frame, int pseudo_reg_num,
   int dst_offset = 0;
 
   value *raw_reg_1_val = value_of_register (raw_reg_1_num, next_frame);
-  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,  0,
+  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_1_val->type ()->length ());
   dst_offset += raw_reg_1_val->type ()->length ();
 
   value *raw_reg_2_val = value_of_register (raw_reg_2_num, next_frame);
-  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_2_val->type ()->length ());
   dst_offset += raw_reg_2_val->type ()->length ();
 
@@ -4258,17 +4263,17 @@ pseudo_from_concat_raw (const frame_info_ptr &next_frame, int pseudo_reg_num,
   int dst_offset = 0;
 
   value *raw_reg_1_val = value_of_register (raw_reg_1_num, next_frame);
-  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_1_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_1_val->type ()->length ());
   dst_offset += raw_reg_1_val->type ()->length ();
 
   value *raw_reg_2_val = value_of_register (raw_reg_2_num, next_frame);
-  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_2_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_2_val->type ()->length ());
   dst_offset += raw_reg_2_val->type ()->length ();
 
   value *raw_reg_3_val = value_of_register (raw_reg_3_num, next_frame);
-  raw_reg_3_val->contents_copy (pseudo_reg_val, dst_offset, 0, 0,
+  raw_reg_3_val->contents_copy (pseudo_reg_val, dst_offset, 0,
 				raw_reg_3_val->type ()->length ());
   dst_offset += raw_reg_3_val->type ()->length ();
 

--- a/gdb/value.h
+++ b/gdb/value.h
@@ -628,8 +628,19 @@ public:
      It is assumed the contents of DST in the [DST_OFFSET,
      DST_OFFSET+LENGTH) range are wholly available.  */
   void contents_copy (struct value *dst, LONGEST dst_offset,
-		      LONGEST src_offset, LONGEST src_bit_offset,
-		      LONGEST length);
+		      LONGEST src_offset, LONGEST length);
+
+  /* Copy BIT_LENGTH bits of this value's content starting at
+     SRC_BIT_OFFSET bits into DST value's contents, starting at
+     DST_BIT_OFFSET bits.  If unavailable contents are being copied
+     from this value, the corresponding DST contents are marked
+     unavailable accordingly.  DST must not be lazy.  If this value
+     is lazy, it will be fetched now.
+
+     It is assumed the contents of DST in the [DST_BIT_OFFSET,
+     DST_BIT_OFFSET+BIT_LENGTH) range are wholly available.  */
+  void contents_copy_bitwise (struct value *dst, LONGEST dst_bit_offset,
+			      LONGEST src_bit_offset, LONGEST bit_length);
 
   /* Given a value (offset by OFFSET bytes)
      of a struct or union type ARG_TYPE,
@@ -893,8 +904,7 @@ private:
      It is assumed the contents of DST in the [DST_OFFSET,
      DST_OFFSET+LENGTH) range are wholly available.  */
   void contents_copy_raw (struct value *dst, LONGEST dst_offset,
-			  LONGEST src_offset, LONGEST src_bit_offset,
-			  LONGEST length);
+			  LONGEST src_offset, LONGEST length);
 
   /* A helper for value_from_component_bitsize that copies bits from
      this value to DEST.  */


### PR DESCRIPTION
Cherry-pick recent changes to amd-staging-rocgdb-16:

- 44c490bd059 gdb: read_frame_register_value do not read past current register
- 6d44429b9cb gdb/value: refactor value::contents_copy methods
- bfeda8593eb gdb/dwarf2/expr: dwarf_location::read get optimized/unavailable ranges
- a22d47ccd95 gdb/dwarf: Fix dwarf_register::read overflow
- 82f56e979de gdb, amdgpu: use segment address in amdgpu_get_watchable_aliases
- d31d424140c gdb: add "catch hiperr" to break on HIP API errors
- d8aa5cbf2cb gdb.rocm/names.exp: Make test program exit once all kernels are running
- a314c8659af .github/workflows: use installed test_rocgdb.py
- 5008d52a21a Update TheRock dependencies and container images
- a66fcd72777 gdb.rocm/update-thread-list.exp: Avoid "update" in exe name

Notable edits during cherry-picks:
- `gdb.dwarf2/access-past-end-reg.exp` to use the old style DWARF assembler
- bfeda8593eb the base used `int` for `optimized` / `unavailable`, master uses `bool`
- d31d424140c:
  - Replace `INIT_GDB_FILE` with explicit declaration / definition
  - Minor edits at the surrounding code was different
- A new commit is added to have the "catch hiperr" entry removed from `CHANGELOG_AMD.md`