### PR TITLE
[workflows] Run extended ROCgdb tests in parallel on PRs

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -138,6 +138,100 @@ jobs:
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-corefile
 
+  # Extended test configurations. These reuse the single build from
+  # therock-build-linux (no rebuild) and fan out in parallel with each other
+  # and with the standard tests, all gated on a successful build.
+  #
+  # The two optimization jobs (test-gpu-o3, test-gpu-lto) follow the same
+  # test_families matrix as test-gpu, so with ci:run-all-archs each adds up
+  # to six GPU jobs (one per architecture family). The check-type and hip
+  # board jobs run on gfx94X only.
+  test-gpu-o3:
+    name: Test GPU (-O3)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu,rocgdb-corefile
+      test_options: "--optimization=-O3"
+
+  test-gpu-lto:
+    name: Test GPU (-O3 -flto)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu,rocgdb-corefile
+      test_options: "--optimization='-O3 -flto'"
+
+  test-gpu-check-read1:
+    name: Test GPU (check-read1)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-read1"
+
+  test-gpu-check-readmore:
+    name: Test GPU (check-readmore)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      test_options: "--check-type check-readmore"
+
+  test-gpu-hip-board:
+    name: Test GPU (hip board)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+      test_options: >-
+        --runtestflags=--target_board=hip
+        --tests gdb.base/attach.exp gdb.base/start.exp gdb.base/callfuncs.exp
+        gdb.base/consecutive-step-over.exp gdb.base/ending-run.exp
+        gdb.base/finish.exp gdb.base/hbreak.exp gdb.base/signals.exp
+        gdb.base/step-test.exp gdb.base/watchpoint.exp
+
   therock_ci_summary:
     name: TheRock CI Summary
     if: always()
@@ -147,6 +241,11 @@ jobs:
       - test-gpu
       - test-cpu
       - test-corefile
+      - test-gpu-o3
+      - test-gpu-lto
+      - test-gpu-check-read1
+      - test-gpu-check-readmore
+      - test-gpu-hip-board
     runs-on: ubuntu-24.04
     steps:
       - name: Output failed jobs

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -185,7 +185,7 @@ jobs:
       test_options: "--optimization='-O3 -flto'"
 
   test-gpu-check-read1:
-    name: Test GPU (check-read1)
+    name: Test check-read1
     needs: [setup, therock-build-linux]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
@@ -199,7 +199,7 @@ jobs:
       test_options: "--check-type check-read1"
 
   test-gpu-check-readmore:
-    name: Test GPU (check-readmore)
+    name: Test check-readmore
     needs: [setup, therock-build-linux]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -13,9 +13,14 @@ on:
         required: true
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Job-specific options appended to each component test_script.'
+        default: ''
       projects_to_test:
         type: string
-        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+        description: 'Components to build the test matrix for.'
+        default: 'rocgdb-cpu,rocgdb-gpu,rocgdb-corefile'
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -28,9 +33,14 @@ on:
         required: true
       artifact_run_id:
         type: string
+      test_options:
+        type: string
+        description: 'Job-specific options appended to each component test_script.'
+        default: ''
       projects_to_test:
         type: string
-        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+        description: 'Components to build the test matrix for.'
+        default: 'rocgdb-cpu,rocgdb-gpu,rocgdb-corefile'
 
 permissions:
   contents: read
@@ -84,13 +94,32 @@ jobs:
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-      - name: Set rocgdb test_script
-        # TheRock now emits the installed script path directly; no rewrite needed.
+      - name: Patch rocgdb test_script options
+        # Append caller-supplied options to each component's test_script.
+        # When test_options contains --tests, first strip any pre-existing
+        # --tests from the upstream test_script so the caller's value wins
+        # explicitly rather than relying on argparse last-wins behaviour.
         id: patch-scripts
         env:
           COMPONENTS: ${{ steps.configure.outputs.components }}
+          TEST_OPTIONS: ${{ inputs.test_options }}
         run: |
-          echo "components=$COMPONENTS" >> $GITHUB_OUTPUT
+          strip_tests=false
+          if [[ " $TEST_OPTIONS " == *" --tests "* ]]; then
+            strip_tests=true
+          fi
+          updated=$(echo "$COMPONENTS" | jq -c \
+            --arg opts "$TEST_OPTIONS" \
+            --argjson strip "$strip_tests" '
+            map(
+              .test_script |= (
+                if $strip then gsub("--tests(\\s+[^-]\\S*)*"; "") else . end
+                | if $opts != "" then . + " " + $opts else . end
+                | gsub("  +"; " ") | sub("\\s+$"; "")
+              )
+            )
+          ')
+          echo "components=$updated" >> $GITHUB_OUTPUT
 
   test_components:
     name: "Test ${{ matrix.components.job_name }}"

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -37,7 +37,6 @@ permissions:
 
 env:
   VENV_DIR: ${{ github.workspace }}/.venv
-  OUTPUT_ARTIFACTS_DIR: "./build"
 
 jobs:
   configure_test_matrix:
@@ -85,23 +84,13 @@ jobs:
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-      - name: Override rocgdb test_script to use artifact-installed script
-        # TheRock's fetch_test_configurations.py points test_rocgdb.py at its own
-        # build_tools copy. Rewrite to the script installed in the artifacts at
-        # OUTPUT_ARTIFACTS_DIR/tests/rocgdb/test_rocgdb.py.
+      - name: Set rocgdb test_script
+        # TheRock now emits the installed script path directly; no rewrite needed.
         id: patch-scripts
+        env:
+          COMPONENTS: ${{ steps.configure.outputs.components }}
         run: |
-          components='${{ steps.configure.outputs.components }}'
-          script_path="${{ env.OUTPUT_ARTIFACTS_DIR }}/tests/rocgdb/test_rocgdb.py"
-          updated=$(echo "$components" | jq -c --arg s "$script_path" '
-            map(
-              .test_script |= gsub(
-                "build_tools/github_actions/test_executable_scripts/test_rocgdb\\.py";
-                $s
-              )
-            )
-          ')
-          echo "components=$updated" >> $GITHUB_OUTPUT
+          echo "components=$COMPONENTS" >> $GITHUB_OUTPUT
 
   test_components:
     name: "Test ${{ matrix.components.job_name }}"


### PR DESCRIPTION
## Summary

Add five extended test configurations that run in parallel with the
standard tests on every pull request. All jobs reuse the single build
from `therock-build-linux` (no extra build cost) and fan out together
once the build completes.

The extended configurations are:

| Job | Options | Architectures |
|-----|---------|---------------|
| `Test GPU (-O3)` | `--optimization=-O3` | all (expands with `ci:run-all-archs`) |
| `Test GPU (-O3 -flto)` | `--optimization='-O3 -flto'` | all (expands with `ci:run-all-archs`) |
| `Test check-read1` | `--check-type check-read1` | gfx94X only |
| `Test check-readmore` | `--check-type check-readmore` | gfx94X only |
| `Test GPU (hip board)` | `--runtestflags=--target_board=hip --tests gdb.base/...` | gfx94X only (GPU only) |

**GPU runner budget:** without `ci:run-all-archs`, all five extended jobs
run on gfx94X only (5 extra GPU jobs). With `ci:run-all-archs`, the two
optimization jobs each fan out to all six architecture families (12 extra
GPU jobs from optimization alone, plus 3 for check-type/hip-board). The
multi-arch coverage for optimization jobs is intentional: the goal is to
catch compiler-specific failures across all supported architectures.

To support per-config scoping, `therock-test-packages.yml` gains one
new input and updates another:
- `test_options` — appended to each component's `test_script` (passed
  via a `TEST_OPTIONS` env var in the jq patch step to avoid injection).
  When `test_options` contains `--tests`, any pre-existing `--tests` in
  the upstream `test_script` is stripped first to make the override
  explicit rather than relying on argparse last-wins.
- `projects_to_test` — restricts the component matrix (already existed;
  gains a description). The two optimization jobs use
  `rocgdb-gpu,rocgdb-corefile` since the options are compiler-specific;
  the hip board job uses `rocgdb-gpu` only.

## Commits

1. `[workflows] Drop now-redundant test_rocgdb.py path rewrite` — TheRock
   now emits the installed script path directly; the gsub rewrite was
   already a no-op at the pinned commit. Removes `OUTPUT_ARTIFACTS_DIR`.
2. `[workflows] Run extended ROCgdb tests in parallel on PRs` — the
   extended jobs and updated `therock-test-packages.yml` inputs.