### PR TITLE
.github: add automerge script and workflow for upstream sync

### DIFF
--- a/.github/scripts/automerge.md
+++ b/.github/scripts/automerge.md
@@ -1,85 +1,92 @@
 # Automerge Workflow
 
-Automatically syncs `sourceware/master` into `origin/amd-staging` every 6 hours,
-opening GitHub PRs for CI validation or conflict resolution as needed.
+Automatically syncs the configured upstream branch into the target branch every
+6 hours, opening GitHub PRs for CI validation or conflict resolution as needed.
 
 ## Files
 
 - `.github/workflows/automerge.yml` — GitHub Actions workflow definition.
 - `.github/scripts/automerge.py` — Python sync script invoked by the workflow.
+- `.github/scripts/test_automerge.py` — Unit tests for automerge.py.
 
 ## Triggers
 
-| Event                 | Condition                                             | Effect            |
-| --------------------- | ----------------------------------------------------- | ----------------- |
-| Scheduled             | Every 6 hours                                         | Normal sync run   |
-| `workflow_dispatch`   | Manual                                                | Normal sync run   |
-| `pull_request` closed | PR merged + label `merge-testing` or `merge-conflict` | Immediate re-sync |
+| Event               | Effect          |
+| ------------------- | --------------- |
+| Scheduled (6 hours) | Normal sync run |
+| `workflow_dispatch` | Manual run; exposes a `dry_run` boolean input |
+
+## Repository Variables
+
+Both variables must be set in the repository settings before the workflow runs:
+
+| Variable                    | Example       | Description                        |
+| --------------------------- | ------------- | ---------------------------------- |
+| `AUTOMERGE_TARGET_BRANCH`   | `amd-staging` | Branch to merge upstream commits into |
+| `AUTOMERGE_UPSTREAM_BRANCH` | `master`      | Upstream branch to pull from       |
+
+## Dry-Run Mode
+
+Pass `--dry-run` on the CLI, or enable the `dry_run` input in a manual
+`workflow_dispatch` run. In dry-run mode the script fetches and probes normally
+but skips all pushes and PR creation, printing what it would do instead.
 
 ## Sync Logic
 
 Each run follows these steps:
 
-1. **Clone or reuse** a local clone of `ROCm/ROCgdb` in `$WORKSPACE/rocgdb_sync/`.
-2. **Fetch** `sourceware/master` and `origin/amd-staging`, then immediately fast-forward `origin/master` to `sourceware/master` to keep the mirror current.
-3. **Gate** — if a fast-forward or conflict PR is already open, skip and exit.
-4. **Compute** the commit range: `merge-base(amd-staging, sourceware/master)..sourceware/master`.
-5. **Probe** — walk commits oldest-to-newest on a throwaway branch off `amd-staging`
+1. **Acquire repo** — use an existing clone passed via `--repo`, or clone/reuse
+   one in `$WORKSPACE/rocgdb_sync/`. In GHA the checked-out workspace is passed
+   as `--repo`, avoiding a redundant clone.
+2. **Fetch upstream and update mirror** — fetch the upstream branch from
+   sourceware, then fast-forward `origin/<upstream>` to keep the mirror current.
+3. **Gate** — if a conflict-free or conflict PR is already open, skip and exit.
+4. **Fetch target** — fetch `origin/<target>` (deferred until after the gate to
+   avoid unnecessary work when a PR is already open).
+5. **Compute** the commit range: `merge-base(TARGET, upstream)..upstream`.
+6. **Probe** — walk commits oldest-to-newest on a throwaway branch off the target
    to find the largest clean-merging prefix.
-6. **Act** based on the probe result:
+7. **Act** based on the probe result:
 
-### 6a. All commits merge cleanly
+### 7a. All commits merge cleanly
 
-Opens a **fast-forward PR** covering the full range. CI must pass before anyone
-merges it. Once merged, the `pull_request` closed trigger fires another sync run
-to pick up any further upstream commits.
+Opens a **conflict-free PR** covering the full range. CI must pass before anyone
+merges it.
 
-### 6b. Partial clean prefix
+### 7b. Partial clean prefix
 
-Opens a **fast-forward PR** for the clean prefix only. The conflict commit is left
-for the next run — after the FF PR merges, the re-sync will find the conflict and
-open a conflict PR then.
+Opens a **conflict-free PR** for the clean prefix only. The conflict commit is
+left for the next scheduled run.
 
-### 6c. No clean commits
+### 7c. No clean commits
 
-Opens a **conflict PR** directly against `amd-staging`. The PR is labeled
-`ci:skip` to suppress CI until conflicts are resolved manually. After the PR is
-merged, the `pull_request` closed trigger fires another sync run.
+Opens a **conflict PR** directly against the target branch. The PR is labeled
+`ci:skip` to suppress CI until conflicts are resolved manually.
 
 ## PR Types
 
-### Fast-forward PR
+### Conflict-free PR
 
-- **Branch**: `users/github/master-to-amd-staging-ff-YYYY-MM-DD-<hash>`
+- **Branch**: `users/github/<upstream>-to-<target>-conflict-free-YYYY-MM-DD-<hash>`
 - **Label**: `merge-testing`
-- **Base**: `amd-staging`
-- **Purpose**: CI gate before fast-forwarding upstream commits into staging.
+- **Base**: target branch
+- **Purpose**: CI gate before landing upstream commits into the target branch.
 
 ### Conflict PR
 
-- **Branch**: `users/github/master-to-amd-staging-conflict-YYYY-MM-DD-<hash>`
+- **Branch**: `users/github/<upstream>-to-<target>-conflict-YYYY-MM-DD-<hash>`
 - **Labels**: `merge-conflict`, `ci:skip`
-- **Base**: `amd-staging`
-- **Purpose**: Signals a merge conflict that requires manual resolution.
+- **Base**: target branch
+- **Purpose**: Signals a merge conflict requiring manual resolution.
   Remove the `ci:skip` label once conflicts are resolved to allow CI to run.
 
 ## Configuration
 
-Environment variables:
-
-| Variable / flag      | Description                                                                 |
-| -------------------- | --------------------------------------------------------------------------- |
-| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. The clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
-
-Key constants at the top of `automerge.py`:
-
-| Constant                 | Description                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `ROCGDB_REPO`            | GitHub repo slug (`ROCm/ROCgdb`)                         |
-| `SOURCEWARE_URL`         | Upstream GDB repository URL                              |
-| `FF_BRANCH_PREFIX`       | Branch prefix for fast-forward PRs                       |
-| `CONFLICT_BRANCH_PREFIX` | Branch prefix for conflict PRs                           |
-| `FF_LABEL`               | Label applied to fast-forward PRs (`merge-testing`)      |
-| `CONFLICT_LABEL`         | Label applied to conflict PRs (`merge-conflict`)         |
-| `CI_SKIP_LABEL`          | Label applied to conflict PRs to suppress CI (`ci:skip`) |
-| `RETRY_DELAYS`           | Sleep intervals (seconds) between network retries        |
+| Variable / flag             | Description                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| `AUTOMERGE_TARGET_BRANCH`   | Required. Branch to merge into.                                                  |
+| `AUTOMERGE_UPSTREAM_BRANCH` | Required. Upstream branch to pull from.                                          |
+| `GITHUB_REPOSITORY`         | Required. Set automatically by GitHub Actions (`owner/repo`).                    |
+| `WORKSPACE` / `--workspace` | Root directory for the working clone. Defaults to `$PWD`. Clone is created at `DIR/rocgdb_sync/binutils-gdb`. The CLI flag takes precedence over the env var. |
+| `--repo`                    | Path to an existing ROCgdb clone to use directly, skipping the clone step. Used in GHA to reuse the `actions/checkout` workspace. |
+| `--dry-run`                 | Skip all pushes and PR creation; print what would happen instead.                |

--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-"""Sync ROCgdb sourceware/master into origin/amd-staging.
+"""Sync ROCgdb upstream branch into the target branch.
 
-Fetches the upstream sourceware master, fast-forwards origin/master to match,
-then merges cleanly into origin/amd-staging. On conflict, pushes a conflict
+Fetches the upstream branch, fast-forwards the origin mirror to match,
+then merges cleanly into the target branch. On conflict, pushes a conflict
 branch and opens a PR for manual resolution.
 """
 
@@ -22,20 +22,52 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-ROCGDB_REPO = "ROCm/ROCgdb"
+SOURCEWARE_URL = "git://sourceware.org/git/binutils-gdb.git"
+SOURCEWARE_REMOTE = "sourceware"
+
+_rocgdb_repo = os.environ.get("GITHUB_REPOSITORY", "")
+if not _rocgdb_repo:
+    print(
+        "Error: GITHUB_REPOSITORY environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+ROCGDB_REPO = _rocgdb_repo
 ROCGDB_ORIGIN_URL = f"https://github.com/{ROCGDB_REPO}.git"
-SOURCEWARE_URL = "https://sourceware.org/git/binutils-gdb.git"
+
+_target_branch = os.environ.get("AUTOMERGE_TARGET_BRANCH", "")
+if not _target_branch:
+    print(
+        "Error: AUTOMERGE_TARGET_BRANCH environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+TARGET_BRANCH = _target_branch
+
+_upstream_branch = os.environ.get("AUTOMERGE_UPSTREAM_BRANCH", "")
+if not _upstream_branch:
+    print(
+        "Error: AUTOMERGE_UPSTREAM_BRANCH environment variable is required.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+UPSTREAM_BRANCH = _upstream_branch
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Sync sourceware/master into origin/amd-staging."
+        description=f"Sync {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH} into origin/{TARGET_BRANCH}."
     )
     p.add_argument(
         "--workspace",
         metavar="DIR",
         help="Root directory for the working clone (overrides $WORKSPACE). "
         "The clone is created at DIR/rocgdb_sync/binutils-gdb.",
+    )
+    p.add_argument(
+        "--repo",
+        metavar="DIR",
+        help="Path to an existing ROCgdb clone to use directly, skipping the clone step.",
     )
     p.add_argument(
         "--dry-run",
@@ -62,10 +94,11 @@ else:
 
 # Never pass secrets as CLI args — use env vars (e.g. GH_TOKEN) instead.
 
-CONFLICT_BRANCH_PREFIX = "users/github/master-to-amd-staging-conflict"
-FF_BRANCH_PREFIX = "users/github/master-to-amd-staging-ff"
+_branch_infix = f"{UPSTREAM_BRANCH}-to-{TARGET_BRANCH}".replace("/", "-")
+CONFLICT_BRANCH_PREFIX = f"users/github/{_branch_infix}-conflict"
+CONFLICT_FREE_BRANCH_PREFIX = f"users/github/{_branch_infix}-conflict-free"
 CONFLICT_LABEL = "merge-conflict"
-FF_LABEL = "merge-testing"
+CONFLICT_FREE_LABEL = "merge-testing"
 CI_SKIP_LABEL = "ci:skip"
 
 # Sleep durations (seconds) between successive network attempts.
@@ -118,6 +151,8 @@ def _is_network_error(exc: subprocess.CalledProcessError) -> bool:
         "no route to host",
         "fatal: unable to access",
         "ssh: connect",
+        "http 429",
+        "rpc failed",
     )
     return any(k in stderr for k in keywords)
 
@@ -178,15 +213,12 @@ def open_conflict_pr(
     merge_base_sha: str,
     conflict_commit: str,
     conflicted_files: list[str],
+    title: str,
 ) -> str:
     compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{merge_base_sha[:12]}...{conflict_commit[:12]}"
     file_list = "\n".join(f"- `{f}`" for f in conflicted_files)
-    title = (
-        f"ROCgdb master → amd-staging conflict: "
-        f"{merge_base_sha[:12]}..{conflict_commit[:12]}"
-    )
     body = (
-        f"## ROCgdb master → amd-staging merge conflict\n\n"
+        f"## ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} merge conflict\n\n"
         f"**Commits being merged:** [{merge_base_sha[:12]}...{conflict_commit[:12]}]({compare_url})\n\n"
         f"**Conflicted files:**\n{file_list}\n\n"
         f"Please resolve the conflicts, remove the `{CI_SKIP_LABEL}` label, "
@@ -204,7 +236,7 @@ def open_conflict_pr(
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--head",
             branch,
             "--title",
@@ -232,7 +264,7 @@ def find_open_conflict_pr() -> str | None:
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--state",
             "open",
             "--label",
@@ -247,24 +279,21 @@ def find_open_conflict_pr() -> str | None:
     return url if url else None
 
 
-def open_ff_pr(
+def open_conflict_free_pr(
     branch: str,
     first_commit: str,
     last_commit: str,
+    title: str,
 ) -> str:
     compare_url = f"https://github.com/{ROCGDB_REPO}/compare/{first_commit[:12]}...{last_commit[:12]}"
-    title = (
-        f"ROCgdb master → amd-staging fast-forward: "
-        f"{first_commit[:12]}..{last_commit[:12]}"
-    )
     body = (
-        f"## ROCgdb master → amd-staging fast-forward merge\n\n"
+        f"## ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free merge\n\n"
         f"**Commits being merged:** [{first_commit[:12]}...{last_commit[:12]}]({compare_url})\n\n"
         f"This PR was opened automatically by the automerge workflow. "
         f"Please validate CI, then merge."
     )
 
-    _ensure_label(FF_LABEL, "0075ca")
+    _ensure_label(CONFLICT_FREE_LABEL, "0075ca")
 
     result = run(
         [
@@ -274,7 +303,7 @@ def open_ff_pr(
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--head",
             branch,
             "--title",
@@ -282,16 +311,16 @@ def open_ff_pr(
             "--body",
             body,
             "--label",
-            FF_LABEL,
+            CONFLICT_FREE_LABEL,
         ]
     )
     pr_url = result.stdout.strip()
-    print(f"Fast-forward PR opened: {pr_url}")
+    print(f"Conflict-free PR opened: {pr_url}")
     return pr_url
 
 
-def find_open_ff_pr() -> str | None:
-    """Return the URL of an open fast-forward PR if one exists, else None."""
+def find_open_conflict_free_pr() -> str | None:
+    """Return the URL of an open conflict-free PR if one exists, else None."""
     result = run(
         [
             "gh",
@@ -300,11 +329,11 @@ def find_open_ff_pr() -> str | None:
             "--repo",
             ROCGDB_REPO,
             "--base",
-            "amd-staging",
+            TARGET_BRANCH,
             "--state",
             "open",
             "--label",
-            FF_LABEL,
+            CONFLICT_FREE_LABEL,
             "--json",
             "url",
             "--jq",
@@ -320,11 +349,18 @@ def find_open_ff_pr() -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def push_master_mirror(repo: Path) -> None:
-    """Fast-forward origin/master to match sourceware/master."""
-    print("Fast-forwarding origin/master to sourceware/master…")
+def push_upstream_mirror(repo: Path) -> None:
+    """Fast-forward origin/UPSTREAM_BRANCH to match SOURCEWARE_REMOTE/UPSTREAM_BRANCH."""
+    print(
+        f"Fast-forwarding origin/{UPSTREAM_BRANCH} to {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}…"
+    )
     run_net(
-        ["git", "push", "origin", "sourceware/master:refs/heads/master"],
+        [
+            "git",
+            "push",
+            "origin",
+            f"{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}:refs/heads/{UPSTREAM_BRANCH}",
+        ],
         cwd=repo,
     )
 
@@ -334,10 +370,10 @@ def probe_clean_prefix(
     commits: list[str],
 ) -> tuple[str | None, str | None]:
     """
-    Walk commits oldest-to-newest on a throwaway branch off origin/amd-staging.
+    Walk commits oldest-to-newest on a throwaway branch off origin/TARGET_BRANCH.
     Returns (last_clean_commit, first_conflict_commit).
     """
-    run(["git", "checkout", "-B", "probe", "origin/amd-staging"], cwd=repo)
+    run(["git", "checkout", "-B", "probe", f"origin/{TARGET_BRANCH}"], cwd=repo)
 
     last_clean = None
     first_conflict = None
@@ -346,49 +382,55 @@ def probe_clean_prefix(
         for commit in commits:
             result = run(["git", "merge", "--no-edit", commit], cwd=repo, check=False)
             if result.returncode != 0:
-                run(["git", "merge", "--abort"], cwd=repo)
+                run(["git", "merge", "--abort"], cwd=repo, check=False)
                 first_conflict = commit
                 break
             last_clean = commit
     finally:
-        run(["git", "checkout", "--detach", "HEAD"], cwd=repo)
-        run(["git", "branch", "-D", "probe"], cwd=repo)
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo, check=False)
+        run(["git", "branch", "-D", "probe"], cwd=repo, check=False)
 
     return last_clean, first_conflict
 
 
 def main() -> None:
-    WORK_DIR.mkdir(parents=True, exist_ok=True)
-    repo = WORK_DIR / "binutils-gdb"
-
-    try:
-        # ------------------------------------------------------------------ #
-        # 1. Clone or reuse.                                                   #
-        # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ #
+    # 1. Clone or reuse.                                                   #
+    # ------------------------------------------------------------------ #
+    if _args.repo:
+        repo = Path(_args.repo).resolve()
+        if not (repo / ".git").exists():
+            print(f"Error: --repo '{repo}' is not a git repository.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Using existing repo at {repo}…")
+    else:
+        WORK_DIR.mkdir(parents=True, exist_ok=True)
+        repo = WORK_DIR / "binutils-gdb"
         if (repo / ".git").exists():
             print(f"Reusing existing clone at {repo}…")
         else:
             print(f"Cloning {ROCGDB_REPO}…")
-            run_net(["git", "clone", ROCGDB_ORIGIN_URL, str(repo)])
+            run_net(
+                ["git", "clone", "--filter=blob:none", ROCGDB_ORIGIN_URL, str(repo)]
+            )
+
+    try:
 
         remotes = run(["git", "remote"], cwd=repo).stdout.split()
-        if "sourceware" not in remotes:
-            run(["git", "remote", "add", "sourceware", SOURCEWARE_URL], cwd=repo)
+        if SOURCEWARE_REMOTE not in remotes:
+            run(["git", "remote", "add", SOURCEWARE_REMOTE, SOURCEWARE_URL], cwd=repo)
 
         # ------------------------------------------------------------------ #
-        # 2. Fetch sourceware/master and origin/amd-staging.                  #
+        # 2. Fetch sourceware/UPSTREAM_BRANCH and update mirror.            #
         # ------------------------------------------------------------------ #
-        print("Fetching sourceware/master…")
-        run_net(["git", "fetch", "sourceware", "master"], cwd=repo)
-
-        print("Fetching origin/amd-staging…")
-        run_net(["git", "fetch", "origin", "amd-staging"], cwd=repo)
+        print(f"Fetching {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}…")
+        run_net(["git", "fetch", SOURCEWARE_REMOTE, UPSTREAM_BRANCH], cwd=repo)
 
         if not DRY_RUN:
-            push_master_mirror(repo)
+            push_upstream_mirror(repo)
 
         # ------------------------------------------------------------------ #
-        # 3. Skip if a conflict or fast-forward PR is already open.           #
+        # 3. Skip if a conflict or conflict-free PR is already open.          #
         # ------------------------------------------------------------------ #
         existing_conflict_pr = find_open_conflict_pr()
         if existing_conflict_pr:
@@ -398,19 +440,30 @@ def main() -> None:
             )
             return
 
-        existing_ff_pr = find_open_ff_pr()
-        if existing_ff_pr:
+        existing_conflict_free_pr = find_open_conflict_free_pr()
+        if existing_conflict_free_pr:
             print(
-                f"Open fast-forward PR found: {existing_ff_pr}\n"
+                f"Open conflict-free PR found: {existing_conflict_free_pr}\n"
                 "Skipping merge — wait for the PR to be merged first."
             )
             return
 
         # ------------------------------------------------------------------ #
-        # 4. Determine the commit range to merge.                             #
+        # 4. Fetch origin/TARGET_BRANCH (only needed for merge work).        #
+        # ------------------------------------------------------------------ #
+        print(f"Fetching origin/{TARGET_BRANCH}…")
+        run_net(["git", "fetch", "origin", TARGET_BRANCH], cwd=repo)
+
+        # ------------------------------------------------------------------ #
+        # 5. Determine the commit range to merge.                             #
         # ------------------------------------------------------------------ #
         merge_base_sha = run(
-            ["git", "merge-base", "origin/amd-staging", "sourceware/master"],
+            [
+                "git",
+                "merge-base",
+                f"origin/{TARGET_BRANCH}",
+                f"{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}",
+            ],
             cwd=repo,
         ).stdout.strip()
 
@@ -420,14 +473,14 @@ def main() -> None:
                 "log",
                 "--format=%H",
                 "--reverse",
-                f"{merge_base_sha}..sourceware/master",
+                f"{merge_base_sha}..{SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}",
             ],
             cwd=repo,
         ).stdout.strip()
 
         if not log_out:
             print(
-                "amd-staging is already up to date with sourceware/master. Nothing to do."
+                f"{TARGET_BRANCH} is already up to date with {SOURCEWARE_REMOTE}/{UPSTREAM_BRANCH}. Nothing to do."
             )
             return
 
@@ -438,64 +491,96 @@ def main() -> None:
         )
 
         # ------------------------------------------------------------------ #
-        # 5. Set up local amd-staging branch.                                 #
+        # 6. Set up local target branch (skipped in dry-run; probe uses the  #
+        #    remote ref directly and we have no local branch to return to).   #
         # ------------------------------------------------------------------ #
         if not DRY_RUN:
             run(
-                ["git", "checkout", "-B", "amd-staging", "origin/amd-staging"],
+                ["git", "checkout", "-B", TARGET_BRANCH, f"origin/{TARGET_BRANCH}"],
                 cwd=repo,
             )
 
         # ------------------------------------------------------------------ #
-        # 6. Probe for the largest clean prefix.                              #
+        # 7. Probe for the largest clean prefix.                              #
         # ------------------------------------------------------------------ #
         print("Probing for clean merge prefix…")
         last_clean, first_conflict = probe_clean_prefix(repo, commits)
 
         # Probe leaves the repo on detached HEAD; return to the local branch.
         if not DRY_RUN:
-            run(["git", "checkout", "amd-staging"], cwd=repo)
+            run(["git", "checkout", TARGET_BRANCH], cwd=repo)
 
         # ------------------------------------------------------------------ #
-        # 7a. All commits apply cleanly → open a fast-forward PR.            #
+        # 7a. All commits apply cleanly → open a conflict-free PR.           #
         # ------------------------------------------------------------------ #
         if first_conflict is None:
             print(f"All {len(commits)} commit(s) merge cleanly.")
-            ff_branch = (
-                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            conflict_free_branch = f"{CONFLICT_FREE_BRANCH_PREFIX}-{date.today().isoformat()}-{commits[-1][:8]}"
+            conflict_free_title = (
+                f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free: "
+                f"{merge_base_sha[:12]}..{commits[-1][:12]}"
             )
             if DRY_RUN:
-                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
+                print(
+                    f"[DRY RUN] Would open conflict-free PR:\n"
+                    f"  Branch : {conflict_free_branch}\n"
+                    f"  Commits: {merge_base_sha[:12]}..{commits[-1][:12]}"
+                    f" ({len(commits)} commit(s))\n"
+                    f"  Title  : {conflict_free_title}"
+                )
             else:
-                run(["git", "checkout", "-B", ff_branch], cwd=repo)
-                run(["git", "merge", "--no-edit", commits[-1]], cwd=repo)
-                run_net(["git", "push", "origin", ff_branch], cwd=repo)
-                open_ff_pr(
-                    branch=ff_branch,
+                run_net(
+                    [
+                        "git",
+                        "push",
+                        "origin",
+                        f"{commits[-1]}:refs/heads/{conflict_free_branch}",
+                    ],
+                    cwd=repo,
+                )
+                open_conflict_free_pr(
+                    branch=conflict_free_branch,
                     first_commit=merge_base_sha,
                     last_commit=commits[-1],
+                    title=conflict_free_title,
                 )
             return
 
         # ------------------------------------------------------------------ #
-        # 7b. Partial clean prefix → open a fast-forward PR for clean range. #
+        # 7b. Partial clean prefix → open a conflict-free PR for clean range.#
         # ------------------------------------------------------------------ #
         if last_clean is not None:
-            print(f"Clean prefix ends at {last_clean[:12]}. Opening fast-forward PR…")
-            ff_branch = (
-                f"{FF_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            print(f"Clean prefix ends at {last_clean[:12]}. Opening conflict-free PR…")
+            clean_count = commits.index(last_clean) + 1
+            conflict_free_branch = f"{CONFLICT_FREE_BRANCH_PREFIX}-{date.today().isoformat()}-{last_clean[:8]}"
+            conflict_free_title = (
+                f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict-free: "
+                f"{merge_base_sha[:12]}..{last_clean[:12]}"
             )
             if DRY_RUN:
-                print(f"[DRY RUN] would push {ff_branch} and open fast-forward PR.")
-            else:
-                run(["git", "checkout", "-B", ff_branch], cwd=repo)
-                run(["git", "merge", "--no-edit", last_clean], cwd=repo)
-                run_net(["git", "push", "origin", ff_branch], cwd=repo)
-                open_ff_pr(
-                    branch=ff_branch,
-                    first_commit=merge_base_sha,
-                    last_commit=last_clean,
+                print(
+                    f"[DRY RUN] Would open conflict-free PR:\n"
+                    f"  Branch : {conflict_free_branch}\n"
+                    f"  Commits: {merge_base_sha[:12]}..{last_clean[:12]}"
+                    f" ({clean_count} commit(s))\n"
+                    f"  Title  : {conflict_free_title}"
                 )
+                return
+            run_net(
+                [
+                    "git",
+                    "push",
+                    "origin",
+                    f"{last_clean}:refs/heads/{conflict_free_branch}",
+                ],
+                cwd=repo,
+            )
+            open_conflict_free_pr(
+                branch=conflict_free_branch,
+                first_commit=merge_base_sha,
+                last_commit=last_clean,
+                title=conflict_free_title,
+            )
             return
         else:
             print("No clean commits to merge; first commit already conflicts.")
@@ -513,25 +598,47 @@ def main() -> None:
         ).stdout.strip()
         print(f"\nConflict commit: {conflict_info}")
 
+        # Probe the conflicted files by attempting the merge on a scratch branch.
+        run(
+            ["git", "checkout", "-B", "probe-conflict", f"origin/{TARGET_BRANCH}"],
+            cwd=repo,
+        )
+        run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
+        conflicted_files = (
+            run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
+            .stdout.strip()
+            .splitlines()
+        )
+        run(["git", "merge", "--abort"], cwd=repo, check=False)
+        run(["git", "checkout", "--detach", "HEAD"], cwd=repo, check=False)
+        run(["git", "branch", "-D", "probe-conflict"], cwd=repo, check=False)
+
+        conflict_title = (
+            f"ROCgdb {UPSTREAM_BRANCH} → {TARGET_BRANCH} conflict: "
+            f"{merge_base_sha[:12]}..{first_conflict[:12]}"
+        )
+
         if DRY_RUN:
-            print(f"[DRY RUN] would push {conflict_branch} and open conflict PR.")
+            files_str = "\n".join(f"    {f}" for f in conflicted_files)
+            print(
+                f"[DRY RUN] Would open conflict PR:\n"
+                f"  Branch            : {conflict_branch}\n"
+                f"  Conflicting commit: {conflict_info}\n"
+                f"  Conflicted files  :\n{files_str}\n"
+                f"  Title             : {conflict_title}"
+            )
         else:
-            # Checkout a fresh conflict branch from the current amd-staging state.
+            # Checkout a fresh conflict branch from the current target branch state.
             run(["git", "checkout", "-B", conflict_branch], cwd=repo)
             run(["git", "merge", "--no-edit", first_conflict], cwd=repo, check=False)
 
-            conflicted_files = (
-                run(["git", "diff", "--name-only", "--diff-filter=U"], cwd=repo)
-                .stdout.strip()
-                .splitlines()
-            )
             print("Conflicted files:")
             for f in conflicted_files:
                 print(f"  {f}")
 
             # Stage and commit the conflict markers so the branch carries a diff
             # that gh pr create can open (the branch would otherwise be identical
-            # to amd-staging and gh would reject it with "no commits between...").
+            # to the target branch and gh would reject it with "no commits between...").
             run(["git", "add", "-A"], cwd=repo)
             run(
                 [
@@ -539,7 +646,7 @@ def main() -> None:
                     "commit",
                     "--no-verify",
                     "-m",
-                    f"Merge {first_conflict[:12]} into amd-staging (unresolved conflicts)",
+                    f"Merge {first_conflict[:12]} into {TARGET_BRANCH} (unresolved conflicts)",
                 ],
                 cwd=repo,
             )
@@ -550,6 +657,7 @@ def main() -> None:
                 merge_base_sha=merge_base_sha,
                 conflict_commit=first_conflict,
                 conflicted_files=conflicted_files,
+                title=conflict_title,
             )
 
     except ConnectivityError:

--- a/.github/scripts/test_automerge.py
+++ b/.github/scripts/test_automerge.py
@@ -19,6 +19,12 @@ import importlib
 import importlib.util
 import os
 
+_TEST_ENV = {
+    "GITHUB_REPOSITORY": "ROCm/ROCgdb",
+    "AUTOMERGE_TARGET_BRANCH": "amd-staging",
+    "AUTOMERGE_UPSTREAM_BRANCH": "master",
+}
+
 
 def _load_automerge():
     """Load automerge as a module, neutralising its module-level side-effects."""
@@ -27,7 +33,8 @@ def _load_automerge():
         Path(__file__).parent / "automerge.py",
     )
     # Patch sys.argv so argparse doesn't see pytest/unittest args.
-    with patch("sys.argv", ["automerge.py"]):
+    # Inject required env vars so module-level validation doesn't call sys.exit.
+    with patch("sys.argv", ["automerge.py"]), patch.dict(os.environ, _TEST_ENV):
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
     return mod
@@ -121,7 +128,7 @@ class TestRunNet(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# find_open_conflict_pr / find_open_ff_pr
+# find_open_conflict_pr / find_open_conflict_free_pr
 # ---------------------------------------------------------------------------
 
 
@@ -151,7 +158,7 @@ class TestFindOpenPr(unittest.TestCase):
 
     def test_ff_returns_none_when_no_pr(self):
         with patch.object(am, "run", return_value=_completed(stdout="")):
-            url = am.find_open_ff_pr()
+            url = am.find_open_conflict_free_pr()
         self.assertIsNone(url)
 
 
@@ -200,8 +207,8 @@ class TestProbeCleanPrefix(unittest.TestCase):
         self.assertEqual(last_clean, "aaa")
         self.assertEqual(first_conflict, "bbb")
 
-    def test_cleanup_runs_even_when_abort_raises(self):
-        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort raises."""
+    def test_cleanup_runs_even_when_abort_fails(self):
+        """Branch cleanup (checkout --detach + branch -D) must run even if merge --abort fails."""
         cleanup_calls = []
 
         def fake_subproc(cmd, **kwargs):
@@ -209,17 +216,17 @@ class TestProbeCleanPrefix(unittest.TestCase):
                 return _completed(returncode=1, stderr="conflict")
             if "--abort" in cmd:
                 # Simulate merge --abort failing (e.g. no merge in progress).
+                # probe_clean_prefix calls this with check=False so it doesn't raise.
                 return _completed(returncode=1, stderr="cannot abort")
             if "--detach" in cmd or "-D" in cmd:
                 cleanup_calls.append(list(cmd))
             return _completed()
 
         with patch("subprocess.run", side_effect=fake_subproc):
-            # merge --abort returns non-zero; run() with check=True will raise.
-            # probe_clean_prefix calls merge --abort with check=True, so it raises.
-            with self.assertRaises(subprocess.CalledProcessError):
-                am.probe_clean_prefix(Path("/repo"), ["aaa"])
+            last_clean, first_conflict = am.probe_clean_prefix(Path("/repo"), ["aaa"])
 
+        self.assertIsNone(last_clean)
+        self.assertEqual(first_conflict, "aaa")
         self.assertEqual(len(cleanup_calls), 2)
 
 
@@ -236,7 +243,7 @@ class TestEarlyExitGate(unittest.TestCase):
             patch.object(am, "run_net", return_value=_completed()),
             patch.object(am, "run", return_value=_completed(stdout="")),
             patch.object(am, "find_open_conflict_pr", return_value=conflict_pr),
-            patch.object(am, "find_open_ff_pr", return_value=ff_pr),
+            patch.object(am, "find_open_conflict_free_pr", return_value=ff_pr),
         ]
         return patches
 
@@ -306,15 +313,15 @@ class TestDryRun(unittest.TestCase):
         ), patch.object(
             am, "find_open_conflict_pr", return_value=None
         ), patch.object(
-            am, "find_open_ff_pr", return_value=None
+            am, "find_open_conflict_free_pr", return_value=None
         ), patch.object(
             am, "probe_clean_prefix", return_value=probe_result
         ), patch.object(
-            am, "open_ff_pr"
+            am, "open_conflict_free_pr"
         ) as mock_ff_pr, patch.object(
             am, "open_conflict_pr"
         ) as mock_conflict_pr, patch.object(
-            am, "push_master_mirror"
+            am, "push_upstream_mirror"
         ) as mock_mirror, patch.object(
             am, "DRY_RUN", True
         ):
@@ -348,6 +355,7 @@ class TestDryRun(unittest.TestCase):
         push_calls = [c for c in run_net_calls if "push" in c]
         self.assertEqual(push_calls, [])
         mock_ff_pr.assert_not_called()
+        mock_conflict_pr.assert_not_called()
         mock_mirror.assert_not_called()
 
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,11 @@ on:
   schedule: # runs every 6 hours
     - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (fetch and probe, but skip pushes and PR creation)'
+        type: boolean
+        default: false
   pull_request:
     types: [closed]
     branches: [amd-staging]
@@ -27,6 +32,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WORKSPACE: ${{ github.workspace }}
+      AUTOMERGE_TARGET_BRANCH: ${{ vars.AUTOMERGE_TARGET_BRANCH }}
+      AUTOMERGE_UPSTREAM_BRANCH: ${{ vars.AUTOMERGE_UPSTREAM_BRANCH }}
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -37,4 +44,5 @@ jobs:
           git config --global credential.helper "!gh auth git-credential"
       - name: Trigger Automerge Job
         run: |
-          python3 .github/scripts/automerge.py
+          python3 .github/scripts/automerge.py \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,9 +8,6 @@ on:
         description: 'Dry run (fetch and probe, but skip pushes and PR creation)'
         type: boolean
         default: false
-  pull_request:
-    types: [closed]
-    branches: [amd-staging]
 
 concurrency:
   group: gdb-automerge
@@ -19,13 +16,6 @@ concurrency:
 jobs:
   automerge-to-staging:
     runs-on: ubuntu-latest
-    if: false
-    # Remove the above and uncomment below to activate:
-    # if: |
-    #   github.event_name != 'pull_request' ||
-    #   (github.event.pull_request.merged == true &&
-    #    (contains(github.event.pull_request.labels.*.name, 'merge-testing') ||
-    #     contains(github.event.pull_request.labels.*.name, 'merge-conflict')))
     permissions:
       contents: write
       pull-requests: write
@@ -45,4 +35,5 @@ jobs:
       - name: Trigger Automerge Job
         run: |
           python3 .github/scripts/automerge.py \
+            --repo "$WORKSPACE" \
             ${{ inputs.dry_run == true && '--dry-run' || '' }}


### PR DESCRIPTION
## Summary

- Make the automerge script fully generic: repo slug, target branch, and upstream branch are read from required repository variables (`AUTOMERGE_TARGET_BRANCH`, `AUTOMERGE_UPSTREAM_BRANCH`) instead of being hardcoded. The script exits with an error if any are unset.
- Push conflict-free branches by direct refspec to avoid local merge commits.
- Add `--dry-run` mode: fetches and probes normally but skips all pushes and PR creation, printing what it would do instead (branch name, commit range, PR title, and conflicted files if applicable).
- Wire `--dry-run` to a boolean `workflow_dispatch` input so it can be toggled from the Actions UI.
- Use "conflict-free" instead of "fast-forward" throughout: the script merges rather than pointer-advances, so the old term was misleading.
- Activate the workflow: remove the `if: false` guard and enable the schedule and `workflow_dispatch` triggers. The `pull_request` trigger has been dropped in favour of relying solely on the 6-hour schedule.

## Repository variables required before merge

- `AUTOMERGE_TARGET_BRANCH` — branch to merge into (e.g. `amd-staging`)
- `AUTOMERGE_UPSTREAM_BRANCH` — upstream branch to pull from (e.g. `master`)

## Test plan

- [x] Trigger manually from the Actions UI with dry-run checked — verify no pushes or PRs are created, output shows what would happen
- [x] Trigger manually with dry-run unchecked — verify `origin/master` is updated and a conflict-free or conflict PR is opened
- [x] Unit tests pass: `python3 -m pytest .github/scripts/test_automerge.py`