### PR TITLE
ci: add gfx125x to TheRock CI matrix

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amdgpu_family: [gfx94X-dcgpu]
+        amdgpu_family: [gfx94X-dcgpu, gfx125X-dcgpu]
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- add gfx125X-dcgpu to the ROCgdb TheRock CI build matrix

This keeps gfx125X-dcgpu build-only because the existing test job remains gated to gfx94X-dcgpu.

Depends on ROCm/therock-ci-config#14.

## Testing
- parsed .github/workflows/therock-ci.yml and .github/workflows/therock-ci-linux.yml with PyYAML
- git diff --check