### PR TITLE
gdb/testsuite/rocm/runtime-core: ensure all or no test run

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -33,6 +33,15 @@ if { [build_executable "failed to prepare" ${testfile} ${srcfile} \
     return -1
 }
 
+# The "do_test" function is called multiple times, and any may exit early if
+# it turns out the current configuration does not allow the creation of core
+# dumps.  However, if at least one core dump can be produced, all must be.
+# Keep track of the number of attempts and their status to enforce this
+# property.
+set total_count 0
+set untested_count 0
+set success_count 0
+
 # do_test FAULT CORE_TYPE OUTPUT_TYPE
 #   Run the test exercising generation of a core dump on fault FAULT
 #   using a file or a pipe.
@@ -45,6 +54,7 @@ if { [build_executable "failed to prepare" ${testfile} ${srcfile} \
 # OUTPUT_TYPE is one of "file" of "pipe".
 #
 proc do_test { fault core_type output_type } {
+    incr ::total_count
     set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
@@ -53,6 +63,7 @@ proc do_test { fault core_type output_type } {
 
     if {$coredump eq ""} {
 	untested "Could not generate a core file"
+	incr ::untested_count
 	return
     }
 
@@ -134,6 +145,7 @@ proc do_test { fault core_type output_type } {
     }
 
     gdb_exit
+    incr ::success_count
 }
 
 with_rocm_gpu_lock {
@@ -151,3 +163,6 @@ with_rocm_gpu_lock {
       do_test $fault lightweight file
     }
 }
+
+gdb_assert {$::total_count == ($::untested_count + $::success_count)} "all tests accounted for"
+gdb_assert {$::untested_count == 0 || $::success_count == 0} "coredump consistently produced"


### PR DESCRIPTION
When working on coredump related issue, it was noticed that some runtime changes could work in some conditions but fail in others.  The gdb.rocm/runtime-core.exp testcase was not really complaining about that, it would validate the core dumps when produced and skip the test if the core was absent.

It is expected that if the system configuration is not adequate, none of the runtime-core cases would run, but if at least one can run, it means all must also run.

This test ensures that we run either all or none of the testcase, and issue a FAIL if this property is not satisfied.

Change-Id: Ic79b958a0991b21dc1dfeb6bb13b3f292c53261f