### PR TITLE
[amd-staging-rocgdb-16] ROCgdb cherry picks from origin/amd-staging (2026-07-20)

### DIFF
--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -1795,9 +1795,8 @@ def run_tests(
             # --retry-ignored-tests or --no-xfail restore the old behaviour.
             retry_candidates = set(failed_tests)
             if not args.retry_ignored_tests and not args.no_xfail and xfailed_tests:
-                all_xfailed = (
-                    set(xfailed_tests.get("Generic", []))
-                    | set(xfailed_tests.get(compiler_label, []))
+                all_xfailed = set(xfailed_tests.get("Generic", [])) | set(
+                    xfailed_tests.get(compiler_label, [])
                 )
                 skipped = retry_candidates & all_xfailed
                 retry_candidates -= all_xfailed
@@ -2438,7 +2437,10 @@ def print_configuration(
     fields.extend(
         [
             ("Use FAIL ignore list", "Not using" if args.no_xfail else "Using"),
-            ("Retry ignored tests", "Enabled" if args.retry_ignored_tests else "Disabled"),
+            (
+                "Retry ignored tests",
+                "Enabled" if args.retry_ignored_tests else "Disabled",
+            ),
             ("Group Results", "Enabled" if args.group_results else "Disabled"),
             ("Default Timeout", default_timeout_display),
             ("Retry Timeout", f"{args.retry_timeout} seconds"),

--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -1252,6 +1252,28 @@ def setup_environment(artifacts_dir: Path) -> Dict[str, str]:
         f"{artifacts_dir}/llvm/lib",
         f"{artifacts_dir}/lib/llvm/lib",
     ]
+
+    # Determine target triple
+    target_triple = None
+    amdclang_path = artifacts_dir / "lib" / "llvm" / "bin" / "amdclang++"
+    if amdclang_path.exists():
+        try:
+            target_triple = subprocess.run(
+                [str(amdclang_path), "--print-target-triple"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            ).stdout.strip()
+        except (subprocess.SubprocessError, OSError) as exc:
+            raise RuntimeError(
+                f"'{amdclang_path} --print-target-triple' failed; "
+                "this suggests a broken toolchain."
+            ) from exc
+
+    if target_triple:
+        ld_library_parts += [f"{artifacts_dir}/lib/llvm/lib/{target_triple}"]
+
     _prepend_to_path_var(env_vars, "PATH", path_parts)
     _prepend_to_path_var(env_vars, "LD_LIBRARY_PATH", ld_library_parts)
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -1,5 +1,5 @@
 # Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-# SPDX-License-Identifier: MIT 
+# SPDX-License-Identifier: MIT
 
 import fnmatch
 import json
@@ -8,6 +8,7 @@ from pathlib import Path
 import subprocess
 import sys
 from typing import Iterable, Optional, Mapping
+
 
 def gha_set_output(vars: Mapping[str, str | Path]):
     """Sets values in a step's output parameters.
@@ -28,6 +29,7 @@ def gha_set_output(vars: Mapping[str, str | Path]):
     with open(step_output_file, "a") as f:
         f.writelines(f"{k}={str(v)}" + "\n" for k, v in vars.items())
 
+
 def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     """Returns the paths of modified files relative to the base reference."""
     try:
@@ -45,7 +47,8 @@ def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
             file=sys.stderr,
         )
         return None
-    
+
+
 GITHUB_WORKFLOWS_CI_PATTERNS = [
     "therock*.yml",
 ]
@@ -56,11 +59,13 @@ def is_path_workflow_file_related_to_ci(path: str) -> bool:
         fnmatch.fnmatch(path, ".github/workflows/" + pattern)
         for pattern in GITHUB_WORKFLOWS_CI_PATTERNS
     )
-    
+
+
 def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> bool:
     if paths is None:
         return False
     return any(is_path_workflow_file_related_to_ci(p) for p in paths)
+
 
 # Paths matching any of these patterns are considered to have no influence over
 # build or test workflows so any related jobs can be skipped if all paths
@@ -71,21 +76,24 @@ SKIPPABLE_PATH_PATTERNS = [
     "*.md",
     "*LICENSE*",
     "*NOTICES*",
-    '.github/CODEOWNERS',
-    '.github/*.md',
-    '.github/dependabot.yml',
-    '.azuredevops*',
+    ".github/CODEOWNERS",
+    ".github/*.md",
+    ".github/dependabot.yml",
+    ".azuredevops*",
 ]
+
 
 def is_path_skippable(path: str) -> bool:
     """Determines if a given relative path to a file matches any skippable patterns."""
     return any(fnmatch.fnmatch(path, pattern) for pattern in SKIPPABLE_PATH_PATTERNS)
+
 
 def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
     """Returns true if at least one path is not in the skippable set."""
     if paths is None:
         return False
     return any(not is_path_skippable(p) for p in paths)
+
 
 def should_ci_run_given_modified_paths(paths: Optional[Iterable[str]]) -> bool:
     """Returns true if CI workflows should run given a list of modified paths."""
@@ -99,7 +107,7 @@ def should_ci_run_given_modified_paths(paths: Optional[Iterable[str]]) -> bool:
         [p for p in paths if p.startswith(".github/workflows")]
     )
     other_paths = paths_set - github_workflows_paths
-    
+
     related_to_ci = check_for_workflow_file_related_to_ci(github_workflows_paths)
     contains_other_non_skippable_files = check_for_non_skippable_path(other_paths)
 
@@ -118,15 +126,15 @@ def should_ci_run_given_modified_paths(paths: Optional[Iterable[str]]) -> bool:
         )
         return False
 
+
 def main(args):
     base_ref = args.get("base_ref")
     modified_paths = get_modified_paths(base_ref)
     print("modified_paths (max 200):", modified_paths[:200])
     enable_jobs = should_ci_run_given_modified_paths(modified_paths)
-    output = {
-        'enable_therock_ci': json.dumps(enable_jobs)
-    }
+    output = {"enable_therock_ci": json.dumps(enable_jobs)}
     gha_set_output(output)
+
 
 if __name__ == "__main__":
     args = {}

--- a/gdb/testsuite/gdb.rocm/hip-graph-launch.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-graph-launch.cpp
@@ -1,0 +1,106 @@
+/* Copyright (C) 2026 Free Software Foundation, Inc.
+   Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* Build a HIP graph by capturing two kernel launches from a stream into a
+   single graph, instantiate it, and then launch (replay) the executable
+   graph several times with hipGraphLaunch.  This exercises the debugger's
+   ability to associate stops with the right kernel and source line when the
+   kernels reach the GPU through a graph launch -- the host submits a whole
+   pre-recorded graph of operations with hipGraphLaunch, which dispatches the
+   kernels -- rather than through a direct kernel<<<>>>() call.
+
+   The two kernels operate on the same buffer, in order, so each graph
+   replay computes out = (out + 1) * 3.  Starting from 0 this gives 3, 12
+   and 39 after the first, second and third replay respectively.  The
+   deterministic values let the .exp verify that each node executed in the
+   right order with the right data on every replay.  */
+
+#include <stdio.h>
+#include <hip/hip_runtime.h>
+
+#include "rocm-test-utils.h"
+
+/* Number of times the executable graph is replayed.  The .exp overrides
+   this via -DNUM_REPLAYS=... so the source and test stay in sync; the
+   default lets the program build on its own.  */
+#ifndef NUM_REPLAYS
+#define NUM_REPLAYS 3
+#endif
+
+/* First graph node.  */
+
+__global__ void
+add_one (int *out)
+{
+  int tid = threadIdx.x;
+  out[tid] = out[tid] + 1; /* break add_one */
+}
+
+/* Second graph node, run after add_one on the same buffer.  */
+
+__global__ void
+times_three (int *out)
+{
+  int tid = threadIdx.x;
+  out[tid] = out[tid] * 3; /* break times_three */
+}
+
+int
+main ()
+{
+  constexpr unsigned int num_elems = 1;
+
+  int *result_ptr;
+  CHECK (hipMalloc (&result_ptr, num_elems * sizeof (int)));
+  CHECK (hipMemset (result_ptr, 0, num_elems * sizeof (int)));
+
+  hipStream_t stream;
+  CHECK (hipStreamCreate (&stream));
+
+  /* Capture two kernel launches into a single graph.  */
+  CHECK (hipStreamBeginCapture (stream, hipStreamCaptureModeGlobal));
+  add_one<<<dim3 (1), dim3 (num_elems), 0, stream>>> (result_ptr);
+  times_three<<<dim3 (1), dim3 (num_elems), 0, stream>>> (result_ptr);
+  hipGraph_t graph;
+  CHECK (hipStreamEndCapture (stream, &graph));
+
+  /* Turn the graph into an executable graph.  */
+  hipGraphExec_t graph_exec;
+  CHECK (hipGraphInstantiate (&graph_exec, graph, nullptr, nullptr, 0));
+
+  /* This is the "launch graph" execution path: instead of the host
+     issuing each kernel<<<>>>(), hipGraphLaunch submits the whole graph and
+     re-dispatches both kernels on every replay.  The debugger should stop
+     in them on each launch.  */
+  for (int i = 0; i < NUM_REPLAYS; i++)
+    {
+      CHECK (hipGraphLaunch (graph_exec, stream));
+      CHECK (hipStreamSynchronize (stream));
+    }
+
+  int result;
+  CHECK (hipMemcpyDtoH (&result, result_ptr, sizeof (int)));
+  printf ("result is %d\n", result);
+
+  CHECK (hipGraphExecDestroy (graph_exec));
+  CHECK (hipGraphDestroy (graph));
+  CHECK (hipStreamDestroy (stream));
+  CHECK (hipFree (result_ptr));
+
+  return 0;
+}

--- a/gdb/testsuite/gdb.rocm/hip-graph-launch.exp
+++ b/gdb/testsuite/gdb.rocm/hip-graph-launch.exp
@@ -1,0 +1,94 @@
+# Copyright (C) 2026 Free Software Foundation, Inc.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+# This file is part of GDB.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test debugging kernels launched through a HIP graph (graph replay).
+#
+# The program captures two kernels (add_one then times_three) from a stream
+# into a single graph, instantiates it, and replays it NUM_REPLAYS times with
+# hipGraphLaunch.  Because the kernels reach the GPU through a graph launch
+# (the host submits a whole pre-recorded graph with hipGraphLaunch, which
+# dispatches the kernels) rather than a direct kernel<<<>>>() call, this
+# checks that the debugger still:
+#
+#   - resolves pending breakpoints in graph-launched kernels
+#   - associates each stop with the right kernel and source line
+#   - stops in each graph node, in order, on every replay (dispatch
+#     numbering / re-dispatch)
+#   - observes the correct per-replay data produced by each node
+
+load_lib rocm.exp
+
+require allow_hip_tests
+
+standard_testfile .cpp
+
+# Number of times the graph is replayed.  Passed to the C source via
+# -DNUM_REPLAYS so the source and test always stay in sync.
+set num_replays 3
+
+if {[build_executable "failed to prepare" $testfile $srcfile \
+	 [list debug hip additional_flags=-DNUM_REPLAYS=$num_replays]]} {
+    return
+}
+
+set add_one_line [gdb_get_line_number "break add_one"]
+set times_three_line [gdb_get_line_number "break times_three"]
+
+# Both kernel nodes are hit, in order, on every graph replay, and each
+# observes the value expected for that replay.
+proc_with_prefix test_replays_and_ordering {} {
+    with_rocm_gpu_lock {
+	clean_restart $::testfile
+
+	if {![runto_main]} {
+	    return
+	}
+
+	gdb_breakpoint "$::srcfile:$::add_one_line" allow-pending
+	gdb_breakpoint "$::srcfile:$::times_three_line" allow-pending
+
+	# out starts at 0.  Each replay computes out = (out + 1) * 3, so at the
+	# add_one stop out holds the value from the previous replay, and at the
+	# times_three stop it holds that value + 1.
+	set val 0
+	for {set i 1} {$i <= $::num_replays} {incr i} {
+	    with_test_prefix "replay $i" {
+		gdb_test "continue" \
+		    "Breakpoint .* add_one .*$::srcfile:$::add_one_line.*" \
+		    "stop in add_one"
+		gdb_test "print out\[0\]" " = $val" \
+		    "add_one sees value from previous replay"
+
+		gdb_test "continue" \
+		    "Breakpoint .* times_three .*$::srcfile:$::times_three_line.*" \
+		    "stop in times_three"
+		gdb_test "print out\[0\]" " = [expr {$val + 1}]" \
+		    "times_three sees add_one result"
+
+		set val [expr {($val + 1) * 3}]
+	    }
+	}
+
+	# After all replays the program prints the final result and exits.
+	gdb_test "continue" \
+	    "result is $val.*$::inferior_exited_re normally.*" \
+	    "continue to end, result $val"
+    }
+}
+
+test_replays_and_ordering

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -33,6 +33,15 @@ if { [build_executable "failed to prepare" ${testfile} ${srcfile} \
     return -1
 }
 
+# The "do_test" function is called multiple times, and any may exit early if
+# it turns out the current configuration does not allow the creation of core
+# dumps.  However, if at least one core dump can be produced, all must be.
+# Keep track of the number of attempts and their status to enforce this
+# property.
+set total_count 0
+set untested_count 0
+set success_count 0
+
 # do_test FAULT CORE_TYPE OUTPUT_TYPE
 #   Run the test exercising generation of a core dump on fault FAULT
 #   using a file or a pipe.
@@ -45,6 +54,7 @@ if { [build_executable "failed to prepare" ${testfile} ${srcfile} \
 # OUTPUT_TYPE is one of "file" of "pipe".
 #
 proc do_test { fault core_type output_type } {
+    incr ::total_count
     set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
@@ -53,6 +63,7 @@ proc do_test { fault core_type output_type } {
 
     if {$coredump eq ""} {
 	untested "Could not generate a core file"
+	incr ::untested_count
 	return
     }
 
@@ -134,6 +145,7 @@ proc do_test { fault core_type output_type } {
     }
 
     gdb_exit
+    incr ::success_count
 }
 
 with_rocm_gpu_lock {
@@ -151,3 +163,6 @@ with_rocm_gpu_lock {
       do_test $fault lightweight file
     }
 }
+
+gdb_assert {$::total_count == ($::untested_count + $::success_count)} "all tests accounted for"
+gdb_assert {$::untested_count == 0 || $::success_count == 0} "coredump consistently produced"


### PR DESCRIPTION
0398a92d18c - gdb/testsuite: add HIP graph-launch kernel debugging test (Sarang Patrange)
cd1860120f6 - gdb/testsuite/rocm/runtime-core: ensure all or no test run (Lancelot SIX)
42e9cad9e7a - .github/scripts: apply black formatting (Luis Machado)
b39194cb9da - Merge pull request #220 from ROCm/users/estewart/update-test-rocgdb-ld-library-path (estewart08)