### PR TITLE
[amd-staging-rocgdb-16] Revert "gdb/testsuite: Fix runtime-core.exp wave ordering dependency …

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -101,15 +101,15 @@ proc do_test { fault core_type output_type } {
     set faulty_wave 0
     set aux_wave 0
     gdb_test_multiple "info thread" "identify waves" -lbl {
-	-re "($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\\n\]*" {
+	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\r\n\]*(?=\r\n)" {
 	    set faulty_wave $expect_out(1,string)
 	    exp_continue
 	}
-	-re "($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\\n\]*" {
+	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\r\n\]*(?=\r\n)" {
 	    set aux_wave $expect_out(1,string)
 	    exp_continue
 	}
-	-re "$::gdb_prompt $" {
+	-re "^\r\n$::gdb_prompt $" {
 	    gdb_assert {($faulty_wave != 0) && ($aux_wave != 0)} $gdb_test_name
 	}
     }


### PR DESCRIPTION
The cherry-pick was accidentally done twice, the second time in the opposite direction.

This reverts commit 342cd4f59e666570ce7a53bd0d26c624355ecb0c.
