### PR TITLE
gdb/testsuite: deduplicate --offload-arch targets in hcc_amdgpu_targets

### DIFF
--- a/gdb/testsuite/gdb.rocm/hcc-amdgpu-targets.exp
+++ b/gdb/testsuite/gdb.rocm/hcc-amdgpu-targets.exp
@@ -1,0 +1,81 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Unit tests for hcc_amdgpu_targets.  These exercise the deduplication
+# logic across both the env-var and device-enumeration code paths, and
+# do not require a GPU or a running GDB instance.
+
+load_lib rocm.exp
+
+# Run BODY with find_amdgpu_devices stubbed to return DEVICES, then
+# restore the original proc.
+proc with_stub_devices {devices body} {
+    rename find_amdgpu_devices __saved_find_amdgpu_devices
+    # tclint-disable-next-line command-args
+    proc find_amdgpu_devices {} [list return $devices]
+    set code [catch {uplevel 1 $body} result]
+    rename find_amdgpu_devices {}
+    rename __saved_find_amdgpu_devices find_amdgpu_devices
+    return -code $code $result
+}
+
+# Tests using find_amdgpu_devices (no HCC_AMDGPU_TARGET env var).
+
+save_vars { env(HCC_AMDGPU_TARGET) } {
+    unset -nocomplain ::env(HCC_AMDGPU_TARGET)
+
+    with_stub_devices {gfx942 gfx942 gfx942} {
+	set result [hcc_amdgpu_targets]
+	verbose -log "hcc_amdgpu_targets: got $result"
+	gdb_assert {$result eq {gfx942}} "duplicates removed: 3x gfx942 produces single entry"
+    }
+
+    with_stub_devices {gfx942 gfx942 gfx1100 gfx1100 gfx942} {
+	set result [hcc_amdgpu_targets]
+	verbose -log "hcc_amdgpu_targets: got $result"
+	gdb_assert {$result eq {gfx942 gfx1100}} "duplicates removed, order preserved: mixed list"
+    }
+
+    with_stub_devices {gfx906 gfx90a} {
+	set result [hcc_amdgpu_targets]
+	verbose -log "hcc_amdgpu_targets: got $result"
+	gdb_assert {$result eq {gfx906 gfx90a}} "no duplicates: distinct devices unchanged"
+    }
+
+    with_stub_devices {} {
+	set result [hcc_amdgpu_targets]
+	verbose -log "hcc_amdgpu_targets: got $result"
+	gdb_assert {$result eq {}} "empty device list returned as-is"
+    }
+}
+
+# Tests using HCC_AMDGPU_TARGET env var.
+
+save_vars { env(HCC_AMDGPU_TARGET) } {
+    set ::env(HCC_AMDGPU_TARGET) "gfx942,gfx942,gfx942"
+    set result [hcc_amdgpu_targets]
+    verbose -log "hcc_amdgpu_targets: got $result"
+    gdb_assert {$result eq {gfx942}} "env var: duplicates removed"
+}
+
+save_vars { env(HCC_AMDGPU_TARGET) } {
+    set ::env(HCC_AMDGPU_TARGET) "gfx906,gfx90a,gfx906"
+    set result [hcc_amdgpu_targets]
+    verbose -log "hcc_amdgpu_targets: got $result"
+    gdb_assert {$result eq {gfx906 gfx90a}} "env var: order preserved when deduplicating"
+}

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -101,20 +101,34 @@ gdb_caching_proc find_amdgpu_devices {} {
     return {}
 }
 
-# Get the list of GPU targets to compile for.
+# Get the list of unique GPU targets to compile for.
 #
 # If HCC_AMDGPU_TARGET is set in the environment, use it.
 # Otherwise, consider the devices available on the system.
+#
+# Duplicates are removed so that systems with multiple identical
+# GPUs do not produce redundant --offload-arch flags.
 
 proc hcc_amdgpu_targets {} {
     # First, look for HCC_AMDGPU_TARGET (same env var the HIP toolchain uses).
     if {[info exists ::env(HCC_AMDGPU_TARGET)]} {
 	# We don't verify the contents of HCC_AMDGPU_TARGET.
 	# That's the toolchain's job.
-	return [split $::env(HCC_AMDGPU_TARGET) ","]
+	set targets [split $::env(HCC_AMDGPU_TARGET) ","]
+    } else {
+	set targets [find_amdgpu_devices]
     }
 
-    return [find_amdgpu_devices]
+    # Remove duplicates while preserving order.
+    array set seen {}
+    set unique {}
+    foreach t $targets {
+	if {![info exists seen($t)]} {
+	    set seen($t) 1
+	    lappend unique $t
+	}
+    }
+    return $unique
 }
 
 gdb_caching_proc allow_hip_tests {} {


### PR DESCRIPTION
## Summary

- On systems with multiple identical GPUs, `hcc_amdgpu_targets` was emitting one `--offload-arch` flag per physical device, producing redundant entries (e.g. eight `--offload-arch=gfx942` flags on an 8-GPU MI300 system).
- Deduplicate the target list in `hcc_amdgpu_targets`, preserving order, using an array for O(1) membership tests. Applied to both the `HCC_AMDGPU_TARGET` env-var and `find_amdgpu_devices` code paths.
- Add `gdb.rocm/hcc-amdgpu-targets.exp` to unit-test the deduplication logic without requiring a GPU.

## Test plan

- [x] Run `make check TESTS="gdb.rocm/hcc-amdgpu-targets.exp"` and confirm all cases pass.
- [x] On a multi-GPU system, verify the compiler invocation now emits a single `--offload-arch=gfx942` instead of N copies.