### PR TITLE
gdb: Fix gdb.rocm/mi-attach.exp FAILs on Windows

### DIFF
--- a/gdb/testsuite/gdb.mi/mi-attach.c
+++ b/gdb/testsuite/gdb.mi/mi-attach.c
@@ -1,0 +1,37 @@
+/* Copyright 2026 Free Software Foundation, Inc.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+int
+main (void)
+{
+  /* Sleep long enough (5 min) to be attached to.  */
+#ifdef _WIN32
+  Sleep (300000);
+#else
+  sleep (300);
+#endif
+  return 0;
+}

--- a/gdb/testsuite/gdb.mi/mi-attach.exp
+++ b/gdb/testsuite/gdb.mi/mi-attach.exp
@@ -1,0 +1,33 @@
+# Copyright 2026 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+load_lib mi-support.exp
+set MIFLAGS "-i=mi"
+
+require can_spawn_for_attach
+
+standard_testfile
+
+if {[build_executable "failed to prepare" $testfile $srcfile {debug}]} {
+    return
+}
+
+set spawn_id [spawn_wait_for_attach $::binfile]
+set prog_pid [spawn_id_get_pid $spawn_id]
+
+mi_clean_restart
+
+mi_gdb_test "-target-attach $prog_pid" ".*\\^done.*" "attach \$PROG_PID"
+kill_wait_spawned_process $spawn_id

--- a/gdb/windows-nat.c
+++ b/gdb/windows-nat.c
@@ -1944,7 +1944,6 @@ windows_nat_target::do_initial_windows_stuff (DWORD pid, bool attaching)
   if (!inf->target_is_pushed (this))
     inf->push_target (this);
   windows_clear_solib ();
-  clear_proceed_status (0);
   init_wait_for_inferior ();
 
   inferior_appeared (inf, pid);


### PR DESCRIPTION
gdb.rocm/mi-attach.exp FAILs on Windows because -target-attach <pid> emits ^running as its result-record instead of ^done. The test matcher .\^done. never fires, so it fails as "unexpected output". The bug is not in the test — ^done is what the MI protocol requires for a synchronous command with set mi-async off, and Linux has been emitting it correctly since Feb 2025. Windows still emits ^running because windows-nat.c::do_initial_windows_stuff has a stale clear_proceed_status call that, in combination with the MI interp's ^running/^done back-compat hack, latches mi_proceeded=1 before the dispatcher gets to print ^done, which then gets suppressed.

This patch removes the stale clear_proceed_status call.
