### PR TITLE
cleanup around wave coordinates

### DIFF
--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -709,53 +709,41 @@ struct work_item_info
   }
 };
 
-/* Populate WI, a work_item_info object.
-   Returns true on success, false if info is not available.  */
-
-static bool
-make_work_item_info (thread_info *tp, work_item_info *wi)
-{
-  wave_info &info = get_thread_wave_info (tp);
-  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
-    {
-      /* The dispatch associated with a wave is not available.  A wave
-	 may not have an associated dispatch if attaching to a process
-	 with already existing waves.  */
-      return false;
-    }
-
-  wi->dispatch_id = info.coords.dispatch_id;
-  wi->queue_id = info.coords.queue_id;
-  wi->agent_id = info.coords.agent_id;
-
-  dispatch_get_info_throw (wi->dispatch_id, AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
-			   wi->grid_sizes);
-
-  dispatch_get_info_throw (wi->dispatch_id,
-			   AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
-			   wi->work_group_sizes);
-
-  wi->work_group_ids = info.coords.group_ids;
-  wi->wave_in_group = info.coords.wave_in_group;
-
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, wi->lane_count);
-
-  return true;
-}
-
 /* Return the work-group position of the work-item assigned to lane LANE.  */
 
 static opt_vec3_u32_t
 lane_workgroup_pos (thread_info *tp, int lane)
 {
   work_item_info wi;
-  if (make_work_item_info (tp, &wi))
+
+  wave_info &info = get_thread_wave_info (tp);
+  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     {
-      vec3_t<size_t> partial_wg_sizes;
-      wi.partial_work_group_sizes (partial_wg_sizes);
-      return flatid_to_id (wi.flatid (lane), partial_wg_sizes);
+      /* The dispatch associated with a wave is not available.  A wave
+	 may not have an associated dispatch if attaching to a process
+	 with already existing waves.  */
+      return std::nullopt;
     }
-  return std::nullopt;
+
+  wi.dispatch_id = info.coords.dispatch_id;
+  wi.queue_id = info.coords.queue_id;
+  wi.agent_id = info.coords.agent_id;
+
+  dispatch_get_info_throw (wi.dispatch_id, AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
+			   wi.grid_sizes);
+
+  dispatch_get_info_throw (wi.dispatch_id,
+			   AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
+			   wi.work_group_sizes);
+
+  wi.work_group_ids = info.coords.group_ids;
+  wi.wave_in_group = info.coords.wave_in_group;
+
+  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, wi.lane_count);
+
+  vec3_t<size_t> partial_wg_sizes;
+  wi.partial_work_group_sizes (partial_wg_sizes);
+  return flatid_to_id (wi.flatid (lane), partial_wg_sizes);
 }
 
 /* Return the lane's work-group position as a string.  */

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -635,12 +635,11 @@ agent_target_id_string (amd_dbgapi_agent_id_t agent_id)
 static std::string
 thread_workgroup_pos_string (thread_info *tp)
 {
-  uint32_t wave_in_group;
-  if (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP,
-		     wave_in_group) != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (tp);
+  if (info.coords.wave_in_group == UINT32_MAX)
     return "?";
 
-  return string_printf ("%u", wave_in_group);
+  return string_printf ("%s", pulongest (info.coords.wave_in_group));
 }
 
 /* Return the coordinates for flat ID FLATID.
@@ -716,8 +715,8 @@ struct work_item_info
 static bool
 make_work_item_info (thread_info *tp, work_item_info *wi)
 {
-  if (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_DISPATCH, wi->dispatch_id)
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (tp);
+  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     {
       /* The dispatch associated with a wave is not available.  A wave
 	 may not have an associated dispatch if attaching to a process
@@ -725,8 +724,10 @@ make_work_item_info (thread_info *tp, work_item_info *wi)
       return false;
     }
 
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_QUEUE, wi->queue_id);
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_AGENT, wi->agent_id);
+  wi->dispatch_id = info.coords.dispatch_id;
+  wi->queue_id = info.coords.queue_id;
+  wi->agent_id = info.coords.agent_id;
+
   dispatch_get_info_throw (wi->dispatch_id, AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
 			   wi->grid_sizes);
 
@@ -734,11 +735,8 @@ make_work_item_info (thread_info *tp, work_item_info *wi)
 			   AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
 			   wi->work_group_sizes);
 
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD,
-		       wi->work_group_ids);
-
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP,
-		       wi->wave_in_group);
+  wi->work_group_ids = info.coords.group_ids;
+  wi->wave_in_group = info.coords.wave_in_group;
 
   wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, wi->lane_count);
 
@@ -1017,18 +1015,13 @@ amd_dbgapi_target::thread_name (thread_info *tp)
      Note: we use a hash instead of the entry point address so that
      the number is stable across runs.  */
 
-  amd_dbgapi_wave_id_t wave_id = get_amd_dbgapi_wave_id (tp->ptid);
-
-  amd_dbgapi_dispatch_id_t dispatch_id;
-  if (amd_dbgapi_wave_get_info (wave_id,
-				AMD_DBGAPI_WAVE_INFO_DISPATCH,
-				sizeof (dispatch_id), &dispatch_id)
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (tp);
+  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     return nullptr;
 
   amd_dbgapi_global_address_t kernel_addr;
   if (amd_dbgapi_dispatch_get_info
-      (dispatch_id,
+      (info.coords.dispatch_id,
        AMD_DBGAPI_DISPATCH_INFO_KERNEL_CODE_ENTRY_ADDRESS,
        sizeof (kernel_addr), &kernel_addr)
       != AMD_DBGAPI_STATUS_SUCCESS)
@@ -1185,15 +1178,11 @@ amd_dbgapi_target::workgroup_grid_pos (thread_info *thr)
   if (!ptid_is_gpu (thr->ptid))
     return beneath ()->workgroup_grid_pos (thr);
 
-  vec3_u32_t group_ids;
-  if (amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (thr->ptid),
-				AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD,
-				sizeof (group_ids),
-				group_ids.data ())
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (thr);
+  if (info.coords.group_ids[0] == UINT32_MAX)
     return std::nullopt;
 
-  return group_ids;
+  return info.coords.group_ids;
 }
 
 /* Implementation of target_ops::workgroup_sizes.  */
@@ -1204,18 +1193,13 @@ amd_dbgapi_target::workgroup_sizes (thread_info *thr)
   if (!ptid_is_gpu (thr->ptid))
     return beneath ()->workgroup_sizes (thr);
 
-  /* Get the current dispatch ID.  */
-  amd_dbgapi_dispatch_id_t dispatch_id;
-  if (amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (thr->ptid),
-				AMD_DBGAPI_WAVE_INFO_DISPATCH,
-				sizeof (dispatch_id),
-				&dispatch_id)
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (thr);
+  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     return std::nullopt;
 
   /* Now that we have a dispatch ID, get the group sizes.  */
   std::array<uint16_t, 3> group_sizes_16b;
-  if (amd_dbgapi_dispatch_get_info (dispatch_id,
+  if (amd_dbgapi_dispatch_get_info (info.coords.dispatch_id,
 				    AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
 				    sizeof (group_sizes_16b),
 				    group_sizes_16b.data ())
@@ -1238,18 +1222,13 @@ amd_dbgapi_target::grid_sizes (thread_info *thr)
   if (!ptid_is_gpu (thr->ptid))
     return beneath ()->grid_sizes (thr);
 
-  /* Get the current dispatch ID.  */
-  amd_dbgapi_dispatch_id_t dispatch_id;
-  if (amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (thr->ptid),
-				AMD_DBGAPI_WAVE_INFO_DISPATCH,
-				sizeof (dispatch_id),
-				&dispatch_id)
-      != AMD_DBGAPI_STATUS_SUCCESS)
+  wave_info &info = get_thread_wave_info (thr);
+  if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     return std::nullopt;
 
   /* Now that we have a dispatch ID, get the group sizes.  */
   std::array<uint16_t, 3> group_sizes;
-  if (amd_dbgapi_dispatch_get_info (dispatch_id,
+  if (amd_dbgapi_dispatch_get_info (info.coords.dispatch_id,
 				    AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
 				    sizeof (group_sizes),
 				    group_sizes.data ())
@@ -1257,7 +1236,7 @@ amd_dbgapi_target::grid_sizes (thread_info *thr)
     return std::nullopt;
 
   vec3_u32_t grid_sizes;
-  if (amd_dbgapi_dispatch_get_info (dispatch_id,
+  if (amd_dbgapi_dispatch_get_info (info.coords.dispatch_id,
 				    AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
 				    sizeof (grid_sizes),
 				    grid_sizes.data ())
@@ -3827,13 +3806,13 @@ info_agents_command (const char *args, int from_tty)
 
   amd_dbgapi_agent_id_t current_agent_id;
   if ((uiout->is_mi_like_p () && args != nullptr && *args != '\0')
-      || !ptid_is_gpu (inferior_ptid)
-      || amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (inferior_ptid),
-				   AMD_DBGAPI_WAVE_INFO_AGENT,
-				   sizeof (current_agent_id),
-				   &current_agent_id)
-	   != AMD_DBGAPI_STATUS_SUCCESS)
+      || !ptid_is_gpu (inferior_ptid))
     current_agent_id = AMD_DBGAPI_AGENT_NONE;
+  else
+    {
+      wave_info &info = get_thread_wave_info (inferior_thread ());
+      current_agent_id = info.coords.agent_id;
+    }
 
   {
     std::optional<ui_out_emit_list> list_emitter;
@@ -4141,13 +4120,13 @@ info_queues_command (const char *args, int from_tty)
 
   amd_dbgapi_queue_id_t current_queue_id;
   if ((uiout->is_mi_like_p () && args != nullptr && *args != '\0')
-      || !ptid_is_gpu (inferior_ptid)
-      || amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (inferior_ptid),
-				   AMD_DBGAPI_WAVE_INFO_QUEUE,
-				   sizeof (current_queue_id),
-				   &current_queue_id)
-	   != AMD_DBGAPI_STATUS_SUCCESS)
+      || !ptid_is_gpu (inferior_ptid))
     current_queue_id = AMD_DBGAPI_QUEUE_NONE;
+  else
+    {
+      wave_info &info = get_thread_wave_info (inferior_thread ());
+      current_queue_id = info.coords.queue_id;
+    }
 
   {
     std::optional<ui_out_emit_list> list_emitter;
@@ -4498,13 +4477,13 @@ info_dispatches_command (const char *args, int from_tty)
 
   amd_dbgapi_dispatch_id_t current_dispatch_id;
   if ((uiout->is_mi_like_p () && args != nullptr && *args != '\0')
-      || !ptid_is_gpu (inferior_ptid)
-      || amd_dbgapi_wave_get_info (get_amd_dbgapi_wave_id (inferior_ptid),
-				   AMD_DBGAPI_WAVE_INFO_DISPATCH,
-				   sizeof (current_dispatch_id),
-				   &current_dispatch_id)
-	   != AMD_DBGAPI_STATUS_SUCCESS)
+      || !ptid_is_gpu (inferior_ptid))
     current_dispatch_id = AMD_DBGAPI_DISPATCH_NONE;
+  else
+    {
+      wave_info &info = get_thread_wave_info (inferior_thread ());
+      current_dispatch_id = info.coords.dispatch_id;
+    }
 
   {
     std::optional<ui_out_emit_list> list_emitter;

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -582,18 +582,8 @@ dispatch_target_id_string (amd_dbgapi_dispatch_id_t dispatch_id)
 static std::string
 dispatch_pos_string (thread_info *tp)
 {
-  vec3_u32_t group_ids;
-  if (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD, group_ids)
-      != AMD_DBGAPI_STATUS_SUCCESS)
-    return "(?,?,?)/?";
-
-  uint32_t wave_in_group;
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP,
-		       wave_in_group);
-
-  return string_printf ("(%d,%d,%d)/%d",
-			group_ids[0], group_ids[1], group_ids[2],
-			wave_in_group);
+  wave_info &info = get_thread_wave_info (tp);
+  return info.coords.dispatch_pos_str ();
 }
 
 /* Return the target id string for a given queue.  */
@@ -785,40 +775,12 @@ lane_workgroup_pos_string (thread_info *tp, int lane)
 static std::string
 lane_target_id_string (thread_info *tp, int lane)
 {
-  amd_dbgapi_dispatch_id_t dispatch_id;
-  amd_dbgapi_queue_id_t queue_id;
-  amd_dbgapi_agent_id_t agent_id;
-  vec3_u32_t group_ids;
+  wave_info &info = get_thread_wave_info (tp);
 
   std::string str = "AMDGPU Lane ";
-
-  str += (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_AGENT, agent_id)
-	  == AMD_DBGAPI_STATUS_SUCCESS)
-	   ? string_printf ("%ld", agent_id.handle)
-	   : " ?";
-
-  str += (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_QUEUE, queue_id)
-	  == AMD_DBGAPI_STATUS_SUCCESS)
-	   ? string_printf (":%ld", queue_id.handle)
-	   : ":?";
-
-  str += (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_DISPATCH,
-			 dispatch_id)
-	  == AMD_DBGAPI_STATUS_SUCCESS)
-	   ? string_printf (":%ld", dispatch_id.handle)
-	   : ":?";
-
-  amd_dbgapi_wave_id_t wave_id = get_amd_dbgapi_wave_id (tp->ptid);
-
-  str += string_printf (":%ld/%d", wave_id.handle, lane);
-
-  str += (wave_get_info (tp, AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD,
-			 group_ids)
-	  == AMD_DBGAPI_STATUS_SUCCESS
-	  ? string_printf (" (%d,%d,%d)", group_ids[0], group_ids[1],
-			   group_ids[2])
-	  : " (?,?,?)");
-
+  str += info.coords.hierarchy_str ();
+  str += string_printf ("/%d ", lane);
+  str += info.coords.workgroup_coord_str ();
   str += lane_workgroup_pos_string (tp, lane);
 
   return str;
@@ -3658,26 +3620,11 @@ amd_dbgapi_wave_id_make_value (struct gdbarch *gdbarch, struct internalvar *var,
 {
   if (ptid_is_gpu (inferior_ptid))
     {
-      amd_dbgapi_wave_id_t wave_id = get_amd_dbgapi_wave_id (inferior_ptid);
-      vec3_u32_t group_ids;
-      uint32_t wave_in_group;
+      wave_info &info = get_thread_wave_info (inferior_thread ());
+      std::string wave_id_str = info.coords.dispatch_pos_str ();
 
-      if (amd_dbgapi_wave_get_info (wave_id,
-				    AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD,
-				    sizeof (group_ids), &group_ids)
-	    == AMD_DBGAPI_STATUS_SUCCESS
-	  && amd_dbgapi_wave_get_info (
-	       wave_id, AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP,
-	       sizeof (wave_in_group), &wave_in_group)
-	       == AMD_DBGAPI_STATUS_SUCCESS)
-	{
-	  std::string wave_id_str
-	    = string_printf ("(%d,%d,%d)/%d", group_ids[0], group_ids[1],
-			     group_ids[2], wave_in_group);
-
-	  return value_cstring (wave_id_str.data (), wave_id_str.length (),
-				builtin_type (gdbarch)->builtin_char);
-	}
+      return value_cstring (wave_id_str.data (), wave_id_str.length (),
+			    builtin_type (gdbarch)->builtin_char);
     }
 
   return value::allocate (builtin_type (gdbarch)->builtin_void);

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -551,8 +551,8 @@ dispatch_target_id_string (amd_dbgapi_dispatch_id_t dispatch_id)
 				    sizeof (queue_id), &queue_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_dispatch_get_info failed to get queue id for "
-	     "dispatch_%ld: %s"),
-	   dispatch_id.handle, get_status_string (status));
+	     "dispatch_%s: %s"),
+	   pulongest (dispatch_id.handle), get_status_string (status));
 
   amd_dbgapi_agent_id_t agent_id;
   status = amd_dbgapi_dispatch_get_info (dispatch_id,
@@ -560,8 +560,8 @@ dispatch_target_id_string (amd_dbgapi_dispatch_id_t dispatch_id)
 					 sizeof (agent_id), &agent_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_dispatch_get_info failed to get agent id for "
-	     "dispatch_%ld: %s"),
-	   dispatch_id.handle, get_status_string (status));
+	     "dispatch_%s: %s"),
+	   pulongest (dispatch_id.handle), get_status_string (status));
 
   amd_dbgapi_os_queue_packet_id_t os_id;
   status = amd_dbgapi_dispatch_get_info
@@ -569,12 +569,14 @@ dispatch_target_id_string (amd_dbgapi_dispatch_id_t dispatch_id)
      sizeof (os_id), &os_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_dispatch_get_info failed to get OS queue packet id "
-	     "for dispatch_%ld: %s"),
-	   dispatch_id.handle, get_status_string (status));
+	     "for dispatch_%s: %s"),
+	   pulongest (dispatch_id.handle), get_status_string (status));
 
-  return string_printf ("AMDGPU Dispatch %ld:%ld:%ld (PKID %ld)",
-			agent_id.handle, queue_id.handle, dispatch_id.handle,
-			os_id);
+  return string_printf ("AMDGPU Dispatch %s:%s:%s (PKID %s)",
+			pulongest (agent_id.handle),
+			pulongest (queue_id.handle),
+			pulongest (dispatch_id.handle),
+			pulongest (os_id));
 }
 
 /* Return the dispatch position string for a given thread.  */
@@ -596,19 +598,20 @@ queue_target_id_string (amd_dbgapi_queue_id_t queue_id)
 				 sizeof (agent_id), &agent_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_queue_get_info failed to get agent id for "
-	     "queue_%ld: %s"),
-	   queue_id.handle, get_status_string (status));
+	     "queue_%s: %s"),
+	   pulongest (queue_id.handle), get_status_string (status));
 
   amd_dbgapi_os_queue_id_t os_id;
   status = amd_dbgapi_queue_get_info (queue_id, AMD_DBGAPI_QUEUE_INFO_OS_ID,
 				      sizeof (os_id), &os_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_queue_get_info failed to get OS queue id for "
-	     "queue_%ld: %s"),
-	   queue_id.handle, get_status_string (status));
+	     "queue_%s: %s"),
+	   pulongest (queue_id.handle), get_status_string (status));
 
-  return string_printf ("AMDGPU Queue %ld:%ld (QID %ld)", agent_id.handle,
-			queue_id.handle, os_id);
+  return string_printf ("AMDGPU Queue %s:%s (QID %s)",
+			pulongest (agent_id.handle),
+			pulongest (queue_id.handle), pulongest (os_id));
 }
 
 /* Return the target id string for a given agent.  */
@@ -621,10 +624,10 @@ agent_target_id_string (amd_dbgapi_agent_id_t agent_id)
 				 sizeof (os_id), &os_id);
   if (status != AMD_DBGAPI_STATUS_SUCCESS)
     error (_("amd_dbgapi_agent_get_info failed to get OS agent id for "
-	     "agent_%ld: %s"),
-	   agent_id.handle, get_status_string (status));
+	     "agent_%s: %s"),
+	   pulongest (agent_id.handle), get_status_string (status));
 
-  return string_printf ("AMDGPU Agent (GPUID %ld)", os_id);
+  return string_printf ("AMDGPU Agent (GPUID %s)", pulongest (os_id));
 }
 
 /* Return the thread/wave's workgroup position as a string.  */
@@ -764,8 +767,9 @@ lane_workgroup_pos_string (thread_info *tp, int lane)
 {
   if (auto wi_ids = lane_workgroup_pos (tp, lane);
       wi_ids.has_value ())
-    return string_printf ("[%d,%d,%d]",
-			  (*wi_ids)[0], (*wi_ids)[1], (*wi_ids)[2]);
+    return string_printf ("[%s,%s,%s]", pulongest ((*wi_ids)[0]),
+			  pulongest ((*wi_ids)[1]),
+			  pulongest ((*wi_ids)[2]));
   else
     return "[?,?,?]";
 }
@@ -3884,10 +3888,11 @@ info_agents_command (const char *args, int from_tty)
 		  = std::max (max_id_width,
 			      (show_inferior_qualified_tids ()
 				   || uiout->is_mi_like_p ()
-				 ? string_printf ("%d.%ld", inf->num,
-						  agent_id.handle)
-				 : string_printf ("%ld", agent_id.handle))
-				.size ());
+			       ? string_printf ("%d.%s", inf->num,
+						pulongest (agent_id.handle))
+			       : string_printf ("%s",
+						pulongest (agent_id.handle)))
+			      .size ());
 
 		/* target id  */
 		max_target_id_width
@@ -3994,10 +3999,11 @@ info_agents_command (const char *args, int from_tty)
 	    uiout->field_string ("id",
 				 (show_inferior_qualified_tids ()
 				      || uiout->is_mi_like_p ()
-				    ? string_printf ("%d.%ld", inf->num,
-						     agent_id.handle)
-				    : string_printf ("%ld", agent_id.handle))
-				   .c_str ());
+				  ? string_printf ("%d.%s", inf->num,
+						   pulongest (agent_id.handle))
+				  : string_printf ("%s",
+						   pulongest (agent_id.handle)))
+				 .c_str ());
 
 	    /* supported  */
 	    amd_dbgapi_agent_state_t agent_state;
@@ -4251,10 +4257,11 @@ info_queues_command (const char *args, int from_tty)
 	    uiout->field_string ("id",
 				 (show_inferior_qualified_tids ()
 				      || uiout->is_mi_like_p ()
-				    ? string_printf ("%d.%ld", inf->num,
-						     queue_id.handle)
-				    : string_printf ("%ld", queue_id.handle))
-				   .c_str ());
+				  ? string_printf ("%d.%s", inf->num,
+						   pulongest (queue_id.handle))
+				  : string_printf ("%s",
+						   pulongest (queue_id.handle)))
+				 .c_str ());
 
 	    /* target-id  */
 	    uiout->field_string ("target-id",
@@ -4387,8 +4394,8 @@ queue_find_command (const char *arg, int from_tty)
 	  std::string target_id = queue_target_id_string (queue_id);
 	  if (re_exec (target_id.c_str ()))
 	    {
-	      gdb_printf (_("Queue %ld has Target Id '%s'\n"),
-			  queue_id.handle, target_id.c_str ());
+	      gdb_printf (_("Queue %s has Target Id '%s'\n"),
+			  pulongest (queue_id.handle), target_id.c_str ());
 	      ++matches;
 	    }
 	}
@@ -4610,8 +4617,9 @@ info_dispatches_command (const char *args, int from_tty)
 
 		max_address_spaces_width
 		  = std::max (max_address_spaces_width,
-			      string_printf ("Shared(%ld), Private(%ld)",
-					     shared_size, private_size)
+			      string_printf ("Shared(%s), Private(%s)",
+					     pulongest (shared_size),
+					     pulongest (private_size))
 				.size ());
 
 		++n_dispatches;
@@ -4687,13 +4695,14 @@ info_dispatches_command (const char *args, int from_tty)
 	      }
 
 	    /* id  */
-	    uiout->field_string ("id", (show_inferior_qualified_tids ()
-					    || uiout->is_mi_like_p ()
-					  ? string_printf ("%d.%ld", inf->num,
-							   dispatch_id.handle)
-					  : string_printf ("%ld",
-							   dispatch_id.handle))
-					 .c_str ());
+	    const char *dispatch_id_str = pulongest (dispatch_id.handle);
+	    uiout->field_string ("id",
+				 ((show_inferior_qualified_tids ()
+				   || uiout->is_mi_like_p ())
+				  ? string_printf ("%d.%s", inf->num,
+						   dispatch_id_str)
+				  : string_printf ("%s",
+						   dispatch_id_str)).c_str ());
 
 	    /* target-id  */
 	    uiout->field_string ("target-id",
@@ -4799,8 +4808,9 @@ info_dispatches_command (const char *args, int from_tty)
 
 		uiout
 		  ->field_string ("address-spaces",
-				  string_printf ("Shared(%ld), Private(%ld)",
-						 shared_size, private_size));
+				  string_printf ("Shared(%s), Private(%s)",
+						 pulongest (shared_size),
+						 pulongest (private_size)));
 
 		/* kernel-desc  */
 		amd_dbgapi_global_address_t kernel_desc;
@@ -4944,8 +4954,8 @@ dispatch_find_command (const char *arg, int from_tty)
 	  std::string target_id = dispatch_target_id_string (dispatch_id);
 	  if (re_exec (target_id.c_str ()))
 	    {
-	      gdb_printf (_("Dispatch %ld has Target Id '%s'\n"),
-			  dispatch_id.handle, target_id.c_str ());
+	      gdb_printf (_("Dispatch %s has Target Id '%s'\n"),
+			  pulongest (dispatch_id.handle), target_id.c_str ());
 	      ++matches;
 	    }
 
@@ -4962,8 +4972,8 @@ dispatch_find_command (const char *arg, int from_tty)
 	    = lookup_minimal_symbol_by_pc_section (kernel_code, nullptr);
 	  if (msymbol.minsym && re_exec (msymbol.minsym->print_name ()))
 	    {
-	      gdb_printf (_("Dispatch %ld has Kernel Function '%s'\n"),
-			  dispatch_id.handle,
+	      gdb_printf (_("Dispatch %s has Kernel Function '%s'\n"),
+			  pulongest (dispatch_id.handle),
 			  msymbol.minsym->print_name ());
 	      ++matches;
 	    }

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -661,39 +661,11 @@ flatid_to_id (size_t flatid, const vec3_t<size_t> &sizes)
   return coord_id;
 }
 
-/* Object used to collect information about all the work-items
-   handled by a wave.  Used to compute work-item coordinates
-   taking into account partial work-groups.  */
-
-struct work_item_info
-{
-  amd_dbgapi_dispatch_id_t dispatch_id;
-  amd_dbgapi_queue_id_t queue_id;
-  amd_dbgapi_agent_id_t agent_id;
-
-  /* Grid sizes in work-items.  */
-  vec3_u32_t grid_sizes;
-
-  /* Grid's work-group sizes in work-items.  */
-  vec3_t<uint16_t> work_group_sizes;
-
-  /* Grid work-group coordinates.  */
-  vec3_u32_t work_group_ids;
-
-  /* Wave in work-group.  */
-  uint32_t wave_in_group;
-
-  /* Lane count per wave.  */
-  size_t lane_count;
-};
-
 /* Return the work-group position of the work-item assigned to lane LANE.  */
 
 static opt_vec3_u32_t
 lane_workgroup_pos (thread_info *tp, int lane)
 {
-  work_item_info wi;
-
   wave_info &info = get_thread_wave_info (tp);
   if (info.coords.dispatch_id == AMD_DBGAPI_DISPATCH_NONE)
     {
@@ -703,21 +675,18 @@ lane_workgroup_pos (thread_info *tp, int lane)
       return std::nullopt;
     }
 
-  wi.dispatch_id = info.coords.dispatch_id;
-  wi.queue_id = info.coords.queue_id;
-  wi.agent_id = info.coords.agent_id;
+  vec3_u32_t grid_sizes;
+  dispatch_get_info_throw (info.coords.dispatch_id,
+			   AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
+			   grid_sizes);
 
-  dispatch_get_info_throw (wi.dispatch_id, AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES,
-			   wi.grid_sizes);
-
-  dispatch_get_info_throw (wi.dispatch_id,
+  vec3_t<uint16_t> work_group_sizes;
+  dispatch_get_info_throw (info.coords.dispatch_id,
 			   AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES,
-			   wi.work_group_sizes);
+			   work_group_sizes);
 
-  wi.work_group_ids = info.coords.group_ids;
-  wi.wave_in_group = info.coords.wave_in_group;
-
-  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, wi.lane_count);
+  size_t lane_count;
+  wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, lane_count);
 
   /* Find the work-group item sizes for each axis, taking into account
      the work-items that actually fit in the grid.  */
@@ -725,14 +694,14 @@ lane_workgroup_pos (thread_info *tp, int lane)
   for (int i = 0; i < 3; i++)
     {
       size_t work_item_start
-	= static_cast<size_t> (wi.work_group_ids[i]) * wi.work_group_sizes[i];
-      size_t work_item_end = work_item_start + wi.work_group_sizes[i];
-      if (work_item_end > wi.grid_sizes[i])
-	work_item_end = wi.grid_sizes[i];
+	= static_cast<size_t> (info.coords.group_ids[i]) * work_group_sizes[i];
+      size_t work_item_end = work_item_start + work_group_sizes[i];
+      if (work_item_end > grid_sizes[i])
+	work_item_end = grid_sizes[i];
       partial_wg_sizes[i] = work_item_end - work_item_start;
     }
 
-  size_t flatid = wi.wave_in_group * wi.lane_count + lane;
+  size_t flatid = info.coords.wave_in_group * lane_count + lane;
 
   return flatid_to_id (flatid, partial_wg_sizes);
 }

--- a/gdb/amd-dbgapi-target.c
+++ b/gdb/amd-dbgapi-target.c
@@ -685,28 +685,6 @@ struct work_item_info
 
   /* Lane count per wave.  */
   size_t lane_count;
-
-  /* Return the flat work-item id of the lane at index LANE_INDEX.  */
-  size_t flatid (int lane_index) const
-  {
-    return wave_in_group * lane_count + lane_index;
-  }
-
-  /* Store in PARTIAL_WORKGROUP_SIZES the work-group item sizes for
-     each axis, taking into account the work-items that actually fit
-     in the grid.  */
-  void partial_work_group_sizes (vec3_t<size_t> &partial_wg_sizes) const
-  {
-    for (int i = 0; i < 3; i++)
-      {
-	size_t work_item_start
-	  = static_cast<size_t> (work_group_ids[i]) * work_group_sizes[i];
-	size_t work_item_end = work_item_start + work_group_sizes[i];
-	if (work_item_end > grid_sizes[i])
-	  work_item_end = grid_sizes[i];
-	partial_wg_sizes[i] = work_item_end - work_item_start;
-      }
-  }
 };
 
 /* Return the work-group position of the work-item assigned to lane LANE.  */
@@ -741,9 +719,22 @@ lane_workgroup_pos (thread_info *tp, int lane)
 
   wave_get_info_throw (tp, AMD_DBGAPI_WAVE_INFO_LANE_COUNT, wi.lane_count);
 
+  /* Find the work-group item sizes for each axis, taking into account
+     the work-items that actually fit in the grid.  */
   vec3_t<size_t> partial_wg_sizes;
-  wi.partial_work_group_sizes (partial_wg_sizes);
-  return flatid_to_id (wi.flatid (lane), partial_wg_sizes);
+  for (int i = 0; i < 3; i++)
+    {
+      size_t work_item_start
+	= static_cast<size_t> (wi.work_group_ids[i]) * wi.work_group_sizes[i];
+      size_t work_item_end = work_item_start + wi.work_group_sizes[i];
+      if (work_item_end > wi.grid_sizes[i])
+	work_item_end = wi.grid_sizes[i];
+      partial_wg_sizes[i] = work_item_end - work_item_start;
+    }
+
+  size_t flatid = wi.wave_in_group * wi.lane_count + lane;
+
+  return flatid_to_id (flatid, partial_wg_sizes);
 }
 
 /* Return the lane's work-group position as a string.  */


### PR DESCRIPTION
## Motivation

Code simplification and reuse.

## Technical Details

Use existing `wave_coordinates` to reduce duplication.

## Test Plan

No new tests needed. This is a refactoring.
