### PR TITLE
.github: xfail gdb.rocm/lane-execution.exp for all compilers

### DIFF
--- a/.github/scripts/rocgdb_ignore_list.json
+++ b/.github/scripts/rocgdb_ignore_list.json
@@ -1,5 +1,6 @@
 {
   "Generic": [
+    "gdb.rocm/lane-execution.exp",
     "gdb.rocm/multi-inferior-fork.exp",
     "gdb.rocm/multi-inferior-gpu.exp"
   ],


### PR DESCRIPTION
Add lane-execution.exp to the ignore list so an upcoming compiler bump does not get blocked on this failure.