### PR TITLE
CI: update actions/github-script from v7 to v8

### DIFF
--- a/.github/workflows/auto_assignee.yml
+++ b/.github/workflows/auto_assignee.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign random reviewer
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;


### PR DESCRIPTION
## Motivation

`actions/github-script@v7` targets Node 20, which is deprecated on GitHub
Actions runners and causes a forced downgrade warning on every run.

## Technical Details

Bump `actions/github-script` from v7 to v8, which targets Node 24.

## Test Plan

- Verify the `auto-assign` workflow runs without the Node 20 deprecation warning.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.