### PR TITLE
fix(test_rocgdb.py): Append additional LD_LIBRARY_PATH entry

### DIFF
--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -1252,6 +1252,28 @@ def setup_environment(artifacts_dir: Path) -> Dict[str, str]:
         f"{artifacts_dir}/llvm/lib",
         f"{artifacts_dir}/lib/llvm/lib",
     ]
+
+    # Determine target triple
+    target_triple = None
+    amdclang_path = artifacts_dir / "lib" / "llvm" / "bin" / "amdclang++"
+    if amdclang_path.exists():
+        try:
+            target_triple = subprocess.run(
+                [str(amdclang_path), "--print-target-triple"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            ).stdout.strip()
+        except (subprocess.SubprocessError, OSError) as exc:
+            raise RuntimeError(
+                f"'{amdclang_path} --print-target-triple' failed; "
+                "this suggests a broken toolchain."
+            ) from exc
+
+    if target_triple:
+        ld_library_parts += [f"{artifacts_dir}/lib/llvm/lib/{target_triple}"]
+
     _prepend_to_path_var(env_vars, "PATH", path_parts)
     _prepend_to_path_var(env_vars, "LD_LIBRARY_PATH", ld_library_parts)
 


### PR DESCRIPTION
When `-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON`, libomp.so and libomptarget.so will be installed one level down in `lib/x86_64-unknown-linux-gnu` for example. This patch  will query clang to get the host triple and add it to the LD_LIBRARY_PATH being passed to rocgdb.

This LLVM option will be the default in ROCm once https://github.com/ROCm/TheRock/pull/5758 lands, which is currently blocked by this test issue.

## Motivation
With -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON, we are seeing cannot find libomp.so/libomptarget.so errors at runtime, which is blocking https://github.com/ROCm/TheRock/pull/5758

## Test Plan
Run gdb.rocm testsuite.

## Test Result
gdb.rocm should have no errors on `omp-target*` tests.

