### PR TITLE
[ci] Use therock-ci-config for dynamic runner selection

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 76b6f7ace6cb1d3f4aad0c38987db3911e4c5462 # 2026-06-26
+  THEROCK_COMMIT_REF: 80e744323d4ebc08b6ea2d31c378fa48c70729fa # 2026-06-26
 
 jobs:
   therock-build-linux:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 2d417fa49bc4e657bcbcf0ae549238784175f0fe # 2026-06-18
+  THEROCK_COMMIT_REF: 76b6f7ace6cb1d3f4aad0c38987db3911e4c5462 # 2026-06-26
 
 jobs:
   therock-build-linux:
@@ -22,6 +22,8 @@ jobs:
     runs-on: azure-linux-scale-rocm
     permissions:
       id-token: write
+    outputs:
+      therock_ref: ${{ steps.export-ref.outputs.therock_ref }}
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6 # 2026-06-11
       options: -v /runner/config:/home/awsconfig/
@@ -33,11 +35,23 @@ jobs:
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
 
     steps:
+      - name: Export TheRock ref
+        id: export-ref
+        run: echo "therock_ref=${{ env.THEROCK_COMMIT_REF }}" >> $GITHUB_OUTPUT
+
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
           ref: ${{ env.THEROCK_COMMIT_REF }}
+
+      - name: Checkout CI config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
 
       - name: Checkout rocGDB repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -74,6 +88,7 @@ jobs:
           package_version: ADHOCBUILD
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
           BUILD_DIR: build
+          CI_CONFIG_PATH: ci-config
         run: |
           python3 build_tools/github_actions/build_configure.py
 
@@ -124,8 +139,9 @@ jobs:
     if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages.yml
+    secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: linux-gfx942-1gpu-core42-ossci-rocm
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -1,0 +1,89 @@
+name: Test component
+
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+      therock_ref:
+        type: string
+        required: true
+      amdgpu_families:
+        type: string
+      test_runs_on:
+        type: string
+      component:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test_component:
+    name: "Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})"
+    runs-on: ${{ inputs.test_runs_on }}
+    timeout-minutes: 60
+    container:
+      image: ${{ fromJSON(inputs.component).container_image }}
+      options: ${{ fromJSON(inputs.component).container_options }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.component).shard_arr }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+      VENV_DIR: ${{ github.workspace }}/.venv
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+
+    steps:
+      - name: Fetch 'build_tools' from TheRock
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          sparse-checkout: build_tools
+          path: "prejob"
+
+      - name: Pre-job cleanup GPU processes
+        if: ${{ runner.os == 'Linux' }}
+        timeout-minutes: 5
+        run: bash ./prejob/build_tools/github_actions/cleanup_processes.sh
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: ${{ inputs.therock_ref }}
+
+      - name: Run setup test environment
+        timeout-minutes: 15
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      - name: Driver / GPU sanity check
+        if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
+        timeout-minutes: 3
+        run: python ./build_tools/print_driver_gpu_info.py
+
+      - name: Test
+        timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+          TOTAL_SHARDS: ${{ fromJSON(inputs.component).total_shards }}
+        run: ${{ fromJSON(inputs.component).test_script }}
+
+      - name: Post-job cleanup GPU processes
+        if: ${{ always() && runner.os == 'Linux' }}
+        timeout-minutes: 5
+        run: bash ./build_tools/github_actions/cleanup_processes.sh

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -7,8 +7,9 @@ on:
         type: string
       artifact_group:
         type: string
-      test_runs_on:
+      therock_ref:
         type: string
+        required: true
       artifact_run_id:
         type: string
   workflow_dispatch:
@@ -17,8 +18,9 @@ on:
         type: string
       artifact_group:
         type: string
-      test_runs_on:
+      therock_ref:
         type: string
+        required: true
       artifact_run_id:
         type: string
 
@@ -26,45 +28,82 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 2d417fa49bc4e657bcbcf0ae549238784175f0fe # 2026-06-18
   VENV_DIR: ${{ github.workspace }}/.venv
   OUTPUT_ARTIFACTS_DIR: "./build"
 
 jobs:
-  rocgdb-tests:
-    name: 'rocgdb'
-    runs-on: ${{ inputs.test_runs_on }}
-    timeout-minutes: 45
-
-    container:
-      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb@sha256:7063e922b4b9145c92f20011674571f1c97b8fad6faaeb0b7d2d165b0bd9ae8b
-      options: "--cap-add=SYS_PTRACE --ipc host --group-add video --device /dev/kfd --device /dev/dri --group-add 110 --ulimit memlock=-1:-1 --security-opt seccomp=unconfined --env-file /etc/podinfo/gha-gpu-isolation-settings --user 0:0"
-
-    defaults:
-      run:
-        shell: bash
-
-    env:
-      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
-
+  configure_test_matrix:
+    name: "Configure test matrix"
+    runs-on: ubuntu-24.04
+    outputs:
+      components: ${{ steps.patch-scripts.outputs.components }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Checkout TheRock repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ env.THEROCK_COMMIT_REF }}
+          ref: ${{ inputs.therock_ref }}
 
-      - name: Run setup test environment workflow
-        uses: './.github/actions/setup_test_environment'
+      - name: Checkout CI config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
-          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
-          VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--debug-tools --tests"
-          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
 
-      - name: Run rocgdb tests
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Configure test matrix
+        env:
+          PROJECTS_TO_TEST: "rocgdb-cpu,rocgdb-gpu"
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          CI_CONFIG_PATH: ci-config
+        id: configure
+        run: python ./build_tools/github_actions/fetch_test_configurations.py
+
+      - name: Override rocgdb test_script to use artifact-installed script
+        # TheRock's fetch_test_configurations.py points test_rocgdb.py at its own
+        # build_tools copy. Rewrite to the script installed in the artifacts at
+        # OUTPUT_ARTIFACTS_DIR/tests/rocgdb/test_rocgdb.py.
+        id: patch-scripts
         run: |
-          python ${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py
+          components='${{ steps.configure.outputs.components }}'
+          script_path="${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py"
+          updated=$(echo "$components" | jq -c --arg s "$script_path" '
+            map(
+              .test_script |= gsub(
+                "build_tools/github_actions/test_executable_scripts/test_rocgdb\\.py";
+                $s
+              )
+            )
+          ')
+          echo "components=$updated" >> $GITHUB_OUTPUT
+
+  test_components:
+    name: "Test ${{ matrix.components.job_name }}"
+    needs: [configure_test_matrix]
+    if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
+    uses: ./.github/workflows/therock-test-component.yml
+    with:
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      therock_ref: ${{ inputs.therock_ref }}
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      # Per-component runner selection:
+      #   1. CPU-only components use a standard Linux scale runner
+      #   2. Per-component GPU runner (set by fetch_test_configurations.py)
+      test_runs_on: >-
+        ${{
+          (matrix.components.linux_cpu_runner == true &&
+            'aws-linux-scale-rocm-prod') ||
+          matrix.components.test_runner
+        }}
+      component: ${{ toJSON(matrix.components) }}
+    secrets: inherit


### PR DESCRIPTION
## Motivation

Runner labels and weights in rocgdb CI were hardcoded, requiring PRs every
time a label changes. Using ROCm/therock-ci-config as a dynamic source of
truth allows runner changes to propagate automatically, matching the approach
taken in TheRock, rocm-libraries, and rocm-systems.

## Technical Details

Switch rocgdb CI workflows to retrieve runner labels dynamically from
[ROCm/therock-ci-config](https://github.com/ROCm/therock-ci-config) instead
of hardcoding them.

Changes:
- Update `THEROCK_COMMIT_REF` to `76b6f7a` (2026-06-26) which includes
  `get_build_runner_labels()` and `load_external_config()` support
- Add **Checkout CI config** step (with `continue-on-error`) to
  `therock-ci-linux.yml` build job; pass `CI_CONFIG_PATH` to `build_configure.py`
- Replace monolithic `rocgdb-tests` job in `therock-test-packages.yml` with
  a `configure_test_matrix` + `test_components` pattern driven by
  `fetch_test_configurations.py` (`PROJECTS_TO_TEST=rocgdb-cpu,rocgdb-gpu`)
- Add new `therock-test-component.yml` for per-component test execution;
  `rocgdb-cpu` routes to a CPU runner, `rocgdb-gpu` routes to a GPU runner
  selected dynamically from `therock-ci-config`

## Test Plan

- Verify CI triggers on this PR and `configure_test_matrix` produces the
  expected `rocgdb-cpu` and `rocgdb-gpu` components
- Confirm `rocgdb-cpu` runs on `aws-linux-scale-rocm-prod` and `rocgdb-gpu`
  runs on the GPU runner resolved from `therock-ci-config`

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.