### PR TITLE
Add automerge workflow

### DIFF
--- a/.github/scripts/automerge.md
+++ b/.github/scripts/automerge.md
@@ -1,0 +1,85 @@
+# Automerge Workflow
+
+Automatically syncs `sourceware/master` into `origin/amd-staging` every 6 hours,
+opening GitHub PRs for CI validation or conflict resolution as needed.
+
+## Files
+
+- `.github/workflows/automerge.yml` — GitHub Actions workflow definition.
+- `.github/scripts/automerge.py` — Python sync script invoked by the workflow.
+
+## Triggers
+
+| Event                 | Condition                                             | Effect            |
+| --------------------- | ----------------------------------------------------- | ----------------- |
+| Scheduled             | Every 6 hours                                         | Normal sync run   |
+| `workflow_dispatch`   | Manual                                                | Normal sync run   |
+| `pull_request` closed | PR merged + label `merge-testing` or `merge-conflict` | Immediate re-sync |
+
+## Sync Logic
+
+Each run follows these steps:
+
+1. **Clone or reuse** a local clone of `ROCm/ROCgdb` in `$WORKSPACE/rocgdb_sync/`.
+2. **Fetch** `sourceware/master` and `origin/amd-staging`, then immediately fast-forward `origin/master` to `sourceware/master` to keep the mirror current.
+3. **Gate** — if a fast-forward or conflict PR is already open, skip and exit.
+4. **Compute** the commit range: `merge-base(amd-staging, sourceware/master)..sourceware/master`.
+5. **Probe** — walk commits oldest-to-newest on a throwaway branch off `amd-staging`
+   to find the largest clean-merging prefix.
+6. **Act** based on the probe result:
+
+### 6a. All commits merge cleanly
+
+Opens a **fast-forward PR** covering the full range. CI must pass before anyone
+merges it. Once merged, the `pull_request` closed trigger fires another sync run
+to pick up any further upstream commits.
+
+### 6b. Partial clean prefix
+
+Opens a **fast-forward PR** for the clean prefix only. The conflict commit is left
+for the next run — after the FF PR merges, the re-sync will find the conflict and
+open a conflict PR then.
+
+### 6c. No clean commits
+
+Opens a **conflict PR** directly against `amd-staging`. The PR is labeled
+`ci:skip` to suppress CI until conflicts are resolved manually. After the PR is
+merged, the `pull_request` closed trigger fires another sync run.
+
+## PR Types
+
+### Fast-forward PR
+
+- **Branch**: `users/github/master-to-amd-staging-ff-YYYY-MM-DD-<hash>`
+- **Label**: `merge-testing`
+- **Base**: `amd-staging`
+- **Purpose**: CI gate before fast-forwarding upstream commits into staging.
+
+### Conflict PR
+
+- **Branch**: `users/github/master-to-amd-staging-conflict-YYYY-MM-DD-<hash>`
+- **Labels**: `merge-conflict`, `ci:skip`
+- **Base**: `amd-staging`
+- **Purpose**: Signals a merge conflict that requires manual resolution.
+  Remove the `ci:skip` label once conflicts are resolved to allow CI to run.
+
+## Configuration
+
+Environment variables:
+
+| Variable / flag      | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. The clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
+
+Key constants at the top of `automerge.py`:
+
+| Constant                 | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `ROCGDB_REPO`            | GitHub repo slug (`ROCm/ROCgdb`)                         |
+| `SOURCEWARE_URL`         | Upstream GDB repository URL                              |
+| `FF_BRANCH_PREFIX`       | Branch prefix for fast-forward PRs                       |
+| `CONFLICT_BRANCH_PREFIX` | Branch prefix for conflict PRs                           |
+| `FF_LABEL`               | Label applied to fast-forward PRs (`merge-testing`)      |
+| `CONFLICT_LABEL`         | Label applied to conflict PRs (`merge-conflict`)         |
+| `CI_SKIP_LABEL`          | Label applied to conflict PRs to suppress CI (`ci:skip`) |
+| `RETRY_DELAYS`           | Sleep intervals (seconds) between network retries        |

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Sync ROCgdb sourceware/master into origin/amd-staging.
+
+Fetches the upstream sourceware master, fast-forwards origin/master to match,
+then merges cleanly into origin/amd-staging. On conflict, pushes a conflict
+branch and opens a PR for manual resolution.
+"""
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+ROCGDB_REPO = "ROCm/ROCgdb"
+ROCGDB_ORIGIN_URL = f"https://github.com/{ROCGDB_REPO}.git"
+SOURCEWARE_URL = "https://sourceware.org/git/binutils-gdb.git"
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Sync sourceware/master into origin/amd-staging.")
+    p.add_argument(
+        "--workspace",
+        metavar="DIR",
+        help="Root directory for the working clone (overrides $WORKSPACE). "
+             "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and probe as normal, but skip all pushes and PR creation.",
+    )
+    return p.parse_args()
+
+
+_args = _parse_args()
+DRY_RUN: bool = _args.dry_run
+_workspace = _args.workspace or os.environ.get("WORKSPACE", "")
+if _workspace:
+    _workspace_path = Path(_workspace).resolve()
+    if not _workspace_path.exists():
+        print(
+            f"Error: workspace '{_workspace}' is not a valid path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    WORK_DIR = _workspace_path / "rocgdb_sync"
+else:
+    WORK_DIR = Path.cwd() / "rocgdb_sync"
+
+# Never pass secrets as CLI args — use env vars (e.g. GH_TOKEN) instead.
+
+CONFLICT_BRANCH_PREFIX = "users/github/master-to-amd-staging-conflict"
+FF_BRANCH_PREFIX = "users/github/master-to-amd-staging-ff"
+CONFLICT_LABEL = "merge-conflict"
+FF_LABEL = "merge-testing"
+CI_SKIP_LABEL = "ci:skip"
+
+# Sleep durations (seconds) between successive network attempts.
+# Total attempts = len(RETRY_DELAYS) + 1.
+RETRY_DELAYS = [60, 120]
+
+
+# ---------------------------------------------------------------------------
+# Subprocess / git helpers
+# ---------------------------------------------------------------------------
+
+
+def run(
+    cmd: list[str],
+    cwd=None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+    redact: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess, printing the command (with any redacted values masked)."""
+    display_cmd = cmd
+    if redact:
+        display_cmd = [
+            "<redacted>" if any(r in arg for r in redact) else arg for arg in cmd
+        ]
+    print(f"[RUN] {' '.join(shlex.quote(str(a)) for a in display_cmd)}")
+    merged_env = {**os.environ, **(env or {})}
+    result = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, env=merged_env
+    )
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.returncode != 0 and result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, result.stdout, result.stderr
+        )
+    return result
+
+
+def _is_network_error(exc: subprocess.CalledProcessError) -> bool:
+    stderr = (exc.stderr or "").lower()
+    keywords = (
+        "could not resolve",
+        "unable to connect",
+        "connection refused",
+        "connection timed out",
+        "network is unreachable",
+        "no route to host",
+        "fatal: unable to access",
+        "ssh: connect",
+    )
+    return any(k in stderr for k in keywords)
+
+
+def run_net(cmd: list[str], cwd=None) -> subprocess.CompletedProcess:
+    """Run a network git command, retrying on transient connectivity errors."""
+    max_attempts = len(RETRY_DELAYS) + 1
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return run(cmd, cwd=cwd)
+        except subprocess.CalledProcessError as exc:
+            if not _is_network_error(exc):
+                raise
+            last_exc = exc
+            if attempt < max_attempts:
+                delay = RETRY_DELAYS[attempt - 1]
+                print(
+                    f"Network error (attempt {attempt}/{max_attempts}), "
+                    f"retrying in {delay}s…"
+                )
+                time.sleep(delay)
+            else:
+                print(f"Network error (attempt {attempt}/{max_attempts}), giving up.")
+    raise ConnectivityError() from last_exc
+
+
+class ConnectivityError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (gh CLI)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_label(label: str, color: str) -> None:
+    result = run(
+        [
+            "gh",
+            "label",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--search",
+            label,
+            "--json",
+            "name",
+        ],
+    )
+    existing = [entry["name"] for entry in json.loads(result.stdout or "[]")]
+    if label not in existing:
+        run(["gh", "label", "create", label, "--repo", ROCGDB_REPO, "--color", color])
+
+
+def open_conflict_pr(
+    branch: str,
+    merge_base_sha: str,
+    conflict_commit: str,
+    conflicted_files: list[str],
+) -> str:
+    compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{merge_base_sha[:12]}...{conflict_commit[:12]}"
+    file_list = "\n".join(f"- `{f}`" for f in conflicted_files)
+    title = (
+        f"ROCgdb master → amd-staging conflict: "
+        f"{merge_base_sha[:12]}..{conflict_commit[:12]}"
+    )
+    body = (
+        f"## ROCgdb master → amd-staging merge conflict\n\n"
+        f"**Commits being merged:** [{merge_base_sha[:12]}...{conflict_commit[:12]}]({compare_url})\n\n"
+        f"**Conflicted files:**\n{file_list}\n\n"
+        f"Please resolve the conflicts, remove the `{CI_SKIP_LABEL}` label, "
+        f"validate in CI, then merge."
+    )
+
+    _ensure_label(CONFLICT_LABEL, "e11d48")
+    _ensure_label(CI_SKIP_LABEL, "f59e0b")
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            CONFLICT_LABEL,
+            "--label",
+            CI_SKIP_LABEL,
+        ]
+    )
+    pr_url = result.stdout.strip()
+    print(f"Conflict PR opened: {pr_url}")
+    return pr_url
+
+
+def find_open_conflict_pr() -> str | None:
+    """Return the URL of an open conflict PR if one exists, else None."""
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--state",
+            "open",
+            "--label",
+            CONFLICT_LABEL,
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+    )
+    url = (result.stdout or "").strip()
+    return url if url else None
+
+
+def open_ff_pr(
+    branch: str,
+    first_commit: str,
+    last_commit: str,
+) -> str:
+    compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{first_commit[:12]}...{last_commit[:12]}"
+    title = (
+        f"ROCgdb master → amd-staging fast-forward: "
+        f"{first_commit[:12]}..{last_commit[:12]}"
+    )
+    body = (
+        f"## ROCgdb master → amd-staging fast-forward merge\n\n"
+        f"**Commits being merged:** [{first_commit[:12]}...{last_commit[:12]}]({compare_url})\n\n"
+        f"This PR was opened automatically by the automerge workflow. "
+        f"Please validate CI, then merge."
+    )
+
+    _ensure_label(FF_LABEL, "0075ca")
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            FF_LABEL,
+        ]
+    )
+    pr_url = result.stdout.strip()
+    print(f"Fast-forward PR opened: {pr_url}")
+    return pr_url
+
+
+def find_open_ff_pr() -> str | None:
+    """Return the URL of an open fast-forward PR if one exists, else None."""
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            "amd-staging",
+            "--state",
+            "open",
+            "--label",
+            FF_LABEL,
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+    )
+    url = (result.stdout or "").strip()
+    return url if url else None
+
+
+# ---------------------------------------------------------------------------
+# Core sync logic
+# ---------------------------------------------------------------------------
+
+
+def push_master_mirror(repo: Path) -> None:
+    """Fast-forward origin/master to match sourceware/master."""
+    print("Fast-forwarding origin/master to sourceware/master…")
+    run_net(
+        ["git", "push", "origin", "sourceware/master:refs/heads/master"],
+        cwd=repo,
+    )
+
+
+def probe_clean_prefix(
+    repo: Path,
+    commits: list[str],
+) -> tuple[str | None, str | None]:
+    """
+    Walk commits oldest-to-newest on a throwaway branch off origin/amd-staging.
+    Returns (last_clean_commit, first_conflict_commit).
+    """
+    run(["git", "checkout", "-B", "probe", "origin/amd-staging"], cwd=repo)
+
+    last_clean = None
+    first_conflict = None
+
+    try:
+        for commit in commits:
+            result = run(["git", "merge", "--no-edit", commit], cwd=repo, check=False)
+            if result.returncode != 0:
+                run(["git", "merge", "--abort"], cwd=repo)
+                first_conflict = commit
+                break
+            last_clean = commit
+    finally:
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo)
+        run(["git", "branch", "-D", "probe"], cwd=repo)
+
+    return last_clean, first_conflict
+
+
+def main() -> None:
+    WORK_DIR.mkdir(parents=True, exist_ok=True)
+    repo = WORK_DIR / "binutils-gdb"
+
+    try:
+        # ------------------------------------------------------------------ #
+        # 1. Clone or reuse.                                                   #
+        # ------------------------------------------------------------------ #
+        if (repo / ".git").exists():
+            print(f"Reusing existing clone at {repo}…")
+        else:
+            print(f"Cloning {ROCGDB_REPO}…")
+            run_net(["git", "clone", ROCGDB_ORIGIN_URL, str(repo)])
+
+        remotes = run(["git", "remote"], cwd=repo).stdout.split()
+        if "sourceware" not in remotes:
+            run(["git", "remote", "add", "sourceware", SOURCEWARE_URL], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 2. Fetch sourceware/master and origin/amd-staging.                  #
+        # ------------------------------------------------------------------ #
+        print("Fetching sourceware/master…")
+        run_net(["git", "fetch", "sourceware", "master"], cwd=repo)
+
+        print("Fetching origin/amd-staging…")
+        run_net(["git", "fetch", "origin", "amd-staging"], cwd=repo)
+
+        if not DRY_RUN:
+            push_master_mirror(repo)
+
+        # ------------------------------------------------------------------ #
+        # 3. Skip if a conflict or fast-forward PR is already open.           #
+        # ------------------------------------------------------------------ #
+        existing_conflict_pr = find_open_conflict_pr()
+        if existing_conflict_pr:
+            print(
+                f"Open conflict PR found: {existing_conflict_pr}\n"
+                "Skipping merge — resolve the PR first."
+            )
+            return
+
+        existing_ff_pr = find_open_ff_pr()
+        if existing_ff_pr:
+            print(
+                f"Open fast-forward PR found: {existing_ff_pr}\n"
+                "Skipping merge — wait for the PR to be merged first."
+            )
+            return
+
+        # ------------------------------------------------------------------ #
+        # 4. Determine the commit range to merge.                             #
+        # ------------------------------------------------------------------ #
+        merge_base_sha = run(
+            ["git", "merge-base", "origin/amd-staging", "sourceware/master"],
+            cwd=repo,
+        ).stdout.strip()
+
+        log_out = run(
+            [
+                "git",
+                "log",
+                "--format=%H",
+                "--reverse",
+                f"{merge_base_sha}..sourceware/master",
+            ],
+            cwd=repo,
+        ).stdout.strip()
+
+        if not log_out:
+            print(
+                "amd-staging is already up to date with sourceware/master. Nothing to do."
+            )
+            return
+
+        commits = log_out.splitlines()
+        print(
+            f"Found {len(commits)} new commit(s) to merge "
+            f"({commits[0][:12]}..{commits[-1][:12]})."
+        )
+
+        # ------------------------------------------------------------------ #
+        # 5. Set up local amd-staging branch.                                 #
+        # ------------------------------------------------------------------ #
+        if not DRY_RUN:
+            run(
+                ["git", "checkout", "-B", "amd-staging", "origin/amd-staging"],
+                cwd=repo,
+            )
+
+        # ------------------------------------------------------------------ #
+        # 6. Probe for the largest clean prefix.                              #
+        # ------------------------------------------------------------------ #
+        print("Probing for clean merge prefix…")
+        last_clean, first_conflict = probe_clean_prefix(repo, commits)
+
+        # Probe leaves the repo on detached HEAD; return to the local branch.
+        if not DRY_RUN:
+            run(["git", "checkout", "amd-staging"], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 7a. All commits apply cleanly → open a fast-forward PR.            #
+        # ------------------------------------------------------------------ #
+        if first_conflict is None:
+            print(f"All {len(commits)} commit(s) merge cleanly.")
+            ff_branch = (
+                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            )
+            if DRY_RUN:
+                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+            else:
+                run(["git", "checkout", "-B", ff_branch], cwd=repo)
+                run(["git", "merge", "--no-edit", commits[-1]], cwd=repo)
+                run_net(["git", "push", "origin", ff_branch], cwd=repo)
+                open_ff_pr(
+                    branch=ff_branch,
+                    first_commit=merge_base_sha,
+                    last_commit=commits[-1],
+                )
+            return
+
+        # ------------------------------------------------------------------ #
+        # 7b. Partial clean prefix → open a fast-forward PR for clean range. #
+        # ------------------------------------------------------------------ #
+        if last_clean is not None:
+            print(f"Clean prefix ends at {last_clean[:12]}. Opening fast-forward PR…")
+            ff_branch = (
+                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            )
+            if DRY_RUN:
+                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+            else:
+                run(["git", "checkout", "-B", ff_branch], cwd=repo)
+                run(["git", "merge", "--no-edit", last_clean], cwd=repo)
+                run_net(["git", "push", "origin", ff_branch], cwd=repo)
+                open_ff_pr(
+                    branch=ff_branch,
+                    first_commit=merge_base_sha,
+                    last_commit=last_clean,
+                )
+            return
+        else:
+            print("No clean commits to merge; first commit already conflicts.")
+
+        # ------------------------------------------------------------------ #
+        # 8. Create conflict branch and open PR.                              #
+        # ------------------------------------------------------------------ #
+        conflict_branch = (
+            f"{CONFLICT_BRANCH_PREFIX}-{date.today().isoformat()}-{first_conflict[:8]}"
+        )
+
+        conflict_info = run(
+            ["git", "log", "-1", "--format=%H %s (%aN <%aE>)", first_conflict],
+            cwd=repo,
+        ).stdout.strip()
+        print(f"\nConflict commit: {conflict_info}")
+
+        if DRY_RUN:
+            print(f"[DRY RUN] would push {conflict_branch} and open conflict PR.")
+        else:
+            # Checkout a fresh conflict branch from the current amd-staging state.
+            run(["git", "checkout", "-B", conflict_branch], cwd=repo)
+            run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
+
+            conflicted_files = (
+                run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
+                .stdout.strip()
+                .splitlines()
+            )
+            print("Conflicted files:")
+            for f in conflicted_files:
+                print(f"  {f}")
+
+            # Stage and commit the conflict markers so the branch carries a diff
+            # that gh pr create can open (the branch would otherwise be identical
+            # to amd-staging and gh would reject it with "no commits between...").
+            run(["git", "add", "-A"], cwd=repo)
+            run(
+                [
+                    "git", "commit", "--no-verify", "-m",
+                    f"Merge {first_conflict[:12]} into amd-staging (unresolved conflicts)",
+                ],
+                cwd=repo,
+            )
+
+            run_net(["git", "push", "origin", conflict_branch], cwd=repo)
+            open_conflict_pr(
+                branch=conflict_branch,
+                merge_base_sha=merge_base_sha,
+                conflict_commit=first_conflict,
+                conflicted_files=conflicted_files,
+            )
+
+    except ConnectivityError:
+        print("Connectivity error: all retries exhausted.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_automerge.py
+++ b/.github/scripts/test_automerge.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for automerge.py."""
+
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test without triggering _parse_args() or WORK_DIR
+# resolution (both run at import time via module-level code).
+# ---------------------------------------------------------------------------
+
+import importlib
+import importlib.util
+import os
+
+
+def _load_automerge():
+    """Load automerge as a module, neutralising its module-level side-effects."""
+    spec = importlib.util.spec_from_file_location(
+        "automerge",
+        Path(__file__).parent / "automerge.py",
+    )
+    # Patch sys.argv so argparse doesn't see pytest/unittest args.
+    with patch("sys.argv", ["automerge.py"]):
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+am = _load_automerge()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    r = MagicMock(spec=subprocess.CompletedProcess)
+    r.returncode = returncode
+    r.stdout = stdout
+    r.stderr = stderr
+    return r
+
+
+# ---------------------------------------------------------------------------
+# run() / run_net()
+# ---------------------------------------------------------------------------
+
+
+class TestRun(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_run_raises_on_nonzero_with_check(self, mock_subproc):
+        mock_subproc.return_value = _completed(returncode=1, stderr="oops")
+        with self.assertRaises(subprocess.CalledProcessError):
+            am.run(["false"])
+
+    @patch("subprocess.run")
+    def test_run_returns_result_when_check_false(self, mock_subproc):
+        mock_subproc.return_value = _completed(returncode=1, stderr="oops")
+        result = am.run(["false"], check=False)
+        self.assertEqual(result.returncode, 1)
+
+    @patch("subprocess.run")
+    def test_run_redacts_matching_args(self, mock_subproc):
+        mock_subproc.return_value = _completed()
+        with patch("builtins.print") as mock_print:
+            am.run(["git", "push", "https://token@host/repo"], redact=["token"])
+        printed = " ".join(str(a) for a in mock_print.call_args_list)
+        self.assertNotIn("token", printed)
+        self.assertIn("<redacted>", printed)
+
+
+class TestRunNet(unittest.TestCase):
+    @patch("time.sleep")
+    def test_retries_on_network_error_then_succeeds(self, mock_sleep):
+        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+        ok = _completed()
+
+        call_count = 0
+
+        def fake_run(cmd, cwd=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise network_err
+            return ok
+
+        with patch.object(am, "run", side_effect=fake_run):
+            result = am.run_net(["git", "fetch"])
+        self.assertEqual(call_count, 2)
+        mock_sleep.assert_called_once()
+
+    @patch("time.sleep")
+    def test_raises_connectivity_error_after_all_retries(self, mock_sleep):
+        network_err = subprocess.CalledProcessError(128, ["git"], "", "could not resolve host")
+
+        with patch.object(am, "run", side_effect=network_err):
+            with self.assertRaises(am.ConnectivityError):
+                am.run_net(["git", "fetch"])
+
+        # sleep called once per inter-attempt gap
+        self.assertEqual(mock_sleep.call_count, len(am.RETRY_DELAYS))
+
+    def test_reraises_non_network_error_immediately(self):
+        non_net_err = subprocess.CalledProcessError(1, ["git"], "", "permission denied")
+
+        with patch.object(am, "run", side_effect=non_net_err):
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.run_net(["git", "fetch"])
+
+
+# ---------------------------------------------------------------------------
+# find_open_conflict_pr / find_open_ff_pr
+# ---------------------------------------------------------------------------
+
+
+class TestFindOpenPr(unittest.TestCase):
+    def test_returns_url_when_present(self):
+        with patch.object(am, "run", return_value=_completed(stdout="https://github.com/ROCm/ROCgdb/pull/42\n")):
+            url = am.find_open_conflict_pr()
+        self.assertEqual(url, "https://github.com/ROCm/ROCgdb/pull/42")
+
+    def test_returns_none_when_no_pr(self):
+        with patch.object(am, "run", return_value=_completed(stdout="")):
+            url = am.find_open_conflict_pr()
+        self.assertIsNone(url)
+
+    def test_raises_on_gh_cli_failure(self):
+        with patch.object(
+            am,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, ["gh"], "", "auth error"),
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.find_open_conflict_pr()
+
+    def test_ff_returns_none_when_no_pr(self):
+        with patch.object(am, "run", return_value=_completed(stdout="")):
+            url = am.find_open_ff_pr()
+        self.assertIsNone(url)
+
+
+# ---------------------------------------------------------------------------
+# probe_clean_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCleanPrefix(unittest.TestCase):
+    def _run_side_effect(self, outcomes):
+        """
+        outcomes: list of returncode ints, one per git-merge call.
+        All other run() calls (checkout, branch -D, merge --abort) succeed.
+        """
+        merge_returncodes = iter(outcomes)
+
+        def fake_run(cmd, cwd=None, check=True, **kwargs):
+            if cmd[:2] == ["git", "merge"] and "--abort" not in cmd:
+                rc = next(merge_returncodes)
+                result = _completed(returncode=rc)
+                if check and rc != 0:
+                    raise subprocess.CalledProcessError(rc, cmd, "", "conflict")
+                return result
+            return _completed()
+
+        return fake_run
+
+    def test_all_clean(self):
+        commits = ["aaa", "bbb", "ccc"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([0, 0, 0])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertEqual(last_clean, "ccc")
+        self.assertIsNone(first_conflict)
+
+    def test_first_conflicts(self):
+        commits = ["aaa", "bbb"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([1])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertIsNone(last_clean)
+        self.assertEqual(first_conflict, "aaa")
+
+    def test_partial_clean_prefix(self):
+        commits = ["aaa", "bbb", "ccc"]
+        with patch.object(am, "run", side_effect=self._run_side_effect([0, 1])):
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), commits)
+        self.assertEqual(last_clean, "aaa")
+        self.assertEqual(first_conflict, "bbb")
+
+    def test_cleanup_runs_even_when_abort_raises(self):
+        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort raises."""
+        cleanup_calls = []
+
+        def fake_subproc(cmd, **kwargs):
+            if cmd[:2] == ["git", "merge"] and "--abort" not in cmd:
+                return _completed(returncode=1, stderr="conflict")
+            if "--abort" in cmd:
+                # Simulate merge --abort failing (e.g. no merge in progress).
+                return _completed(returncode=1, stderr="cannot abort")
+            if "--detach" in cmd or "-D" in cmd:
+                cleanup_calls.append(list(cmd))
+            return _completed()
+
+        with patch("subprocess.run", side_effect=fake_subproc):
+            # merge --abort returns non-zero; run() with check=True will raise.
+            # probe_clean_prefix calls merge --abort with check=True, so it raises.
+            with self.assertRaises(subprocess.CalledProcessError):
+                am.probe_clean_prefix(Path("/repo"), ["aaa"])
+
+        self.assertEqual(len(cleanup_calls), 2)
+
+
+# ---------------------------------------------------------------------------
+# Early-exit gate (main integration slice — no actual git/gh calls)
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyExitGate(unittest.TestCase):
+    def _patch_main_deps(self, conflict_pr=None, ff_pr=None):
+        """Patch just enough of main() to test the gate logic."""
+        patches = [
+            patch("pathlib.Path.mkdir"),
+            patch.object(am, "run_net", return_value=_completed()),
+            patch.object(am, "run", return_value=_completed(stdout="")),
+            patch.object(am, "find_open_conflict_pr", return_value=conflict_pr),
+            patch.object(am, "find_open_ff_pr", return_value=ff_pr),
+        ]
+        return patches
+
+    def test_skips_when_conflict_pr_open(self):
+        patches = self._patch_main_deps(conflict_pr="https://github.com/ROCm/ROCgdb/pull/1")
+        # Also patch repo/.git exists check so clone is skipped.
+        with patch("pathlib.Path.exists", return_value=True), \
+             patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patch.object(am, "probe_clean_prefix") as mock_probe:
+                am.main()
+                mock_probe.assert_not_called()
+
+    def test_skips_when_ff_pr_open(self):
+        patches = self._patch_main_deps(ff_pr="https://github.com/ROCm/ROCgdb/pull/2")
+        with patch("pathlib.Path.exists", return_value=True), \
+             patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patch.object(am, "probe_clean_prefix") as mock_probe:
+                am.main()
+                mock_probe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run end-to-end flow
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun(unittest.TestCase):
+    """
+    Exercises the full main() flow with --dry-run set, verifying that
+    probe_clean_prefix runs but no push or PR-creation calls are made.
+    """
+
+    def _run_dry(self, probe_result):
+        """
+        Run main() with DRY_RUN=True, returning the set of run_net call args.
+        probe_result: (last_clean, first_conflict) tuple returned by probe.
+        """
+        run_net_calls = []
+
+        def fake_run(cmd, cwd=None, check=True, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            # Return a plausible stdout for commands that produce output.
+            if "remote" in cmd and cmd[-1] == "remote":
+                return _completed(stdout="origin\nsourceware\n")
+            if "merge-base" in cmd:
+                return _completed(stdout="base0000000000000000000000000000000000000000")
+            if "log" in cmd and "--format=%H" in cmd:
+                return _completed(stdout="aaa\nbbb\nccc")
+            if "log" in cmd and "--format=%H %s" in cmd:
+                return _completed(stdout="aaa subject (Author <a@b.com>)")
+            if "diff" in cmd:
+                return _completed(stdout="file.c\n")
+            return _completed()
+
+        def fake_run_net(cmd, cwd=None):
+            run_net_calls.append(list(cmd))
+            return _completed()
+
+        with patch("pathlib.Path.mkdir"), \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch.object(am, "run", side_effect=fake_run), \
+             patch.object(am, "run_net", side_effect=fake_run_net), \
+             patch.object(am, "find_open_conflict_pr", return_value=None), \
+             patch.object(am, "find_open_ff_pr", return_value=None), \
+             patch.object(am, "probe_clean_prefix", return_value=probe_result), \
+             patch.object(am, "open_ff_pr") as mock_ff_pr, \
+             patch.object(am, "open_conflict_pr") as mock_conflict_pr, \
+             patch.object(am, "push_master_mirror") as mock_mirror, \
+             patch.object(am, "DRY_RUN", True):
+            am.main()
+
+        return run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror
+
+    def test_dry_run_all_clean_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=("ccc", None)
+        )
+        # Only the two fetches should have gone out, no push.
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_ff_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+    def test_dry_run_conflict_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=(None, "aaa")
+        )
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_conflict_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+    def test_dry_run_partial_prefix_skips_push_and_pr(self):
+        run_net_calls, mock_ff_pr, mock_conflict_pr, mock_mirror = self._run_dry(
+            probe_result=("aaa", "bbb")
+        )
+        push_calls = [c for c in run_net_calls if "push" in c]
+        self.assertEqual(push_calls, [])
+        mock_ff_pr.assert_not_called()
+        mock_mirror.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,40 @@
+name: GDB Automerge
+on:
+  schedule: # runs every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [amd-staging]
+
+concurrency:
+  group: gdb-automerge
+  cancel-in-progress: false
+
+jobs:
+  automerge-to-staging:
+    runs-on: ubuntu-latest
+    if: false
+    # Remove the above and uncomment below to activate:
+    # if: |
+    #   github.event_name != 'pull_request' ||
+    #   (github.event.pull_request.merged == true &&
+    #    (contains(github.event.pull_request.labels.*.name, 'merge-testing') ||
+    #     contains(github.event.pull_request.labels.*.name, 'merge-conflict')))
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      WORKSPACE: ${{ github.workspace }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - name: Configure git identity and credentials
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global credential.helper "!gh auth git-credential"
+      - name: Trigger Automerge Job
+        run: |
+          python3 .github/scripts/automerge.py


### PR DESCRIPTION
Adds a GitHub Actions workflow that every 6 hours syncs sourceware/master into
origin/amd-staging. The workflow also triggers on closure of fast-forward
or conflict PRs to immediately start the next sync.

On a clean merge, a fast-forward PR is opened against amd-staging for CI
validation. On a conflict, a conflict PR is opened for manual resolution.
Only one PR of either type is allowed open at a time and further syncs are
postponed until it is resolved.

The fast-forward PR range is expressed as merge-base..last-clean-commit
so the title and compare URL are always meaningful even when only one
commit is being merged.

The script lives in .github/scripts/automerge.py and is documented in
.github/scripts/automerge.md.