### PR TITLE
gdb: add -catch-hiperr to the Machine Interface (MI)

### DIFF
--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -5,6 +5,13 @@ Full documentation for ROCgdb is available at
 
 ## ROCgdb-X for ROCm-next
 
+### Added
+
+- The "catch hiperr" feature is now exposed to MI too, with a new
+  `-catch-hiperr` command and related fields in `*stopped` records.
+  See the "HIP Runtime Error" subsection of the "GDB/MI Catchpoint
+  Commands" section in the ROCgdb manual.
+
 ## ROCgdb-16-3 for ROCm-7.14
 
 ### Added

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -2077,15 +2077,15 @@ amd64_init_reg (gdbarch *gdbarch, int regnum, dwarf2_frame_state_reg *reg,
     }
 }
 
-/* The AMD64 Linux ABI version of fetch_hiperr_parameters.  */
+/* The AMD64 Linux ABI version of fetch_hiperr_info.  */
 
-static std::optional<hiperr_parameters>
-amd64_linux_fetch_hiperr_parameters (frame_info_ptr frame)
+static std::optional<hiperr_info>
+amd64_linux_fetch_hiperr_info (frame_info_ptr frame)
 {
   CORE_ADDR struct_addr
     = value_as_address (value_of_register (AMD64_RDI_REGNUM, frame));
 
-  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+  return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
 static void
@@ -2151,9 +2151,9 @@ amd64_linux_init_abi_common (struct gdbarch_info info, struct gdbarch *gdbarch,
 					amd64_linux_get_shadow_stack_pointer);
   dwarf2_frame_set_init_reg (gdbarch, amd64_init_reg);
 
-  /* Extract hiperr parameters for 'catch hiperr'.  */
-  set_gdbarch_fetch_hiperr_parameters
-    (gdbarch, amd64_linux_fetch_hiperr_parameters);
+  /* Extract hiperr info for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_info
+    (gdbarch, amd64_linux_fetch_hiperr_info);
 }
 
 static void

--- a/gdb/amd64-tdep.c
+++ b/gdb/amd64-tdep.c
@@ -1060,10 +1060,10 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
 }
 
 
-/* Extract HIP error parameters from the STRUCT_ADDR which is
-   a struct address passed to "__hipOnError ()" as an argument.
+/* Extract HIP error info from the STRUCT_ADDR which is a struct
+   address passed to "__hipOnError ()" as an argument.
 
-   Only when all the parameters are retrieved successfully, return
+   Only when all the fields are retrieved successfully, return
    them as the result.  Otherwise [1], return an std::nullopt.
 
    [1]
@@ -1072,10 +1072,10 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
    - Not all the strings were read successfully
 */
 
-std::optional<hiperr_parameters>
-amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
+std::optional<hiperr_info>
+amd64_fetch_hiperr_info (frame_info_ptr frame, CORE_ADDR struct_addr)
 {
-  /* The HIP error parameters are packed in a struct with the following format:
+  /* The HIP error info is packed in a struct with the following format:
 
      struct {
 	uint32_t version;
@@ -1087,7 +1087,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
     The "version" is bumped when more fields are added to the structure.
     Newer versions must keep backward compatibility with the previous ones,
     by only tacking new fields at the end of the structure, so that older
-    clients can still extract the parameters they know.
+    clients can still extract the fields they know.
   */
 
   /* Cover the version (4), number (4) and two pointers (2*8).  */
@@ -1108,7 +1108,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
      compatible.  See note above.  */
   if (version < 1)
     {
-      warning (_("version '%s' for HIP error parameters is not supported."),
+      warning (_("version '%s' for HIP error info is not supported."),
 	       pulongest (version));
       return std::nullopt;
     }
@@ -1130,7 +1130,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
     return std::nullopt;
   err_str = std::move (str);
 
-  return hiperr_parameters {err_no, std::move (err_name), std::move (err_str)};
+  return hiperr_info {err_no, std::move (err_name), std::move (err_str)};
 }
 
 

--- a/gdb/amd64-tdep.h
+++ b/gdb/amd64-tdep.h
@@ -139,10 +139,10 @@ extern void amd64_collect_fxsave (const struct regcache *regcache, int regnum,
 extern void amd64_collect_xsave (const struct regcache *regcache,
 				 int regnum, void *xsave, int gcore);
 
-/* Helper routine to fetch error parameters of a HIP error from the
-   STRUCT_ADDR within the FRAME context.  */
+/* Helper routine to fetch HIP error information from the STRUCT_ADDR
+   within the FRAME context.  */
 
-extern std::optional<hiperr_parameters> amd64_fetch_hiperr_parameters
+extern std::optional<hiperr_info> amd64_fetch_hiperr_info
   (frame_info_ptr frame, CORE_ADDR struct_addr);
 
 /* Floating-point register set. */

--- a/gdb/amd64-windows-tdep.c
+++ b/gdb/amd64-windows-tdep.c
@@ -1271,15 +1271,15 @@ amd64_windows_skip_trampoline_code (const frame_info_ptr &frame, CORE_ADDR pc)
   return destination;
 }
 
-/* The AMD64 Windows ABI version of fetch_hiperr_parameters.  */
+/* The AMD64 Windows ABI version of fetch_hiperr_info.  */
 
-static std::optional<hiperr_parameters>
-amd64_windows_fetch_hiperr_parameters (frame_info_ptr frame)
+static std::optional<hiperr_info>
+amd64_windows_fetch_hiperr_info (frame_info_ptr frame)
 {
   CORE_ADDR struct_addr
     = value_as_address (value_of_register (AMD64_RCX_REGNUM, frame));
 
-  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+  return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
 /* Common parts for gdbarch initialization for Windows and Cygwin on AMD64.  */
@@ -1324,9 +1324,9 @@ amd64_windows_init_abi_common (gdbarch_info info, struct gdbarch *gdbarch)
     (gdbarch, windows_core_xfer_shared_libraries);
   set_gdbarch_core_pid_to_str (gdbarch, windows_core_pid_to_str);
 
-  /* Extract hiperr parameters for 'catch hiperr'.  */
-  set_gdbarch_fetch_hiperr_parameters
-    (gdbarch, amd64_windows_fetch_hiperr_parameters);
+  /* Extract hiperr info for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_info
+    (gdbarch, amd64_windows_fetch_hiperr_info);
 }
 
 /* gdbarch initialization for Windows on AMD64.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -148,26 +148,26 @@ hiperr_frame_p (frame_info_ptr frame)
 }
 
 /* Format the HIP error info as a string (with newline) for printing.
-   Returns an empty string if the parameters cannot be fetched.  */
+   Returns an empty string if the information cannot be fetched.  */
 
 static std::string
 hiperr_info_string (struct gdbarch *gdbarch)
 {
   frame_info_ptr frame = get_selected_frame (_("No frame selected"));
 
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
     return std::string ();
 
-  std::optional<hiperr_parameters> err_params
-    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+  std::optional<hiperr_info> err_info
+    = gdbarch_fetch_hiperr_info (gdbarch, frame);
 
-  if (!err_params.has_value ())
+  if (!err_info.has_value ())
     return std::string ();
 
   return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
-			err_params->err_name.get (),
-			err_params->err_no,
-			err_params->err_str.get ());
+			err_info->err_name.get (),
+			err_info->err_no,
+			err_info->err_str.get ());
 }
 
 /* Message printed when the breakpoint is hit.  */
@@ -188,11 +188,11 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
   print_num_locno (bs, uiout);
   uiout->text (" (HIP error)\n");
 
-  const std::string hiperr_info
+  const std::string hiperr_info_str
     = hiperr_info_string (bs->bp_location_at->gdbarch);
-  if (!hiperr_info.empty ())
+  if (!hiperr_info_str.empty ())
     {
-      uiout->text (hiperr_info.c_str ());
+      uiout->text (hiperr_info_str.c_str ());
       uiout->text
 	("\nThe $_hiperr convenience variable holds the error number.\n");
     }
@@ -244,13 +244,13 @@ compute_hiperr (struct gdbarch *gdbarch,
 {
   frame_info_ptr frame = get_selected_frame (_("No frame selected"));
 
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
     return value::allocate (builtin_type (gdbarch)->builtin_void);
 
-  std::optional<hiperr_parameters> err_params
-    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+  std::optional<hiperr_info> err_info
+    = gdbarch_fetch_hiperr_info (gdbarch, frame);
 
-  if (!err_params.has_value ())
+  if (!err_info.has_value ())
     return value::allocate (builtin_type (gdbarch)->builtin_void);
 
   /* If there's a "hipError_t" type in the debug symbols that is
@@ -263,13 +263,13 @@ compute_hiperr (struct gdbarch *gdbarch,
     {
       gdb_byte err_no[4];
       const bfd_endian byte_order = gdbarch_byte_order (gdbarch);
-      store_unsigned_integer (err_no, 4, byte_order, err_params->err_no);
+      store_unsigned_integer (err_no, 4, byte_order, err_info->err_no);
       return value_from_contents (bs.symbol->type (), err_no);
     }
 
   /* Return hiperr as an unsigned int.  */
   return value_from_ulongest (builtin_type (gdbarch)->builtin_uint32,
-			      err_params->err_no);
+			      err_info->err_no);
 }
 
 /* Implementation of the '$_hiperr' variable.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -36,11 +36,6 @@ struct hiperr_catchpoint : public code_breakpoint
 		     const char *cond_string)
     : code_breakpoint (gdbarch, bp_catchpoint, temp, cond_string)
   {
-    /* Make sure "locspec" is initialized, irrespective of the
-       "__hipOnError ()" symbol being found.  This allows listing the
-       breakpoint as a pending one when the binary is not loaded yet.
-       Otherwise, "info breakpoints" is going to trigger an assert.  */
-    locspec = new_explicit_location_spec_function ("__hipOnError");
     pspace = current_program_space;
     re_set (nullptr);
   }
@@ -71,7 +66,9 @@ hiperr_catchpoint::re_set (program_space * /*ps*/)
 
   try
     {
-      sals = this->decode_location_spec (this->locspec.get (),
+      location_spec_up locspec
+	= new_explicit_location_spec_function ("__hipOnError");
+      sals = this->decode_location_spec (locspec.get (),
 					 current_program_space);
     }
   catch (const gdb_exception_error &ex)

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -144,29 +144,6 @@ hiperr_frame_p (frame_info_ptr frame)
   return true;
 }
 
-/* Format the HIP error info as a string (with newline) for printing.
-   Returns an empty string if the information cannot be fetched.  */
-
-static std::string
-hiperr_info_string (struct gdbarch *gdbarch)
-{
-  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
-
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
-    return std::string ();
-
-  std::optional<hiperr_info> err_info
-    = gdbarch_fetch_hiperr_info (gdbarch, frame);
-
-  if (!err_info.has_value ())
-    return std::string ();
-
-  return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
-			err_info->err_name.get (),
-			err_info->err_no,
-			err_info->err_str.get ());
-}
-
 /* Message printed when the breakpoint is hit.  */
 
 enum print_stop_action
@@ -185,10 +162,19 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
   print_num_locno (bs, uiout);
   uiout->text (" (HIP error)\n");
 
-  const std::string hiperr_info_str
-    = hiperr_info_string (bs->bp_location_at->gdbarch);
-  if (!hiperr_info_str.empty ())
+  std::optional<hiperr_info> err_info;
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+  struct gdbarch *barch = bs->bp_location_at->gdbarch;
+  if (hiperr_frame_p (frame) && gdbarch_fetch_hiperr_info_p (barch))
+    err_info = gdbarch_fetch_hiperr_info (barch, frame);
+
+  if (err_info.has_value ())
     {
+      const std::string hiperr_info_str
+	= string_printf (_("HIP API call failed with error %s (%u): %s\n"),
+			 err_info->err_name.get (),
+			 err_info->err_no,
+			 err_info->err_str.get ());
       uiout->text (hiperr_info_str.c_str ());
       uiout->text
 	("\nThe $_hiperr convenience variable holds the error number.\n");
@@ -201,9 +187,26 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
       uiout->field_string ("reason",
 			   async_reason_lookup (EXEC_ASYNC_BREAKPOINT_HIT));
       uiout->field_string ("disp", bpdisp_text (disposition));
+
+      if (err_info.has_value ())
+	{
+	  uiout->field_unsigned ("hiperr-code", err_info->err_no);
+	  uiout->field_string ("hiperr-name", err_info->err_name.get ());
+	  uiout->field_string ("hiperr-str", err_info->err_str.get ());
+	}
     }
 
   return PRINT_NOTHING;
+}
+
+/* Instantiate a hiperr_catchpoint.  */
+
+void
+add_catch_hiperr (const char *condition, bool tempflag)
+{
+  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
+						  tempflag, condition);
+  install_breakpoint (0, std::move (hcp), 1);
 }
 
 /* Implementation of "catch hiperr" command.  */
@@ -224,10 +227,7 @@ catch_hiperr_command (const char *arg,
   if ((*arg != '\0') && !c_isspace (*arg))
     error (_("Junk at the end of arguments."));
 
-  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
-						  tempflag, cond_string);
-
-  install_breakpoint (0, std::move (hcp), 1);
+  add_catch_hiperr (cond_string, tempflag);
 }
 
 

--- a/gdb/breakpoint.h
+++ b/gdb/breakpoint.h
@@ -2099,6 +2099,13 @@ extern void catch_exception_event (enum exception_event_kind ex_event,
 				   const char *regex, bool tempflag,
 				   int from_tty);
 
+/* Catch a HIP error according to the input arguments.  If CONDITION is
+   provided, only failures that satisfy it will trigger the catchpoint.
+   If TEMPFLAG is set, the catchpoint is triggered once and then it
+   is removed.  */
+
+extern void add_catch_hiperr (const char *condition, bool tempflag);
+
 /* Return true if BPT is of any hardware watchpoint kind.  */
 
 bool is_hardware_watchpoint (const struct breakpoint *bpt);

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -36745,6 +36745,7 @@ catchpoints.
 * Shared Library GDB/MI Catchpoint Commands::
 * Ada Exception GDB/MI Catchpoint Commands::
 * C++ Exception GDB/MI Catchpoint Commands::
+* HIP Runtime Error GDB/MI Catchpoint Commands::
 @end menu
 
 @node Shared Library GDB/MI Catchpoint Commands
@@ -37082,6 +37083,74 @@ and @samp{tcatch catch} (@pxref{Set Catchpoints}).
   thread-id="1",stopped-threads="all",core="6"
 (gdb)
 @end smallexample
+
+@node HIP Runtime Error GDB/MI Catchpoint Commands
+@subsection HIP Runtime Error @sc{gdb/mi} Catchpoints
+
+The following @sc{gdb/mi} commands can be used to create catchpoints
+that stop the execution when HIP runtime errors are being returned.
+
+@findex -catch-hiperr
+@subheading The @code{-catch-hiperr} Command
+
+@subsubheading Synopsis
+
+@smallexample
+ -catch-hiperr [ -c @var{condition} ] [ -t ]
+@end smallexample
+
+Stop when the debuggee catches a HIP runtime error.
+
+@table @samp
+@item -c @var{condition}
+Make the catchpoint conditional on @var{condition}.
+@item -t
+Create a temporary catchpoint.
+@end table
+
+@subsubheading @value{GDBN} Command
+
+The corresponding @value{GDBN} commands are @samp{catch hiperr} and
+@samp{tcatch hiperr} (@pxref{catch hiperr}).
+
+@subsubheading Example
+
+@smallexample
+-catch-hiperr -c $_hiperr==hipErrorInvalidDevice -t
+^done,bkpt=@{number="1",type="catchpoint",disp="del",enabled="y",
+  what="catch hiperr",catch-type="hiperr",
+  cond="$_hiperr==hipErrorInvalidDevice",times="0"@}
+(gdb)
+-exec-run
+^running
+(gdb)
+~"\n"
+~"Thread 1 \"hip\" hit Temporary catchpoint 1 (HIP error)\n"
+~"HIP API call failed with error hipErrorInvalidDevice (101):
+  invalid device ordinal\n"
+~"\n"
+~"The $_hiperr convenience variable holds the error number.\n"
+*stopped,bkptno="1",reason="breakpoint-hit",disp="del",
+  hiperr-code="101",hiperr-name="hipErrorInvalidDevice",
+  hiperr-str="invalid device ordinal",thread-id="1",
+  stopped-threads="all",core="0"
+=breakpoint-deleted,id="1"
+@end smallexample
+
+The @samp{*stopped} record is extended with three fields:
+
+@table @samp
+
+@item hiperr-code
+The error number.
+
+@item hiperr-name
+The name of the error.
+
+@item hiperr-str
+The descriptive text about the error.
+
+@end table
 
 @c %%%%%%%%%%%%%%%%%%%%%%%%%%%% SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 @node GDB/MI Program Context

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -179,7 +179,7 @@ struct gdbarch
   gdbarch_address_class_name_to_id_ftype *address_class_name_to_id = nullptr;
   gdbarch_register_reggroup_p_ftype *register_reggroup_p = default_register_reggroup_p;
   gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument = nullptr;
-  gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters = nullptr;
+  gdbarch_fetch_hiperr_info_ftype *fetch_hiperr_info = nullptr;
   gdbarch_iterate_over_regset_sections_ftype *iterate_over_regset_sections = nullptr;
   gdbarch_make_corefile_notes_ftype *make_corefile_notes = nullptr;
   gdbarch_find_memory_regions_ftype *find_memory_regions = nullptr;
@@ -456,7 +456,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of address_class_name_to_id, has predicate.  */
   /* Skip verify of register_reggroup_p, invalid_p == 0.  */
   /* Skip verify of fetch_pointer_argument, invalid_p == 0.  */
-  /* Skip verify of fetch_hiperr_parameters, has predicate.  */
+  /* Skip verify of fetch_hiperr_info, has predicate.  */
   /* Skip verify of iterate_over_regset_sections, has predicate.  */
   /* Skip verify of make_corefile_notes, has predicate.  */
   /* Skip verify of find_memory_regions, has predicate.  */
@@ -1056,11 +1056,11 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
 	      "gdbarch_dump: fetch_pointer_argument = <%s>\n",
 	      host_address_to_string (gdbarch->fetch_pointer_argument));
   gdb_printf (file,
-	      "gdbarch_dump: gdbarch_fetch_hiperr_parameters_p() = %d\n",
-	      gdbarch_fetch_hiperr_parameters_p (gdbarch));
+	      "gdbarch_dump: gdbarch_fetch_hiperr_info_p() = %d\n",
+	      gdbarch_fetch_hiperr_info_p (gdbarch));
   gdb_printf (file,
-	      "gdbarch_dump: fetch_hiperr_parameters = <%s>\n",
-	      host_address_to_string (gdbarch->fetch_hiperr_parameters));
+	      "gdbarch_dump: fetch_hiperr_info = <%s>\n",
+	      host_address_to_string (gdbarch->fetch_hiperr_info));
   gdb_printf (file,
 	      "gdbarch_dump: gdbarch_iterate_over_regset_sections_p() = %d\n",
 	      gdbarch_iterate_over_regset_sections_p (gdbarch));
@@ -3885,27 +3885,27 @@ set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch,
 }
 
 bool
-gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch)
+gdbarch_fetch_hiperr_info_p (struct gdbarch *gdbarch)
 {
   gdb_assert (gdbarch != nullptr);
-  return gdbarch->fetch_hiperr_parameters != nullptr;
+  return gdbarch->fetch_hiperr_info != nullptr;
 }
 
-std::optional<hiperr_parameters>
-gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame)
+std::optional<hiperr_info>
+gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, frame_info_ptr frame)
 {
   gdb_assert (gdbarch != nullptr);
-  gdb_assert (gdbarch->fetch_hiperr_parameters != nullptr);
+  gdb_assert (gdbarch->fetch_hiperr_info != nullptr);
   if (gdbarch_debug >= 2)
-    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_parameters called\n");
-  return gdbarch->fetch_hiperr_parameters (frame);
+    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_info called\n");
+  return gdbarch->fetch_hiperr_info (frame);
 }
 
 void
-set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch,
-				     gdbarch_fetch_hiperr_parameters_ftype fetch_hiperr_parameters)
+set_gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch,
+			       gdbarch_fetch_hiperr_info_ftype fetch_hiperr_info)
 {
-  gdbarch->fetch_hiperr_parameters = fetch_hiperr_parameters;
+  gdbarch->fetch_hiperr_info = fetch_hiperr_info;
 }
 
 bool

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1025,15 +1025,15 @@ using gdbarch_fetch_pointer_argument_ftype = CORE_ADDR (const frame_info_ptr &fr
 CORE_ADDR gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, const frame_info_ptr &frame, int argi, struct type *type);
 void set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument);
 
-/* Fetch HIP error parameters from the FRAME's function arguments.
+/* Fetch HIP error information from the FRAME's function arguments.
    FRAME is the frame of a "__hipOnError ()" function.  On a successful
-   run, return the parameters.  Otherwise, return a std::nullopt. */
+   run, return the info.  Otherwise, return a std::nullopt. */
 
-bool gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch);
+bool gdbarch_fetch_hiperr_info_p (struct gdbarch *gdbarch);
 
-using gdbarch_fetch_hiperr_parameters_ftype = std::optional<hiperr_parameters> (frame_info_ptr frame);
-std::optional<hiperr_parameters> gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame);
-void set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters);
+using gdbarch_fetch_hiperr_info_ftype = std::optional<hiperr_info> (frame_info_ptr frame);
+std::optional<hiperr_info> gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, frame_info_ptr frame);
+void set_gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_info_ftype *fetch_hiperr_info);
 
 /* Iterate over all supported register notes in a core file.  For each
    supported register note section, the iterator must call CB and pass

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -144,9 +144,9 @@ enum call_dummy_location_type
   AT_ENTRY_POINT,
 };
 
-/* The data structure holding the HIP error parameters.  */
+/* The data structure holding the HIP error information.  */
 
-struct hiperr_parameters
+struct hiperr_info
 {
   /* The error number.  */
   uint32_t err_no;
@@ -154,7 +154,7 @@ struct hiperr_parameters
   /* The string representing the error name.  */
   gdb::unique_xmalloc_ptr<char> err_name;
 
-  /* The string describing the error name.  */
+  /* The descriptive text about the error name.  */
   gdb::unique_xmalloc_ptr<char> err_str;
 };
 

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -1750,12 +1750,12 @@ Fetch the pointer to the ith function argument.
 
 Function(
     comment="""
-Fetch HIP error parameters from the FRAME's function arguments.
+Fetch HIP error information from the FRAME's function arguments.
 FRAME is the frame of a "__hipOnError ()" function.  On a successful
-run, return the parameters.  Otherwise, return a std::nullopt.
+run, return the info.  Otherwise, return a std::nullopt.
 """,
-    type="std::optional<hiperr_parameters>",
-    name="fetch_hiperr_parameters",
+    type="std::optional<hiperr_info>",
+    name="fetch_hiperr_info",
     params=[
         ("frame_info_ptr", "frame"),
     ],

--- a/gdb/mi/mi-cmd-catch.c
+++ b/gdb/mi/mi-cmd-catch.c
@@ -358,3 +358,48 @@ mi_cmd_catch_catch (const char *cmd, const char *const *argv, int argc)
 {
   mi_cmd_catch_exception_event (EX_EVENT_CATCH, cmd, argv, argc);
 }
+
+/* Handler for -catch-hiperr.  */
+
+void
+mi_cmd_catch_hiperr (const char *cmd, const char *const *argv, int argc)
+{
+  bool temp = false;
+  const char *condition = nullptr;
+
+  int oind = 0;
+  const char *oarg;
+
+  enum opt
+    {
+      OPT_CONDITION,
+      OPT_TEMP,
+    };
+  static const struct mi_opt opts[] =
+    {
+      { "c", OPT_CONDITION, 1 },
+      { "t", OPT_TEMP, 0 },
+      { 0, 0, 0 }
+    };
+
+  for (;;)
+    {
+      int opt = mi_getopt (cmd, argc, argv, opts, &oind, &oarg);
+
+      if (opt < 0)
+	break;
+
+      switch ((enum opt) opt)
+	{
+	case OPT_CONDITION:
+	  condition = oarg;
+	  break;
+	case OPT_TEMP:
+	  temp = true;
+	  break;
+	}
+    }
+
+  scoped_restore restore_breakpoint_reporting = setup_breakpoint_reporting ();
+  add_catch_hiperr (condition, temp);
+}

--- a/gdb/mi/mi-cmds.c
+++ b/gdb/mi/mi-cmds.c
@@ -237,6 +237,8 @@ add_builtin_mi_commands ()
 		 &mi_suppress_notification.breakpoint),
   add_mi_cmd_mi ("catch-catch", mi_cmd_catch_catch,
 		 &mi_suppress_notification.breakpoint),
+  add_mi_cmd_mi ("catch-hiperr", mi_cmd_catch_hiperr,
+		 &mi_suppress_notification.breakpoint),
   add_mi_cmd_mi ("complete", mi_cmd_complete);
   add_mi_cmd_mi ("data-disassemble", mi_cmd_disassemble);
   add_mi_cmd_mi ("data-evaluate-expression", mi_cmd_data_evaluate_expression);

--- a/gdb/mi/mi-cmds.h
+++ b/gdb/mi/mi-cmds.h
@@ -55,6 +55,7 @@ extern mi_cmd_argv_ftype mi_cmd_catch_unload;
 extern mi_cmd_argv_ftype mi_cmd_catch_throw;
 extern mi_cmd_argv_ftype mi_cmd_catch_rethrow;
 extern mi_cmd_argv_ftype mi_cmd_catch_catch;
+extern mi_cmd_argv_ftype mi_cmd_catch_hiperr;
 extern mi_cmd_argv_ftype mi_cmd_disassemble;
 extern mi_cmd_argv_ftype mi_cmd_data_evaluate_expression;
 extern mi_cmd_argv_ftype mi_cmd_data_list_register_names;

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -21,10 +21,10 @@
 #include <hip/hip_runtime.h>
 #include "rocm-test-utils.h"
 
-/* If set, the "hip_* ()" functions will record the error parameters.  */
+/* If set, the "hip_* ()" functions will record the error info.  */
 static bool gen_ref = false;
 
-struct hiperr_params_ref
+struct hiperr_info_ref
 {
   volatile int no;  /* Prevent the optimizer from keeping this in a register.  */
   const char *name;
@@ -39,9 +39,9 @@ struct hiperr_params_ref
 };
 
 /* Reference values for the test.  */
-static hiperr_params_ref hip_set_device_err;
-static hiperr_params_ref hip_get_device_err;
-static hiperr_params_ref hip_launch_kernel_err;
+static hiperr_info_ref hip_set_device_err;
+static hiperr_info_ref hip_get_device_err;
+static hiperr_info_ref hip_launch_kernel_err;
 
 /* Get the maximum number of threads per block.  */
 
@@ -70,7 +70,7 @@ kernel ()
 }
 
 /* The purpose of these "hip_* ()" functions is to produce some errors
-   and have the error parameters recorded.  GDB can use these recorded
+   and have the error info recorded.  GDB can use these recorded
    values as references to verify the catchpoints outputs.  */
 
 /* Dispatch a kernel via the triple chevron syntax with an oversized

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -30,7 +30,7 @@ struct hiperr_info_ref
   const char *name;
   const char *str;
 
-  void save (hipError_t err_no)
+  void save (hipError_t err_no) volatile
   {
     no = static_cast <int> (err_no);
     name = hipGetErrorName (err_no);
@@ -39,9 +39,9 @@ struct hiperr_info_ref
 };
 
 /* Reference values for the test.  */
-static hiperr_info_ref hip_set_device_err;
-static hiperr_info_ref hip_get_device_err;
-static hiperr_info_ref hip_launch_kernel_err;
+volatile static hiperr_info_ref hip_set_device_err;
+volatile static hiperr_info_ref hip_get_device_err;
+volatile static hiperr_info_ref hip_launch_kernel_err;
 
 /* Get the maximum number of threads per block.  */
 
@@ -130,7 +130,8 @@ main (int argc, const char **argv)
       hip_set_device ();
       hip_get_device ();
       hip_launch_kernel ();
-      asm volatile ("" ::: "memory"); /* Break after reference initialization.  */
+      /* Break after reference initialization.  */
+      HOST_NOP;
     }
   else if (test == "one")
     hip_set_device ();

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -16,20 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Test catching HIP's API errors:
+# Test catching HIP's API errors.  Test goals are:
 #
-# 1. The executable is loaded and started.
-# 2. The executable is loaded but not started.
-# 3. There's no executable set yet.
-# 4. Two API errors are returned and caught.
-# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
-# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
-# 7. Temporary catch of the first error, while there are 2 errors.
-# 8. $_hiperr is printed correctly when debug symbols are available.
-# 9. $_hiperr is printed correctly without debug symbols.
-#    This one checks if "catch hiperr" works without debug symbols as well.
+# - CLI: check catchpoints, either simple or complex (conditional or
+# temporary) are getting triggered correctly.  Also try without debug
+# symbols.
+#
+# - MI: parsing for the "-catch-hiperr ..." command.
+# - MI: catchpoints are set correctly and reported correctly when
+# triggered.
 
 load_lib rocm.exp
+load_lib mi-support.exp
 
 require allow_hip_tests
 
@@ -77,21 +75,29 @@ proc get_string_valueof {exp default} {
 }
 
 # Get the reference values from the program (which is run with "ref" argument)
+# Return true when all references are initialized; false, otherwise.
 
 proc init_reference_hip_errors {} {
     foreach func {set_device get_device launch_kernel} {
+	set sum 0
+
 	set ::hip_${func}_err_no [get_integer_valueof "hip_${func}_err.no" bad]
-	gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
-	    "hip_${func}_err_no initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
+		      "hip_${func}_err_no initialized"]
 
 	set ::hip_${func}_err_name [get_string_valueof "hip_${func}_err.name" bad]
-	gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
-	    "hip_${func}_err_name initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
+		      "hip_${func}_err_name initialized"]
 
 	set ::hip_${func}_err_str [get_string_valueof "hip_${func}_err.str" bad]
-	gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
-	    "hip_${func}_err_str initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
+		      "hip_${func}_err_str initialized"]
+
+	if {$sum != 3} {
+	    return false
+	}
     }
+    return true
 }
 
 # Set a hiperr catchpoint and check if it set accordingly.  If TEMP is
@@ -187,12 +193,14 @@ proc check_hip_launch_kernel_err {cmd} {
 	$::hip_launch_kernel_err_str
 }
 
-proc do_test {} {
-    with_rocm_gpu_lock {
+# Check for __hipOnError symbol existence and initialize references
+# using the test program.  Return false if anything goes wrong.
 
+proc_with_prefix preparation_test {} {
+    with_rocm_gpu_lock {
 	clean_restart ${::testfile}.dbg
 	if {![runto_main]} {
-	    return
+	    return false
 	}
 	gdb_test_multiple "info symbol __hipOnError" \
 	    "check if __hipOnError symbol exists" {
@@ -201,21 +209,39 @@ proc do_test {} {
 	    }
 	    -re -wrap ".*" {
 		unsupported "no __hipOnError symbol was found"
-		return
+		return false
 	    }
 	}
 
 	# Let all the errors occur and their values be recorded by the program.
-	with_test_prefix "getting reference values" {
+	with_test_prefix "get ref vals" {
 	    clean_restart ${::testfile}.dbg
 	    gdb_test_no_output "set args ref"
 	    if {![runto [gdb_get_line_number \
 			    "Break after reference initialization"]]} {
-		return
+		return false
 	    }
-	    init_reference_hip_errors
+	    set res [init_reference_hip_errors]
 	}
+    }
+    return $res
+}
 
+# Test catching HIP's API errors (through CLI interface):
+#
+# 1. The executable is loaded and started.
+# 2. The executable is loaded but not started.
+# 3. There's no executable set yet.
+# 4. Two API errors are returned and caught.
+# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
+# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
+# 7. Temporary catch of the first error, while there are 2 errors.
+# 8. $_hiperr is printed correctly when debug symbols are available.
+# 9. $_hiperr is printed correctly without debug symbols.
+#    This one checks if "catch hiperr" works without debug symbols as well.
+
+proc_with_prefix cli_test {} {
+    with_rocm_gpu_lock {
 	with_test_prefix "after starting" {
 	    clean_restart ${::testfile}.dbg
 	    gdb_test_no_output "set args one"
@@ -329,6 +355,188 @@ proc do_test {} {
 		"print as $::hip_launch_kernel_err_no"
 	}
     }
+    gdb_exit
 }
 
-do_test
+# Return a string that looks like:
+#
+#   number="BP_NUM",type="catchpoint",disp="DISP",enabled="y",
+#   what="catch hiperr",catch-type="hiperr",cond="COND",
+#   times="0"
+#
+# The 'cond=...' field is added only if the provided COND is
+# not an empty string.
+
+proc hiperr_bkpt_re {bp_num disp cond} {
+    append bkpt "number=\"$bp_num\",type=\"catchpoint\",disp=\"$disp\","
+    append bkpt "enabled=\"y\",what=\"catch hiperr\",catch-type=\"hiperr\","
+    if {$cond != ""} {
+	append bkpt "cond=\"$cond\","
+    }
+    append bkpt "times=\"0\""
+    return $bkpt
+}
+
+
+# Check if the following commands are handled correctly:
+#
+# -catch-hiperr -c "$_hiperr == hipErrorInvalidDevice -t" -t
+# -catch-hiperr -c
+# -catch-hiperr -abc
+# -catch-hiperr one two three
+
+proc_with_prefix mi_parsing {} {
+    mi_clean_restart
+
+    # Each element is {TEST OPTIONS DISP COND ERR}, where TEST is the
+    # test name, OPTIONS are the extra "-catch-hiperr" options to
+    # test, DISP is the expected disposition ("keep" or "del"),
+    # COND is the expected condition ("" for none), and ERR is the
+    # expected error ("" for none) after issuing the MI command.
+    #
+    # Note that in the first case the "-t" embedded in the -c argument
+    # is part of the condition, while the trailing -t is what makes
+    # the catchpoint temporary.
+    set tests {
+	{ "trailing -t in condition"
+	  {-c "$_hiperr == hipErrorInvalidDevice -t" -t}
+	  del
+	  {$_hiperr == hipErrorInvalidDevice -t}
+	  "" }
+
+	{ "dangling -c"
+	  "-c"
+	  keep
+	  ""
+	  "Option -c requires an argument" }
+
+	{ "unknown option"
+	  "-abc"
+	  keep
+	  ""
+	  "Unknown option \\\"abc\\\"" }
+
+	{ "trailing junk"
+	  "-t one two three"
+	  del
+	  ""
+	  "" }
+    }
+
+    set bp_num 0
+    foreach t $tests {
+	lassign $t test options disp cond err
+
+	if {$err == ""} {
+	    incr bp_num
+	    set cond_re [expr {$cond eq "" ? "" : [string_to_regexp $cond]}]
+	    set params [hiperr_bkpt_re $bp_num $disp $cond_re]
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^done,bkpt=\{$params\}" \
+		"$test: mi-catch-hiperr"
+
+	    mi_gdb_test "-break-info $bp_num" \
+		".*\{$params\}.*" \
+		"$test: breakpoint info"
+	} else {
+	    set err_re [expr {$err eq "" ? "" : [string_to_regexp $err]}]
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^error,msg=\"catch-hiperr: $err_re\"" \
+		"$test: mi-catch-hiperr"
+	}
+    }
+    mi_gdb_exit
+}
+
+# Test different combinations of "-catch-hiperr [-c <condition>] [-t]"
+#
+# 1. -catch-hiperr
+# 2. -catch-hiperr -t
+# 3. -catch-hiperr -c $_hiperr==101
+# 4. -catch-hiperr -c $_hiperr==101 -t
+#
+# Check if they're set correctly and also hit accordingly.
+
+proc_with_prefix mi_test {} {
+    with_rocm_gpu_lock {
+
+	mi_clean_restart
+
+	# Each element is {TEST OPTIONS DISP COND}, where TEST is the
+	# test name, OPTIONS are the extra "-catch-hiperr" options to
+	# test, DISP is the expected disposition ("keep" or "del"),
+	# and COND is the expected condition ("" for none).
+	set tests {
+	    { "simple catch"
+	      ""
+	      keep
+	      "" }
+
+	    { "temporary catch"
+	      "-t"
+	      del
+	      "" }
+
+	    { "conditional catch"
+	      {-c "$_hiperr == 101"}
+	      keep
+	      {$_hiperr == 101} }
+
+	    { "temporary conditional catch"
+	      {-c "$_hiperr == hipErrorInvalidDevice" -t}
+	      del
+	      {$_hiperr == hipErrorInvalidDevice} }
+	}
+
+	# The relevant part of MI stop after catching a hiperr.
+	append hiperr_stop_re "\\*stopped,bkptno=\"1\","
+	append hiperr_stop_re "reason=\"breakpoint-hit\".*hiperr-code=\"$::hip_set_device_err_no\","
+	append hiperr_stop_re "hiperr-name=\"$::hip_set_device_err_name\","
+	append hiperr_stop_re "hiperr-str=\"$::hip_set_device_err_str\".*"
+
+	foreach t $tests {
+	    lassign $t test options disp cond
+	    set cond_re [expr {$cond eq "" ? "" : [string_to_regexp $cond]}]
+	    set params [hiperr_bkpt_re 1 $disp $cond_re]
+
+	    mi_clean_restart
+	    mi_gdb_load $::binfile.dbg
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^done,bkpt=\{$params\}" \
+		"$test: mi-catch-hiperr"
+
+	    mi_gdb_test "-break-info" \
+		".*\{$params\}.*" \
+		"$test: breakpoint info"
+
+	    # Run the test program to trigger one hipErrorInvalidDevice error.
+	    mi_gdb_test "-exec-arguments one" "\\^done" "$test: set argument"
+	    mi_run_cmd
+
+	    # Check for the async stop.  mi_expect_stop cannot be used because
+	    # it is breakpoint oriented with arguments like "func", "args", ...
+	    # and no checking for the "hiperr-*" fields.
+	    gdb_expect {
+		-re $hiperr_stop_re {
+		    pass $test
+		} -re ".*\r\n$::mi_gdb_prompt$" {
+		    fail "$test (unexpected output)"
+		} timeout {
+		    fail "$test (timeout)"
+		}
+	    }
+	}
+	mi_gdb_exit
+    }
+}
+
+# Start with "mi_parsing" because it doesn't need "preparation_test".
+mi_parsing
+if {![preparation_test]} {
+    return
+}
+cli_test
+mi_test

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -45,7 +45,7 @@ if {[prepare_for_testing "failed to prepare non-debug version of ${testfile}" \
     return -1
 }
 
-# Reference error parameters for HIP API calls:
+# Reference error info for HIP API calls:
 #   hipSetDevice (...)
 #   hipGetDevice (...)
 #   hipLaunchKernel (...)

--- a/gdb/testsuite/gdb.rocm/rocm-test-utils.h
+++ b/gdb/testsuite/gdb.rocm/rocm-test-utils.h
@@ -54,4 +54,9 @@
 
 #define NOP(N) asm volatile ("s_nop " #N)
 
+/* Insert host "nop" into the code.  It's useful for adding pieces of code
+   that we can set a breakpoint on without getting optimized away.  */
+
+#define HOST_NOP asm volatile ("nop")
+
 #endif /* ROCM_TEST_UTILS_H */


### PR DESCRIPTION
Introduce a new MI command to catch HIP runtime errors that takes the form of:
```
  -catch-hiperr [ -c <condition> ] [ -t ]
```

Along with it the documentation is updated and new tests are added.

## Motivation

Add Machine Interface for "catch hiperr".

## Technical Details

Machine Interface allows other tools control GDB by sending it commands and reading its feedback. This was missing for the "catch hiperr" support that we added [earlier](https://github.com/ROCm/ROCgdb/pull/129).

## Test Plan

New MI tests are added `hip-catch-errors.exp`.

## Test Result

All the new tests are and "catch hiperr" tests are passing.
```
Running /data/work/src/dev/rocgdb/gdb/testsuite/gdb.rocm/hip-catch-errors.exp ...
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: trailing -t in condition: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: trailing -t in condition: breakpoint info
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: dangling -c: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: unknown option: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: dangling texts: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_parsing: dangling texts: breakpoint info
[ CLI tests in here ]
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: simple catch: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: simple catch: breakpoint info
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: simple catch: set argument
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: simple catch
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary catch: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary catch: breakpoint info
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary catch: set argument
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary catch
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: conditional catch: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: conditional catch: breakpoint info
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: conditional catch: set argument
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: conditional catch
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary conditional catch: mi-catch-hiperr
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary conditional catch: breakpoint info
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary conditional catch: set argument
PASS: gdb.rocm/hip-catch-errors.exp: mi_test: temporary conditional catch
```
