### PR TITLE
gdb/testsuite: Fix runtime-core.exp wave ordering dependency

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -86,15 +86,15 @@ proc do_test { fault core_type output_type } {
     set faulty_wave 0
     set aux_wave 0
     gdb_test_multiple "info thread" "identify waves" -lbl {
-	-re "($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\\n\]*" {
+	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\r\n\]*(?=\r\n)" {
 	    set faulty_wave $expect_out(1,string)
 	    exp_continue
 	}
-	-re "($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\\n\]*" {
+	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\r\n\]*(?=\r\n)" {
 	    set aux_wave $expect_out(1,string)
 	    exp_continue
 	}
-	-re "$::gdb_prompt $" {
+	-re "^\r\n$::gdb_prompt $" {
 	    gdb_assert {($faulty_wave != 0) && ($aux_wave != 0)} $gdb_test_name
 	}
     }


### PR DESCRIPTION
The "identify waves" test was failing when waves appeared in different
order because the patterns were not anchored to line boundaries, causing
expect to match patterns out of order even with -lbl mode.

Problem:
The test uses gdb_test_multiple with -lbl (line-by-line mode) expecting
each pattern to match complete lines in sequence. However, without proper
anchoring, expect could match a later pattern before an earlier one if
the later pattern's text appeared first in the buffer, consuming the
buffer incorrectly.

When aux_kernel wave appeared before pagefault_kernel wave:
- pagefault_kernel pattern matched its line first (even though it appeared
  later in output)
- Buffer was consumed up to that match
- aux_kernel line (which appeared earlier) was already consumed
- Second pattern failed to match → test FAIL

Solution:
Anchor patterns to line boundaries using:
- `^\r\n` - enforce beginning of line after previous line ending
- `[^\r\n]+` - match line prefix before the wave info
- `(?=\r\n)` - lookahead to ensure pattern matches up to line ending

This ensures each pattern matches a complete line from start to finish,
making the test properly order-independent as -lbl mode intended.

The same anchoring is applied to the gdb_prompt pattern for consistency.