### PR TITLE
Leave PC at trap instruction for debugtrap (ROCM-22957)

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -1666,6 +1666,28 @@ amd_dbgapi_target::resume (ptid_t scope_ptid, int step, enum gdb_signal signo)
       wave_info &wi = get_thread_wave_info (&thread);
       amd_dbgapi_resume_mode_t &resume_mode = wi.last_resume_mode;
       amd_dbgapi_exceptions_t wave_exception;
+
+      /* If this thread is stopped at a program breakpoint (e.g., debugtrap),
+	 advance PC past the trap instruction before resuming.  This prevents
+	 hitting the same trap instruction again immediately after resuming.  */
+      if (thread.ptid == inferior_ptid)
+	{
+	  regcache *regcache = get_thread_regcache (&thread);
+	  gdbarch *gdbarch = regcache->arch ();
+	  CORE_ADDR pc = regcache_read_pc (regcache);
+
+	  if (gdbarch_program_breakpoint_here_p (gdbarch, pc))
+	    {
+	      amd_dbgapi_debug_printf ("advancing PC past program breakpoint at %s",
+				       paddress (gdbarch, pc));
+
+	      int bp_len;
+	      gdbarch_breakpoint_from_pc (gdbarch, &pc, &bp_len);
+	      pc += bp_len;
+	      regcache_write_pc (regcache, pc);
+	    }
+	}
+
       if (thread.ptid == inferior_ptid)
 	{
 	  resume_mode = (step

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -2455,7 +2455,9 @@ amd_dbgapi_target::stopped_by_sw_breakpoint ()
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     return false;
 
-  return (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT) != 0;
+  return (stop_reason
+	  & (AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT
+	     | AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP)) != 0;
 }
 
 bool

--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -2019,6 +2019,34 @@ amdgpu_supports_arch_info (const struct bfd_arch_info *info)
   return status == AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+static bool
+amdgpu_program_breakpoint_here_p (gdbarch *gdbarch, CORE_ADDR address)
+{
+  scoped_restore restore_memory
+    = make_scoped_restore_show_memory_breakpoints (0);
+
+  amd_dbgapi_architecture_id_t architecture_id;
+  if (amd_dbgapi_get_architecture
+      (gdbarch_bfd_arch_info (gdbarch)->mach, &architecture_id)
+      != AMD_DBGAPI_STATUS_SUCCESS)
+    error (_("amd_dbgapi_get_architecture failed"));
+
+  size_t len = gdbarch_max_insn_length (gdbarch);
+  gdb::byte_vector buffer (len);
+
+  if (target_read_memory (address, buffer.data (), len) != 0)
+    error (_("target_read_memory failed"));
+
+  amd_dbgapi_instruction_kind_t insn_kind;
+  if (amd_dbgapi_classify_instruction (architecture_id,
+				       address, &len, buffer.data (),
+				       &insn_kind, nullptr, nullptr)
+      != AMD_DBGAPI_STATUS_SUCCESS)
+    return false;  /* Treat unclassifiable instructions as non-traps.  */
+
+  return insn_kind == AMD_DBGAPI_INSTRUCTION_KIND_TRAP;
+}
+
 static struct gdbarch *
 amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 {
@@ -2234,6 +2262,8 @@ amdgpu_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
     error (_("amd_dbgapi_architecture_get_info failed"));
 
   set_gdbarch_max_insn_length (gdbarch, max_insn_length);
+  set_gdbarch_program_breakpoint_here_p (gdbarch,
+					 amdgpu_program_breakpoint_here_p);
 
   /* Lane debugging.  */
   set_gdbarch_active_lanes_mask (gdbarch, amdgpu_active_lanes_mask);

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -327,7 +327,7 @@ if test "$gdb_require_amd_dbgapi" = true \
   # stability until amd-dbgapi hits 1.0, but for convenience, still check for
   # greater or equal that version.  It can be handy when testing with a newer
   # version of the library.
-  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.80.0],
+  PKG_CHECK_MODULES([AMD_DBGAPI], [amd-dbgapi >= 0.81.0],
 		    [has_amd_dbgapi=yes], [has_amd_dbgapi=no])
 
   if test "$has_amd_dbgapi" = "yes"; then

--- a/gdb/testsuite/gdb.rocm/debugtrap.exp
+++ b/gdb/testsuite/gdb.rocm/debugtrap.exp
@@ -49,18 +49,17 @@ proc_with_prefix do_test_under_debugger {} {
 	    "Thread $::decimal.*received signal SIGTRAP, Trace/breakpoint trap\..*" \
 	    "raises SIGTRAP"
 
-	# The __builtin_debugtrap intrinsic  is implemented using the
-	# 's_trap 3' instruction.  When SIGTRAP is raised, the PC should point
-	# to the instruction just after the s_trap, and not the s_trap
-	# directly.  This is so we can "continue" execution past this
-	# instruction.  Note that we know that 's_trap 3' is encoded as a
-	# 4 byte instruction which is the smallest encoding of the ISA (s_trap
-	# is also used to implement software breakpoints).
-	gdb_test "x/2i \$pc - 4" \
-	    [multi_line \
-		"   ${::hex}\[^\r\n\]*s_trap 3" \
-		"=> ${::hex}\[^\r\n\]*"]
+	# The __builtin_debugtrap intrinsic is implemented using the
+	# 's_trap 3' instruction.  With the new trap handler ABI (version 12),
+	# when SIGTRAP is raised, the PC points AT the s_trap instruction
+	# (not after it).  GDB will automatically advance PC when continuing.
+	# Note that 's_trap 3' is encoded as a 4 byte instruction which is
+	# the smallest encoding of the ISA (s_trap is also used to implement
+	# software breakpoints).
+	gdb_test "x/i \$pc" \
+	    "=> ${::hex}\[^\r\n\]*s_trap 3"
 
+	# GDB should be able to continue past the debugtrap.
 	gdb_continue_to_end "continue until exit" continue 1
     }
 }


### PR DESCRIPTION
● Motivation

  Make ROCgdb compliant with the LLVM llvm.debugtrap reference document specification for s_trap 3 instruction
  handling. Per the specification, when the debugger is enabled, the trap handler must leave the PC at the s_trap 3
  instruction, and the debugger is responsible for incrementing the PC before resuming execution.

  Fixes: https://amd-hub.atlassian.net/browse/ROCM-22957

  Technical Details

  This is adaptation of https://gerrit-git.amd.com/plugins/gitiles/compute/ec/rocm-gdb/+/refs/heads/lancesix/pc_adjust%5E%21/

  Changes:
  - gdb/amdgpu-tdep.c: Add amdgpu_program_breakpoint_here_p() to detect trap instructions using
  amd_dbgapi_classify_instruction(). Handles illegal instructions gracefully by returning false when classification
  fails.
  - gdb/amd-dbgapi-target.c: Treat DEBUG_TRAP as a software breakpoint in stopped_by_sw_breakpoint()
  - gdb/infrun.c: Advance PC past trap instructions in resume() before continuing execution
  - gdb/testsuite/gdb.rocm/debugtrap.exp: Update test expectations to verify PC is at trap instruction when stopped
  - gdb/configure.ac: Bump required amd-dbgapi version to 0.81.0

  Coordinated Changes Required:

  This PR must be merged together with corresponding changes in:
  - rocm-dbgapi: Set breakpoint_instruction_pc_adjust() to return 0, bump ABI version to 12
  - hsa-runtime: Modify trap handler to leave PC at trap when debugger is attached, set r_version to 12
  These changes are in https://github.com/ROCm/rocm-systems/pull/7978

  Test Plan

  - Verified gdb.rocm/debugtrap.exp test passes with new behavior (PC at trap instruction)
  - Verified gdb.rocm/illegal-insn-sigill.exp test passes (graceful handling of unclassifiable instructions)
  - Full gdb.rocm/*.exp test suite executed

  Test Result

  All gdb.rocm tests passing: 1,945 expected passes, 0 unexpected failures
