### PR TITLE
.github: xfail gdb.rocm/deep-stack.exp for all compilers

### DIFF
--- a/.github/scripts/rocgdb_ignore_list.json
+++ b/.github/scripts/rocgdb_ignore_list.json
@@ -1,5 +1,6 @@
 {
   "Generic": [
+    "gdb.rocm/deep-stack.exp",
     "gdb.rocm/lane-execution.exp",
     "gdb.rocm/multi-inferior-fork.exp",
     "gdb.rocm/multi-inferior-gpu.exp"


### PR DESCRIPTION
## Motivation

Add deep-stack.exp to the ignore list so an upcoming compiler bump does not get blocked on this failure.

## Technical Details

Adds `gdb.rocm/deep-stack.exp` to the `Generic` section of `.github/scripts/rocgdb_ignore_list.json`.

## Test Plan

N/A — CI configuration change only.

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.