### PR TITLE
.github/scripts: add --retry-ignored-tests switch to test_rocgdb.py

### DIFF
--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -372,6 +372,12 @@ def parse_arguments() -> argparse.Namespace:
         help="Do not use ignore lists for failed tests. Default is to use the ignore lists.",
     )
     parser.add_argument(
+        "--retry-ignored-tests",
+        action="store_true",
+        help="Retry tests that are on the ignore list when they fail. "
+        "Default is off: ignored tests that fail on the first run are not retried.",
+    )
+    parser.add_argument(
         "--optimization",
         type=str,
         default="",
@@ -1649,6 +1655,7 @@ def run_tests(
     compiler_label: str,
     test_results: "TestResults",
     args: argparse.Namespace,
+    xfailed_tests: Optional[Dict[str, List[str]]] = None,
 ) -> None:
     """
     Run ROCgdb test suite with retry logic for failed tests.
@@ -1664,6 +1671,8 @@ def run_tests(
         compiler_label: Compiler identifier (e.g., "GCC").
         test_results: TestResults object for storing results.
         args: Parsed command-line arguments.
+        xfailed_tests: Compiler labels mapped to expected failing test paths.
+            Used to skip retrying ignored tests when --retry-ignored-tests is off.
 
     Returns:
         None
@@ -1779,10 +1788,35 @@ def run_tests(
             )
             break
         elif iteration < max_iterations:
-            # Only rerun failed tests next time.
-            current_tests = sorted(set(failed_tests))
+            # Collect the failed tests for the next iteration.  By default,
+            # tests on the ignore list are not retried: they are known failures
+            # and re-running them (potentially many times, for two compilers)
+            # adds significant wall-clock time for no diagnostic value.
+            # --retry-ignored-tests or --no-xfail restore the old behaviour.
+            retry_candidates = set(failed_tests)
+            if not args.retry_ignored_tests and not args.no_xfail and xfailed_tests:
+                all_xfailed = (
+                    set(xfailed_tests.get("Generic", []))
+                    | set(xfailed_tests.get(compiler_label, []))
+                )
+                skipped = retry_candidates & all_xfailed
+                retry_candidates -= all_xfailed
+                if skipped:
+                    logger.info(
+                        f"{STATUS_WARN} Skipping retry of {len(skipped)} ignored test(s) "
+                        f"for {compiler_label} (use --retry-ignored-tests to retry them):"
+                    )
+                    for t in sorted(skipped):
+                        logger.info(f"       {t}")
+            if not retry_candidates:
+                logger.info(
+                    f"{STATUS_PASS} All remaining failures for {compiler_label} are on the "
+                    f"ignore list. Stopping iterations."
+                )
+                break
+            current_tests = sorted(retry_candidates)
             logger.info(
-                f"{STATUS_FAIL} {len(failed_tests)} failing test(s) found for {compiler_label}. "
+                f"{STATUS_FAIL} {len(current_tests)} failing test(s) found for {compiler_label}. "
                 f"Proceeding to iteration {iteration + 1} with only failed tests."
             )
         else:
@@ -2030,6 +2064,7 @@ def main() -> None:
             compiler_label,
             test_results,
             args,
+            xfailed_tests,
         )
 
     # Final summaries.
@@ -2403,6 +2438,7 @@ def print_configuration(
     fields.extend(
         [
             ("Use FAIL ignore list", "Not using" if args.no_xfail else "Using"),
+            ("Retry ignored tests", "Enabled" if args.retry_ignored_tests else "Disabled"),
             ("Group Results", "Enabled" if args.group_results else "Disabled"),
             ("Default Timeout", default_timeout_display),
             ("Retry Timeout", f"{args.retry_timeout} seconds"),


### PR DESCRIPTION
## Motivation

Tests on the ignore list are known to fail. When they fail (e.g. with a
timeout), the current retry logic re-runs them up to `--max-failed-retries`
times for each of the two compiler runs, adding significant wall-clock time
for no diagnostic value.

## Technical Details

Add a `--retry-ignored-tests` switch to `test_rocgdb.py` (default: off).

When off (the default), any test that appears in the ignore list
(`rocgdb_ignore_list.json`) and fails on the first run is excluded from
subsequent retry iterations.  If all remaining failures are on the ignore
list, iterations stop early.  Skipped tests are logged with a note pointing
to `--retry-ignored-tests`.

When `--retry-ignored-tests` is passed (or `--no-xfail` is active), the
previous behaviour is preserved: every failing test is retried regardless of
ignore-list membership.

The new flag is shown in the configuration summary printed at the start of
each run.

## Test Plan

- Manual inspection of the retry-filtering logic.
- Verified that `--retry-ignored-tests` and `--no-xfail` both bypass the
  filter correctly.

## Test Result

N/A (CI-script change only; no GPU hardware required to validate the logic).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.