### PR TITLE
[amd-staging-rocgdb-16] gdb/testsuite/runtime-core: Fix piped GPU coredumps test cases

### DIFF
--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -569,7 +569,7 @@ proc hip_device_is_less_than { version } {
 proc rocm_core_find_1 {coredir binfile {arg ""} \
 		       {use_pipe false}} {
     if { $use_pipe } {
-	set coredump_pattern "|tee $coredir/$binfile"
+	set coredump_pattern "|tee $coredir/gpucore.%p"
     } else {
 	set coredump_pattern "gpucore.%p"
     }


### PR DESCRIPTION
Change the pipe pattern to "|tee $coredir/gpucore.%p" so the glob can find the resulting file (mirroring the non-pipe pattern).