### PR TITLE
gdb/testsuite: strip ANSI escapes before pruning omp-rocm ld.lld warning

### DIFF
--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -7006,6 +7006,19 @@ proc gdb_compile {source dest type options} {
 	set omp_early_flags "-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa\
 			     -mllvm=-amdgpu-spill-cfi-saved-regs"
 
+	# The benign __keep_alive warning pruned below is emitted by the
+	# device ld.lld at link time.  Newer lld (e.g. LLVM 23) defaults
+	# --color-diagnostics to "auto" and colorizes when spawned under a
+	# pty (as DejaGnu does), inserting ANSI escapes between "ld.lld:"
+	# and "warning:" that would stop the anchored regexp from matching.
+	# Tell the offload (device) linker not to colorize; only on the
+	# link step, so the compile step does not warn about an unused
+	# argument.  -Wl, would only reach the host linker, not the device
+	# ld.lld that emits this warning.
+	if {$type eq "executable"} {
+	    append omp_early_flags " -Xoffload-linker --no-color-diagnostics"
+	}
+
 	# amdflang does not understand some clang-only diagnostic
 	# flags, so only pass them on the C/C++ (non-f90) paths.
 	if {[lsearch -exact $options f90] == -1} {


### PR DESCRIPTION
## Summary

The OpenMP-offload ROCm tests (`gdb.rocm/omp-target-*.exp`) compile device code with `amdclang`. The device linker `ld.lld` emits a benign warning:

```
ld.lld: warning: <unknown>:0:0: in function __keep_alive void (): local memory global used by non-kernel function
```

`gdb_compile` treats leftover compiler/linker output as a build failure, so an existing `regsub` already prunes this warning. That prune is anchored on the literal `ld.lld: warning:`.

With newer toolchains (LLVM 23), `ld.lld` colorizes its own diagnostics: `--color-diagnostics` defaults to `auto` and turns on whenever stderr is a tty, which is the case when the compiler is spawned under a pty (as DejaGnu does), regardless of clang's `-fdiagnostics-color=never`. The warning then carries ANSI SGR escapes (e.g. `ESC[0;35m`) between `ld.lld:` and `warning:`, defeating the anchored regexp. The warning survives, the build is treated as failed, and the testcase is skipped (UNSUPPORTED/UNTESTED).

This strips ANSI SGR escapes from the captured compiler output before the existing `omp-rocm` prunes run. Only escape bytes are removed (never diagnostic text), so genuine `error:` diagnostics are still detected and real build failures still fail.

## JIRA

AIROCGDB-642

