### PR TITLE
gdb.rocm/hip-builtin-variables: add '$' for Tcl vars in messages

### DIFF
--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
@@ -88,7 +88,7 @@ proc check_builtin_variables_values {} {
 	set num_z [set ${ref}_z]
 
 	gdb_test "p $var3d" "= {x = $num_x, y = $num_y, z = $num_z}" \
-	    "$var3d == $ref"
+	    "$var3d == \$$ref"
 	gdb_test "p ${var3d}.x" "$num_x" "${var3d}.x == $num_x"
 	gdb_test "p ${var3d}.y" "$num_y" "${var3d}.y == $num_y"
 	gdb_test "p ${var3d}.z" "$num_z" "${var3d}.z == $num_z"


### PR DESCRIPTION
```
When checking values against some Tcl variables, reflect it in
the "messages" with a '$'.  For example, the following output in
gdb.sum:

  PASS: ...: with debug info: kernel(): blockIdx == group_idx

will turn into:

  PASS: ...: with debug info: kernel(): blockIdx == $group_idx
```

## Motivation
Add `$` sign to Tcl variables in "messages".

## Technical Details
Without the `$` it can be confused with normal source level variables.

## Test Plan
```
make check-gdb TESTS=gdb.rocm/hip-builtin-variables.exp
```

## Test Result
```
...
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: kernel(): threadIdx == $thread_idx
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: kernel(): blockIdx == $group_idx
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: kernel(): blockDim == $group_size
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: kernel(): gridDim == $grid_size
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: inner_func1(): threadIdx == $thread_idx
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: inner_func1(): blockIdx == $group_idx
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: inner_func1(): blockDim == $group_size
PASS: gdb.rocm/hip-builtin-variables.exp: with debug info: inner_func1(): gridDim == $grid_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func2(): threadIdx == $thread_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func2(): blockIdx == $group_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func2(): blockDim == $group_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func2(): gridDim == $grid_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: kernel(): threadIdx == $thread_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: kernel(): blockIdx == $group_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: kernel(): blockDim == $group_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: kernel(): gridDim == $grid_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func1(): threadIdx == $thread_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func1(): blockIdx == $group_idx
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func1(): blockDim == $group_size
PASS: gdb.rocm/hip-builtin-variables.exp: without debug info: inner_func1(): gridDim == $grid_size
...
        === gdb Summary ===

# of expected passes        195
```

