### PR TITLE
[amd-staging-rocgdb-16] ROCgdb cherry picks from origin/amd-staging (2026-07-24)

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 710812f49673c52777894c0a6fed0ce9d526ac12 # 2026-07-15
+  THEROCK_COMMIT_REF: aa5a1653f4475a28146899d79eb7c23ea2501e64 # 2026-07-22
 
 jobs:
   therock-build-linux:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: aa5a1653f4475a28146899d79eb7c23ea2501e64 # 2026-07-22
+  THEROCK_COMMIT_REF: 013e3cb9928a76b2eea52151b29dc18473a8cdbe # 2026-07-23
 
 jobs:
   therock-build-linux:

--- a/gdb/infrun.c
+++ b/gdb/infrun.c
@@ -7825,11 +7825,37 @@ process_event_stop_test (struct execution_control_state *ecs)
       && (!ecs->event_thread->is_simd_lane_active
 	  (ecs->event_thread->current_simd_lane ())))
     {
-      infrun_debug_printf
-	("stepping divergent lane %s",
-	 target_lane_to_str (ecs->event_thread,
-			     ecs->event_thread->current_simd_lane ()).c_str ());
+      if (execution_direction == EXEC_FORWARD
+	  && stepped_into_subroutine (ecs->event_thread, frame))
+	{
+	  /* We just stepped inside a new function, and the current
+	     lane is inactive.  None of the architectures we support
+	     can atomically jump to a new frame while changing the set
+	     of active lanes, so the current lane was inactive at the
+	     call site.
 
+	     Because the lane is already inactive on entry, we expect
+	     it to remain logically inactive for the entire frame.
+	     The function may still activate the lane transiently,
+	     e.g., for a whole-wave vector register spill, but that's
+	     an implementation detail that the user should not see.
+	     Therefore, even if we issued a step rather than a next,
+	     there is nothing to stop for in this frame, so we can
+	     return directly to the caller.  */
+	  infrun_debug_printf
+	    ("stepping into subroutine with divergent lane %s",
+	     target_lane_to_str (ecs->event_thread,
+				 ecs->event_thread->current_simd_lane ()
+				 ).c_str ());
+	  insert_step_resume_breakpoint_at_caller (frame);
+	}
+      else
+	{
+	  infrun_debug_printf
+	    ("stepping divergent lane %s",
+	     target_lane_to_str (ecs->event_thread,
+				 ecs->event_thread->current_simd_lane ()).c_str ());
+	}
       keep_going (ecs);
       return;
     }

--- a/gdb/infrun.c
+++ b/gdb/infrun.c
@@ -7493,6 +7493,56 @@ private:
 
 }
 
+/* Return true if THREAD, currently stopped at FRAME, has stepped into
+   a subroutine call relative to the frame the step operation started
+   in (THREAD->control.step_stack_frame_id).  */
+
+static bool
+stepped_into_subroutine (thread_info *thread, const frame_info_ptr &frame)
+{
+  /* This is not really necessary -- the check of the previous frame's
+     ID is sufficient -- but this is a common case and cheaper than
+     checking the previous frame's ID.  */
+  if (get_stack_frame_id (frame) == thread->control.step_stack_frame_id)
+    return false;
+
+  /* We want "nexti" to step into, not over, signal handlers invoked
+     by the kernel, therefore this subroutine check should not trigger
+     for a signal handler invocation.  On most platforms, this is
+     already not the case, as the kernel puts a signal trampoline
+     frame onto the stack to handle proper return after the handler,
+     and therefore at this point, the current frame is a grandchild of
+     the step frame, not a child.  However, on some platforms, the
+     kernel actually uses a trampoline to handle *invocation* of the
+     handler.  In that case, when executing the first instruction of
+     the trampoline, this check would erroneously detect the
+     trampoline invocation as a subroutine call.  Fix this by checking
+     for SIGTRAMP_FRAME.  */
+  if (get_frame_type (frame) == SIGTRAMP_FRAME)
+    return false;
+
+  /* NOTE: frame_id::operator== will never report two invalid frame
+     IDs as being equal, so for this to return true, both the current
+     and previous frame must have valid frame IDs.  */
+  if (frame_unwind_caller_id (frame) != thread->control.step_stack_frame_id)
+    return false;
+
+  /* Heuristic to detect stepping through startup code.  If we step
+     over an instruction that sets the stack pointer from an invalid
+     value to a valid value, we may detect that as a subroutine call
+     from the mythical "outermost" function.  This could be fixed by
+     marking outermost frames as !stack_p,code_p,special_p.  Then the
+     initial outermost frame, before sp was valid, would have
+     code_addr == &_start.  See the comment in frame_id::operator==
+     for more.  */
+  if (thread->control.step_stack_frame_id == outer_frame_id
+      && (thread->control.step_start_function
+	  == find_pc_function (thread->stop_pc ())))
+    return false;
+
+  return true;
+}
+
 /* Come here when we've got some debug event / signal we can explain
    (IOW, not a random signal), and test whether it should cause a
    stop, or whether we should resume the inferior (transparently).
@@ -7932,44 +7982,8 @@ process_event_stop_test (struct execution_control_state *ecs)
 	}
     }
 
-  /* Check for subroutine calls.  The check for the current frame
-     equalling the step ID is not necessary - the check of the
-     previous frame's ID is sufficient - but it is a common case and
-     cheaper than checking the previous frame's ID.
-
-     NOTE: frame_id::operator== will never report two invalid frame IDs as
-     being equal, so to get into this block, both the current and
-     previous frame must have valid frame IDs.  */
-  /* The outer_frame_id check is a heuristic to detect stepping
-     through startup code.  If we step over an instruction which
-     sets the stack pointer from an invalid value to a valid value,
-     we may detect that as a subroutine call from the mythical
-     "outermost" function.  This could be fixed by marking
-     outermost frames as !stack_p,code_p,special_p.  Then the
-     initial outermost frame, before sp was valid, would
-     have code_addr == &_start.  See the comment in frame_id::operator==
-     for more.  */
-
-  /* We want "nexti" to step into, not over, signal handlers invoked
-     by the kernel, therefore this subroutine check should not trigger
-     for a signal handler invocation.  On most platforms, this is already
-     not the case, as the kernel puts a signal trampoline frame onto the
-     stack to handle proper return after the handler, and therefore at this
-     point, the current frame is a grandchild of the step frame, not a
-     child.  However, on some platforms, the kernel actually uses a
-     trampoline to handle *invocation* of the handler.  In that case,
-     when executing the first instruction of the trampoline, this check
-     would erroneously detect the trampoline invocation as a subroutine
-     call.  Fix this by checking for SIGTRAMP_FRAME.  */
-  if ((get_stack_frame_id (frame)
-       != ecs->event_thread->control.step_stack_frame_id)
-      && get_frame_type (frame) != SIGTRAMP_FRAME
-      && ((frame_unwind_caller_id (frame)
-	   == ecs->event_thread->control.step_stack_frame_id)
-	  && ((ecs->event_thread->control.step_stack_frame_id
-	       != outer_frame_id)
-	      || (ecs->event_thread->control.step_start_function
-		  != find_pc_function (ecs->event_thread->stop_pc ())))))
+  /* Check for subroutine calls.  */
+  if (stepped_into_subroutine (ecs->event_thread, frame))
     {
       CORE_ADDR stop_pc = ecs->event_thread->stop_pc ();
       CORE_ADDR real_stop_pc;

--- a/gdb/testsuite/gdb.rocm/alu-exceptions.cpp
+++ b/gdb/testsuite/gdb.rocm/alu-exceptions.cpp
@@ -21,11 +21,15 @@
 #include <limits>
 #include <cstdlib>
 
-__device__ void
+/* The debugger sets a breakpoint on this function and uses an inferior
+   call to enable ALU exceptions before each kernel launches.  optnone
+   implies noinline (so the breakpoint reliably fires at each call site)
+   and keeps the body opaque to the optimizer, so IPO cannot prove the
+   call away and dead-strip the function.  */
+
+__device__ __attribute__ ((optnone)) void
 enable_alu_exceptions ()
 {
-  /* By default, ALU exceptions are not enabled.  Break here and use the
-     debugger to enable exceptions.  */
 }
 
 __global__ void
@@ -33,7 +37,7 @@ raise_invalid ()
 {
   enable_alu_exceptions ();
   volatile float a = -1;
-  float b = sqrt (a); /* Break here for invalid.  */
+  volatile float b = sqrt (a); /* Break here for invalid.  */
 }
 
 __global__ void
@@ -41,7 +45,7 @@ raise_denorm ()
 {
   enable_alu_exceptions ();
   volatile float inp = std::numeric_limits<float>::denorm_min ();
-  float b = inp * inp; /* Break here for denorm.  */
+  volatile float b = inp * inp; /* Break here for denorm.  */
 }
 
 __global__ void
@@ -49,7 +53,7 @@ raise_float_div0 ()
 {
   enable_alu_exceptions ();
   volatile float a = 1, b = 0;
-  float c = a / b; /* Break here for float_div0.  */
+  volatile float c = a / b; /* Break here for float_div0.  */
 }
 
 __global__ void
@@ -57,7 +61,7 @@ raise_overflow ()
 {
   enable_alu_exceptions ();
   volatile float max = std::numeric_limits<float>::max ();
-  float b = max * 2.0f; /* Break here for overflow.  */
+  volatile float b = max * 2.0f; /* Break here for overflow.  */
 }
 
 __global__ void
@@ -65,7 +69,7 @@ raise_underflow ()
 {
   enable_alu_exceptions ();
   volatile float min = std::numeric_limits<float>::min ();
-  float c = min * min; /* Break here for underflow.  */
+  volatile float c = min * min; /* Break here for underflow.  */
 }
 
 __global__ void
@@ -73,7 +77,7 @@ raise_inexact ()
 {
   enable_alu_exceptions ();
   volatile float f = 1.1f;
-  float r = f * f; /* Break here for inexact.  */
+  volatile float r = f * f; /* Break here for inexact.  */
 }
 
 __global__ void
@@ -81,7 +85,7 @@ raise_int_div0 ()
 {
   enable_alu_exceptions ();
   volatile int a = 1, b = 0;
-  int c = a / b; /* Break here for int_div0.  */
+  volatile int c = a / b; /* Break here for int_div0.  */
 }
 
 int

--- a/gdb/testsuite/gdb.rocm/aspace-user-input.exp
+++ b/gdb/testsuite/gdb.rocm/aspace-user-input.exp
@@ -22,6 +22,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile bit-extract.cpp
 

--- a/gdb/testsuite/gdb.rocm/aspace-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/aspace-watchpoint.exp
@@ -25,6 +25,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/convenience_variables.exp
+++ b/gdb/testsuite/gdb.rocm/convenience_variables.exp
@@ -22,6 +22,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/corefile.cpp
+++ b/gdb/testsuite/gdb.rocm/corefile.cpp
@@ -33,13 +33,13 @@
 	}                                                                    \
     } while (0)
 
-__device__ int
+__device__ int __attribute__ ((optnone))
 bar ()
 {
   return threadIdx.x;
 }
 
-__device__ int
+__device__ int __attribute__ ((optnone))
 baz ()
 {
   return 0;

--- a/gdb/testsuite/gdb.rocm/deep-stack.cpp
+++ b/gdb/testsuite/gdb.rocm/deep-stack.cpp
@@ -36,8 +36,8 @@ base_case ()
 {
   /* That printf is necessary to reproduce the exact failure as initially
      seen.  */
-  printf ("Hello device\n");
-  return; /* break here */
+  printf ("Hello device\n"); /* break here */
+  return;
 }
 
 template <unsigned int N>

--- a/gdb/testsuite/gdb.rocm/deep-stack.exp
+++ b/gdb/testsuite/gdb.rocm/deep-stack.exp
@@ -42,17 +42,17 @@ with_rocm_gpu_lock {
     gdb_test "continue" "Thread $decimal \"hip_deep\" hit Breakpoint $decimal.*"
     gdb_test "backtrace" \
 	[multi_line \
-	    "#0 .* base_case .*" \
-	    "#1 .* deep<0u> .*" \
-	    "#2 .* deep<1u> .*" \
-	    "#3 .* deep<2u> .*" \
-	    "#4 .* deep<3u> .*" \
-	    "#5 .* deep<4u> .*" \
-	    "#6 .* deep<5u> .*" \
-	    "#7 .* deep<6u> .*" \
-	    "#8 .* deep<7u> .*" \
-	    "#9 .* deep<8u> .*" \
-	    "#10 .* deep<9u> .*" \
-	    "#11 .* deep<10u> .*" \
-	    "#12 .* hip_deep .*"]
+	    "#0 +(($hex in )?base_case) .*" \
+	    "#1 +(($hex in )?deep<0u>) .*" \
+	    "#2 +(($hex in )?deep<1u>) .*" \
+	    "#3 +(($hex in )?deep<2u>) .*" \
+	    "#4 +(($hex in )?deep<3u>) .*" \
+	    "#5 +(($hex in )?deep<4u>) .*" \
+	    "#6 +(($hex in )?deep<5u>) .*" \
+	    "#7 +(($hex in )?deep<6u>) .*" \
+	    "#8 +(($hex in )?deep<7u>) .*" \
+	    "#9 +(($hex in )?deep<8u>) .*" \
+	    "#10 +(($hex in )?deep<9u>) .*" \
+	    "#11 +(($hex in )?deep<10u>) .*" \
+	    "#12 +(($hex in )?hip_deep) .*"]
 }

--- a/gdb/testsuite/gdb.rocm/deref-scoped-pointer.exp
+++ b/gdb/testsuite/gdb.rocm/deref-scoped-pointer.exp
@@ -28,6 +28,15 @@ load_lib rocm.exp
 
 require allow_hip_tests
 
+# At -O1+ the HIP compiler drops the DWARF name->location mapping for
+# kernel locals (e.g. "local_var") at arbitrary line breakpoints, even
+# when their address is escaped and the storage is kept live, so GDB
+# reports them as <optimized out>.  This test relies on resolving
+# "local_var" symbolically at the "set breakpoint here" location, so
+# restrict it to non-optimized builds until the toolchain improves
+# debug info for HIP kernels under optimization.
+require no_optimized_code
+
 standard_testfile .cpp
 
 if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {

--- a/gdb/testsuite/gdb.rocm/device-attach.cpp
+++ b/gdb/testsuite/gdb.rocm/device-attach.cpp
@@ -37,7 +37,7 @@ bit_extract_kernel (uint32_t *C_d, const uint32_t *A_d, size_t N)
 {
   size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
   size_t stride = blockDim.x * gridDim.x;
-  int loop_forever = 1;
+  volatile int loop_forever = 1;
   int a = 9;
   while (loop_forever)
     a = 8;

--- a/gdb/testsuite/gdb.rocm/device-barrier.exp
+++ b/gdb/testsuite/gdb.rocm/device-barrier.exp
@@ -20,6 +20,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/finish.exp
+++ b/gdb/testsuite/gdb.rocm/finish.exp
@@ -23,6 +23,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu-execee.cpp
+++ b/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu-execee.cpp
@@ -15,9 +15,14 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-static void
+/* noinline so the breakpoint reliably fires; the asm gives the
+   function a side effect the optimizer cannot prove away.  */
+
+static void __attribute__ ((noinline))
 break_here_execee (void)
-{}
+{
+  asm volatile ("" ::: "memory");
+}
 
 int
 main (void)

--- a/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu-execer.cpp
+++ b/gdb/testsuite/gdb.rocm/fork-exec-gpu-to-non-gpu-execer.cpp
@@ -26,7 +26,10 @@ __global__ static void
 kernel1 ()
 {}
 
-__device__ static void
+/* optnone implies noinline and keeps the body opaque to the optimizer,
+   so the breakpoint reliably fires and the call is not proven away.  */
+
+__device__ static void __attribute__ ((optnone))
 break_here_execer ()
 {
 }

--- a/gdb/testsuite/gdb.rocm/fork-exec-non-gpu-to-gpu.exp
+++ b/gdb/testsuite/gdb.rocm/fork-exec-non-gpu-to-gpu.exp
@@ -21,6 +21,10 @@ load_lib rocm.exp
 
 require allow_hip_tests
 require allow_fork_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile -execer.cpp -execee.cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
@@ -27,6 +27,9 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks is not reliable with
+# link-time optimization, so skip it for -flto builds.
+require no_lto
 
 standard_testfile hip-builtin-variables.cpp
 

--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.cpp
@@ -34,7 +34,7 @@
 /* A function to be called by "kern ()", without any references to
    threadIdx, blockIdx, blockDim, gridDim, or warpSize variables.  */
 
-__device__ void
+__device__ void __attribute__ ((optnone))
 inner_func1 ()
 {
   return;
@@ -42,14 +42,14 @@ inner_func1 ()
 
 /* A function to be called by "kern ()", with its own "blockIdx".  */
 
-__device__ void
+__device__ void __attribute__ ((optnone))
 inner_func2 ()
 {
   int blockIdx = 0x42424242;
   return;
 }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 kern ()
 {
   const int thread_idx_x = threadIdx.x;

--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
@@ -21,6 +21,9 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks is not reliable with
+# link-time optimization, so skip it for -flto builds.
+require no_lto
 
 standard_testfile .cpp
 
@@ -226,7 +229,16 @@ with_rocm_gpu_lock {
 	# Get into inner_func2() with its own local blockIdx variable.
 	gdb_test "step" "inner_func2 \\(\\) at.*" \
 	    "step into inner_func2() with its own blockIdx"
-	gdb_test "next" "$::decimal\[ \t\]+return;" \
+	# Accept landing on either the "return;" statement or the
+	# closing brace.  At -O0 Clang emits a separate line entry
+	# for the explicit "return;", so "next" lands there.  Under
+	# __attribute__((optnone)) (which we use to keep the local
+	# blockIdx observable at -O1/-O2/-O3) Clang merges the line
+	# entry of the "return;" with the function's closing brace,
+	# so "next" lands on the brace instead.  Either is fine for
+	# this test -- the point is just to step past the local
+	# initialization before reading blockIdx.
+	gdb_test "next" "$::decimal\[ \t\]+(return;|\})" \
 	    "let the initialization happen"
 	gdb_test "p/x blockIdx" "0x42424242" \
 	    "local blockIdx shadowing the built-in"

--- a/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
+++ b/gdb/testsuite/gdb.rocm/hip-lang-detect.exp
@@ -22,6 +22,9 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks is not reliable with
+# link-time optimization, so skip it for -flto builds.
+require no_lto
 
 standard_testfile hip-builtin-variables.cpp
 

--- a/gdb/testsuite/gdb.rocm/instruction-stepping-commands.cpp
+++ b/gdb/testsuite/gdb.rocm/instruction-stepping-commands.cpp
@@ -35,15 +35,21 @@
     }								\
   while (0)
 
-/* Make sure the function isn't inlined, for the nexti test.  */
-__device__ static __attribute__ ((noinline))
+/* "noinline" so the nexti test can step into a real function call;
+   "optnone" so the body has stable instructions for stepi/nexti and
+   the locally-initialized value is not folded into the return.  */
+__device__ static __attribute__ ((noinline, optnone))
 int
 return_zero ()
 {
-  return 0;
+  int ret = 0;
+  return ret;
 }
 
-__global__ void
+/* "optnone" so each statement below maps to its own instruction
+   sequence and the "var += 1" lines are not folded together --
+   stepi/nexti rely on stepping through them one at a time.  */
+__global__ void __attribute__ ((optnone))
 kernel ()
 {
   int var = return_zero ();

--- a/gdb/testsuite/gdb.rocm/lane-execution.exp
+++ b/gdb/testsuite/gdb.rocm/lane-execution.exp
@@ -35,6 +35,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/lane-info.cpp
+++ b/gdb/testsuite/gdb.rocm/lane-info.cpp
@@ -33,21 +33,34 @@
   }
 
 /* The kernel never returns, via this sleep, so that the .exp file can
-   test background execution (cont&).  */
+   test background execution (cont&).  The volatile loop guard keeps
+   the loop's observable behavior well-defined (an infinite loop
+   without side effects would otherwise be UB in C++); do not mark
+   the function noreturn, as that would license the compiler to
+   eliminate the very behavior the volatile is preserving.  */
 
-__device__ static void
+__device__ static void __attribute__ ((noinline))
 sleep_forever ()
 {
-  while (1)
+  volatile bool keep_going = true;
+  while (keep_going)
     __builtin_amdgcn_s_sleep (1);
 }
 
-__device__ static void
+/* foo() and bar() are non-static so each lane has a stable call frame
+   and an externally visible symbol under -O1/-O2/-O3, which the test
+   relies on for "info lanes" and "lane apply" to discriminate active
+   vs inactive lanes.  foo() uses optnone (which implies noinline and
+   keeps the body opaque) so the call cannot be proven away.  In bar(),
+   disable_tail_calls keeps the bar() frame on the stack so the sleeping
+   wave appears in bar() rather than in sleep_forever().  */
+
+__device__ void __attribute__ ((optnone))
 foo ()
 {
 }
 
-__device__ static void
+__device__ void __attribute__ ((noinline, disable_tail_calls))
 bar ()
 {
   sleep_forever ();

--- a/gdb/testsuite/gdb.rocm/line-breakpoint-in-kernel.cpp
+++ b/gdb/testsuite/gdb.rocm/line-breakpoint-in-kernel.cpp
@@ -31,7 +31,7 @@
       }                                                                      \
   }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 kernel ()
 {
   int x = 0;

--- a/gdb/testsuite/gdb.rocm/mi-aspace.exp
+++ b/gdb/testsuite/gdb.rocm/mi-aspace.exp
@@ -21,6 +21,10 @@ load_lib mi-support.exp
 set MIFLAGS "-i=mi"
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code no_lto
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/mi-lanes.exp
+++ b/gdb/testsuite/gdb.rocm/mi-lanes.exp
@@ -21,6 +21,10 @@ load_lib mi-support.exp
 set MIFLAGS "-i=mi"
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile lane-execution.cpp
 

--- a/gdb/testsuite/gdb.rocm/multi-inferior-fork.cpp
+++ b/gdb/testsuite/gdb.rocm/multi-inferior-fork.cpp
@@ -36,9 +36,11 @@ __global__ void
 kernel ()
 {}
 
-static void
+static void __attribute__ ((noinline))
 child_after_fork ()
-{}
+{
+  asm volatile ("" ::: "memory");
+}
 
 int
 main ()

--- a/gdb/testsuite/gdb.rocm/multi-inferior-gpu.cpp
+++ b/gdb/testsuite/gdb.rocm/multi-inferior-gpu.cpp
@@ -32,7 +32,7 @@ kern ()
 
 /* Spawn one child process per detected GPU.  */
 
-static int
+static int __attribute__ ((optnone))
 parent (int argc, char **argv)
 {
   /* Identify how many GPUs we have, and spawn one child for each.  */
@@ -73,7 +73,8 @@ parent (int argc, char **argv)
     }
 
   /* Last break here.  */
-  return 0;
+  int ret = 0;
+  return ret;
 }
 
 static int

--- a/gdb/testsuite/gdb.rocm/names.cpp
+++ b/gdb/testsuite/gdb.rocm/names.cpp
@@ -117,7 +117,7 @@ templ_non_type ()
 }
 
 template<typename... Args>
-__global__ void
+__global__ void __attribute__ ((optnone))
 templ_type (Args... args)
 {
   wait_all_kernels ();

--- a/gdb/testsuite/gdb.rocm/nonstop-displaced.exp
+++ b/gdb/testsuite/gdb.rocm/nonstop-displaced.exp
@@ -21,6 +21,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/ocp_mx.exp
+++ b/gdb/testsuite/gdb.rocm/ocp_mx.exp
@@ -19,6 +19,9 @@
 load_lib rocm.exp
 
 require allow_hip_tests allow_python_tests
+# The fp8/6/4 testing helpers rely on observable locals and call
+# structure, so the test is not meaningful under optimization.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/omp-target-basic.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-basic.exp
@@ -30,6 +30,11 @@ load_lib rocm.exp
 
 require allow_omp_offload_tests
 
+# Reading OpenMP mapped/firstprivate data inside a target region
+# (and single-stepping it) requires unoptimized device code; those
+# values are optimized out at -O1 and above.  Skip under optimization.
+require no_optimized_code
+
 standard_testfile
 
 set first_line [gdb_get_line_number "first-target-line"]

--- a/gdb/testsuite/gdb.rocm/omp-target-data.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-data.exp
@@ -24,6 +24,11 @@ load_lib rocm.exp
 
 require allow_omp_offload_tests
 
+# Reading OpenMP mapped/firstprivate data inside a target region
+# (and single-stepping it) requires unoptimized device code; those
+# values are optimized out at -O1 and above.  Skip under optimization.
+require no_optimized_code
+
 standard_testfile
 
 set k1_line [gdb_get_line_number "data-k1"]

--- a/gdb/testsuite/gdb.rocm/omp-target-teams.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-teams.exp
@@ -25,6 +25,11 @@ load_lib rocm.exp
 
 require allow_omp_offload_tests
 
+# Reading OpenMP mapped/firstprivate data inside a target region
+# (and single-stepping it) requires unoptimized device code; those
+# values are optimized out at -O1 and above.  Skip under optimization.
+require no_optimized_code
+
 standard_testfile
 
 set break_line [gdb_get_line_number "teams-line"]

--- a/gdb/testsuite/gdb.rocm/precise-memory-exec.c
+++ b/gdb/testsuite/gdb.rocm/precise-memory-exec.c
@@ -19,9 +19,13 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-static void
+/* noinline so the breakpoint reliably fires; the asm gives the
+   function a side effect the optimizer cannot prove away.  */
+
+static void __attribute__ ((noinline))
 second (void)
 {
+  asm volatile ("" ::: "memory");
 }
 
 int

--- a/gdb/testsuite/gdb.rocm/precise-memory-fork.c
+++ b/gdb/testsuite/gdb.rocm/precise-memory-fork.c
@@ -22,9 +22,13 @@ parent (void)
 {
 }
 
-static void
+/* noinline so the breakpoint reliably fires; the asm gives the
+   function a side effect the optimizer cannot prove away.  */
+
+static void __attribute__ ((noinline))
 child (void)
 {
+  asm volatile ("" ::: "memory");
 }
 
 int

--- a/gdb/testsuite/gdb.rocm/precise-memory-warning-sigsegv.cpp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-warning-sigsegv.cpp
@@ -24,7 +24,7 @@
 __global__ void
 kernel ()
 {
-  int *p = nullptr;
+  volatile int *p = nullptr;
   *p = 1;
 }
 

--- a/gdb/testsuite/gdb.rocm/precise-memory-warning-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/precise-memory-warning-watchpoint.exp
@@ -21,6 +21,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 if { ![istarget "*-linux*"] } then {
     continue

--- a/gdb/testsuite/gdb.rocm/register-watchpoint.exp
+++ b/gdb/testsuite/gdb.rocm/register-watchpoint.exp
@@ -21,6 +21,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile bit-extract.cpp
 

--- a/gdb/testsuite/gdb.rocm/resume-exception.cpp
+++ b/gdb/testsuite/gdb.rocm/resume-exception.cpp
@@ -22,7 +22,7 @@ __global__ void
 raise_fpe ()
 {
   volatile float a = 1, b = 0;
-  float c = a / b;		/* Raise an exception.  */
+  volatile float c = a / b;	/* Raise an exception.  */
   __builtin_debugtrap ();	/* A trap that mustn't be reached.  */
 }
 

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -25,6 +25,10 @@ load_lib rocm.exp
 
 require allow_rocm_core_tests
 require allow_hip_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/scheduler-locking.cpp
+++ b/gdb/testsuite/gdb.rocm/scheduler-locking.cpp
@@ -33,7 +33,7 @@
       }									      \
   }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 bit_extract_kernel (uint32_t *C_d, const uint32_t *A_d, size_t N)
 {
   size_t offset = (blockIdx.x * blockDim.x + threadIdx.x); /* location line */

--- a/gdb/testsuite/gdb.rocm/shared-memory.exp
+++ b/gdb/testsuite/gdb.rocm/shared-memory.exp
@@ -21,6 +21,10 @@ load_lib rocm.exp
 
 # Python support is required to use $_streq.
 require allow_hip_tests allow_python_tests
+# The debug behavior this test checks (inspecting device locals
+# and/or single-stepping) is not reliable on optimized device
+# code, so skip it for optimized builds.
+require no_optimized_code
 
 standard_testfile .cpp -size.cpp
 

--- a/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
+++ b/gdb/testsuite/gdb.rocm/snapshot-objfile-on-load.exp
@@ -65,10 +65,15 @@ with_rocm_gpu_lock {
 	gdb_test_no_output "set args $mode $hipmodule_path" "set args"
 
 	runto "printId" allow-pending
+	# Frame #1 normally looks like "#1  0x... in kernel () at ...",
+	# but under -O1/-O2/-O3 the return address can fall on the
+	# entry instruction of kernel(), in which case GDB omits the
+	# leading "0x... in " prefix and prints just "#1  kernel () at
+	# ...".  Accept either form.
 	gdb_test "bt" \
 	    [multi_line \
 		 "#0\[ \t\]*printId \\(\\) at \[^\r\n\]+" \
-		 "#1\[ \t\]*${::hex} in kernel \\(\\) at \[^\r\n\]+"]
+		 "#1\[ \t\]*(${::hex} in )?kernel \\(\\) at \[^\r\n\]+"]
 
 	# Now force GDB to reload the shared library, to make sure it
 	# doesn't crash when it finds the corrupted code object image.

--- a/gdb/testsuite/gdb.rocm/static-global.cpp
+++ b/gdb/testsuite/gdb.rocm/static-global.cpp
@@ -34,7 +34,12 @@
 __device__ int extern_global;
 __device__ static int static_global;
 
-__device__ static void
+/* Non-static so a line breakpoint set on "done" before launch has a
+   stable, externally visible symbol to resolve to.  optnone keeps the
+   call to done() under -O1/-O2/-O3: it implies noinline and makes the
+   body opaque to IPO, so the pending breakpoint resolves.  */
+
+__device__ void __attribute__ ((optnone))
 done ()
 {
 }

--- a/gdb/testsuite/gdb.rocm/static-global.exp
+++ b/gdb/testsuite/gdb.rocm/static-global.exp
@@ -39,6 +39,10 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The fgpu_rdc=1 variant fails to link under -flto because the per-TU
+# __hip_gpubin_handle / __hip_fatbin symbols emitted into the HIP
+# module ctor do not survive the LTO merge.
+require no_lto
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
@@ -23,8 +23,10 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 
 /* Helper function where the debugger places a breakpoint to be sure no wave
-   can run to completion without the debugger noticing.  */
-__device__ void
+   can run to completion without the debugger noticing.  optnone implies
+   noinline and keeps the body opaque to the optimizer, so the breakpoint is
+   reliable and the call is not proven away under -O1/-O2/-O3.  */
+__device__ void __attribute__ ((optnone))
 end_of_kernel ()
 {
 }

--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.exp
@@ -131,10 +131,14 @@ proc do_test {} {
 	# that new waves can now be created and hit the breakpoint.
 	gdb_test_no_output "set scheduler-locking off"
 
-	# Issue a few "next" commands until some other thread has had a chance
-	# to make enough progress to reach the "end_of_kernel" breakpoint.  Set
-	# maximum number of "next" commands as a fail safe.
-	set max_iter 10
+	# Issue a few "next" commands until some other thread has had a
+	# chance to make enough progress to reach the "end_of_kernel"
+	# breakpoint.  max_iter is only a fail-safe cap on the number of
+	# "next" commands, not an expected step count.  At -O0 another
+	# wave gets there within ~10 steps, but under -O1/-O2/-O3 each
+	# "next" covers a different amount of code, so allow a small
+	# cushion over that -O0 budget to keep the test reliable.
+	set max_iter 15
 	gdb_test_multiple "next" "next" {
 	    -re -wrap "\r\nThread $::decimal .* hit Breakpoint $::decimal.*" {
 		pass $gdb_test_name

--- a/gdb/testsuite/gdb.rocm/unaligned-memory-access.cpp
+++ b/gdb/testsuite/gdb.rocm/unaligned-memory-access.cpp
@@ -49,12 +49,12 @@ __device__ byte_array global = {
 /* An array in LDS.  */
 __shared__ byte_array shared;
 
-__device__ void
+__device__ void __attribute__ ((noinline))
 done ()
 {
 }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 kernel ()
 {
   /* An array in the private_lane (swizzled) address space.  */

--- a/gdb/testsuite/gdb.rocm/until-tests.exp
+++ b/gdb/testsuite/gdb.rocm/until-tests.exp
@@ -72,9 +72,23 @@ with_test_prefix "until without location; scheduler-locking on" {
     gdb_test "run" {.+hit\sBreakpoint\s[\d].+\sbit_extract_kernel\s\(.*\)\sat.*}
     gdb_test_no_output "set scheduler-locking on"
     gdb_test "info line" "Line $breakpoint_loc.*"
-    gdb_test "until" "\[^\r\n\]*[expr $breakpoint_loc+1].*"
-    gdb_test "info line" "Line [expr $breakpoint_loc+1].*" \
-	"info line at breakpoint_loc + 1"
+
+    # Under optimization the compiler may merge or reorder statements,
+    # so "until" can land one line further than at -O0.  Use the
+    # no_optimized_code predicate (rather than a hand-written flag
+    # check) so any optimization level relaxes the expected line range.
+    if {![no_optimized_code]} {
+	set pattern "([expr {$breakpoint_loc + 1}]|[expr {$breakpoint_loc + 2}])"
+	set test_name "info line at breakpoint_loc + 1 or 2 lines"
+    } else {
+	set pattern "[expr {$breakpoint_loc + 1}]"
+	set test_name "info line at breakpoint_loc + 1"
+    }
+    # Anchor the matched line number with a non-digit so a two-digit
+    # number does not accidentally match a longer one (e.g. line 43
+    # matching line 430).
+    gdb_test "until" "\[^\r\n\]*$pattern\[^0-9\].*"
+    gdb_test "info line" "Line $pattern\[^0-9\].*" $test_name
     gdb_test_no_output "set scheduler-locking off"
     gdb_test "clear bit_extract_kernel"
     gdb_test "continue" {.+Inferior\s[\d].+\sexited\snormally.+}

--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.cpp
@@ -24,7 +24,7 @@ kern ()
 {
 }
 
-int
+int __attribute__ ((optnone))
 main (int argc, char* argv[])
 {
   kern<<<1, 1>>> ();
@@ -35,7 +35,10 @@ main (int argc, char* argv[])
   if (hipGetSymbolAddress (reinterpret_cast<void **> (&devGlobal), global))
     return 2;
 
-  /* Now update the device global from a CPU thread.  */
-  *devGlobal = 8;
+  /* Now update the device global from a CPU thread.  Use a volatile
+     pointer at the access site so the store survives optimization
+     without forcing devGlobal itself to be volatile (which would
+     require dropping the qualifier with a C-style cast above).  */
+  *static_cast<volatile int *> (devGlobal) = 8;
   return 0;
 }

--- a/gdb/testsuite/gdb.rocm/watchpoint-at-end-of-shader.exp
+++ b/gdb/testsuite/gdb.rocm/watchpoint-at-end-of-shader.exp
@@ -19,6 +19,9 @@
 load_lib rocm.exp
 
 require allow_hip_tests
+# The debug behavior this test checks is not reliable with
+# link-time optimization, so skip it for -flto builds.
+require no_lto
 
 standard_testfile .cpp
 

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -176,6 +176,81 @@ gdb_caching_proc allow_rocm_core_tests {} {
     return 1
 }
 
+# Check whether any of the given flag patterns appear in
+# GDB_TESTCASE_OPTIONS, CFLAGS_FOR_TARGET or CXXFLAGS_FOR_TARGET.
+# Each pattern is matched as a regular expression anchored against a
+# whole whitespace-separated token, so a single pattern can match a
+# family of flags: e.g. "-flto(=.*)?" matches both "-flto" and
+# "-flto=thin", while "-O2" still matches only "-O2" (not "-O20").
+# Usage example: check_for_any_flags {-flto(=.*)? -O[1-9]}
+
+proc check_for_any_flags {flags} {
+    global GDB_TESTCASE_OPTIONS CFLAGS_FOR_TARGET CXXFLAGS_FOR_TARGET
+
+    if {[llength $flags] == 0} {
+	return 0
+    }
+
+    # Sources of compile flags to check, in order:
+    #   - GDB_TESTCASE_OPTIONS (the standard testsuite override).
+    #   - CFLAGS_FOR_TARGET / CXXFLAGS_FOR_TARGET, in case the
+    #     caller injects optimization flags that way instead.
+    # These arrive as Tcl globals when set on the runtest command
+    # line; each is read only when present (see "info exists" below).
+    set sources [list]
+    foreach var {GDB_TESTCASE_OPTIONS CFLAGS_FOR_TARGET CXXFLAGS_FOR_TARGET} {
+	if {[info exists $var]} {
+	    set val [set $var]
+	    if {$val ne ""} {
+		lappend sources $val
+	    }
+	}
+    }
+
+    foreach src $sources {
+	# Split on whitespace so each flag is matched on its own; the
+	# anchored regexp below then keeps matching to a whole token
+	# (e.g. "-O2" does not match inside "-O20").
+	foreach tok [split $src] {
+	    foreach pat $flags {
+		if {[regexp -- "^(?:$pat)\$" $tok]} {
+		    return 1
+		}
+	    }
+	}
+    }
+
+    return 0
+}
+
+# Predicate that succeeds (returns 1) when no optimization flag is in
+# effect, and fails (returns 0) when one is present.  Any -O level
+# other than -O0 enables optimization (a bare -O means -O1).  Use with
+# "require no_optimized_code" to gate tests that are not meaningful
+# under optimization.
+
+gdb_caching_proc no_optimized_code {} {
+    if {[check_for_any_flags {-O([1-9][0-9]*|fast|s|z|g)?}]} {
+	verbose -log "Optimization flags are present."
+	return 0
+    }
+    return 1
+}
+
+# Predicate that succeeds (returns 1) when -flto is not in effect,
+# and fails (returns 0) when it is.  Matches -flto as well as its
+# moded forms (e.g. -flto=thin, -flto=full).  Use with "require
+# no_lto" to gate tests that are not meaningful under link-time
+# optimization.
+
+gdb_caching_proc no_lto {} {
+    if {[check_for_any_flags {-flto(=.*)?}]} {
+	verbose -log "Link-time optimization flags are present."
+	return 0
+    }
+    return 1
+}
+
 # The empty host object put in bundles when compiling assembly files.
 # As a speed optimization, avoid recompiling it over and over for each
 # testcase program.


### PR DESCRIPTION
Cherry-picks:

17638670b55 gdb/infrun: improve stepping with lane divergence
2dd1fcebf6b gdb/infrun: factor out stepped_into_subroutine predicate
bb613ca46e8 Update TheRock dependencies and container images
e03c14da3b5 Update TheRock dependencies and container images
4c635de40ca gdb/testsuite: update gdb.rocm tests to support optimized code
63060fa6e61 gdb/testsuite: update gdb.rocm framework to support optimized code