### PR TITLE
gdb, testsuite: increase timeout in gdb.rocm/step-schedlock-spurious-…

### DIFF
--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
@@ -113,8 +113,10 @@ proc do_test {} {
 	# (the only printed line is the source line number and the source line).
 	set num_nexts 5
 	for {set i 0} {$i < 5} {incr i} {
-	    gdb_test "next" "^${::decimal}\[^\r\n\]+" \
-		"next, iter $i"
+	    with_timeout_factor 2 {
+		gdb_test "next" "^${::decimal}\[^\r\n\]+" \
+		    "next, iter $i"
+	    }
 	}
 
 	gdb_test "thread" "Current thread is $cur_thread, .*" \


### PR DESCRIPTION
In a test where we are doing "next", the thread steps over a for-loop header, single-stepping roughly 90 instructions.  With a debug build of GDB and dbgapi, the command takes about 10 seconds and may occasionally fail with a timeout.  Increase the timeout temporarily.
