### PR TITLE
gdb/testsuite: resume-exception.exp - handle failure to hit breakpoint

### DIFF
--- a/gdb/testsuite/gdb.rocm/resume-exception.exp
+++ b/gdb/testsuite/gdb.rocm/resume-exception.exp
@@ -123,11 +123,15 @@ proc interrupt_running_threads { } {
 with_rocm_gpu_lock {
     # Run to GPU thread.
     gdb_breakpoint "raise_fpe" -allow-pending
+    set gpu_thread "invalid"
     gdb_test_multiple "run" "" {
 	-re -wrap ".*Thread ($::decimal) \[^\r\n]* hit Breakpoint .*" {
 	    set gpu_thread $expect_out(1,string)
 	    pass $gdb_test_name
 	}
+    }
+    if {$gpu_thread eq "invalid"} {
+	return
     }
     gdb_test "thread $gpu_thread" "raise_fpe.*" "select GPU thread"
 


### PR DESCRIPTION
If GDB fails to hit the breakpoint in raise_fpe, gpu_thread is never
set and referencing it later would cause a Tcl error.  Initialize
gpu_thread to "invalid" before running and return early if it was not
updated by the breakpoint handler.

Jira: AIROCGDB-640