### PR TITLE
gdb/testsuite: restore -O0 for amdclang++ HIP test compiles

### DIFF
--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6832,7 +6832,9 @@ proc gdb_compile {source dest type options} {
 	# before .cpp/.c sources and "-x none" before .o/.a files.
 	# --hip-link is still required when linking to bring in the HIP
 	# runtime.
-	set hip_early_flags "-mllvm=-amdgpu-spill-cfi-saved-regs\
+	# amdclang++ does not always default to -O0 for -x hip device compiles;
+	# omitting -O0 can emit DW_CC_nocall and break gdb.rocm finish tests.
+	set hip_early_flags "-O0 -mllvm=-amdgpu-spill-cfi-saved-regs\
 			     -Wno-unused-command-line-argument"
 	if {$type eq "executable"} {
 	    set hip_early_flags "--hip-link $hip_early_flags"


### PR DESCRIPTION
Commit `ab3a83eb` migrated the gdb.rocm testsuite from `hipcc` to `amdclang++` and dropped `-O0` from `hip_early_flags`, assuming `amdclang++` defaults to `-O0` for `-x hip` compiles. With WW28-era compiler builds that is not always true.

Without `-O0`, device helper functions can be emitted with `DW_AT_calling_convention (DW_CC_nocall)`. rocgdb then warns that functions "do not follow the target calling convention" and tests such as `finish.exp` and `device-barrier.exp` fail (LCOMPILER-2452: 32 unexpected failures on MI300X with the WW28 tarball).

Problem:
- WW28 build + WW28 amdclang++ harness (no `-O0`) → 32 failures on MI300X
- Same build + WW25 hipcc harness (with `-O0`) → pass
- Same build + this patch → pass (122 pass, 0 unexpected fail on MI300X)

Manual compile on device objects from `finish0.o`:
- `amdclang++ -x hip` without `-O0` → `DW_CC_nocall` on helpers
- `amdclang++ -x hip -O0` → no `DW_CC_nocall`

Solution:
Restore explicit `-O0` in `hip_early_flags` in `gdb/testsuite/lib/gdb.exp`, matching the old hipcc path.

Tested locally on MI300X (`gfx942`, `ROCR_VISIBLE_DEVICES=3`) with the WW28 TheRock tests tarball.

Made with [Cursor](https://cursor.com)