### PR TITLE
[ROCgdb] Update ignore list: remove unused gdb.rocm entries

### DIFF
--- a/.github/scripts/rocgdb_ignore_list.json
+++ b/.github/scripts/rocgdb_ignore_list.json
@@ -1,10 +1,5 @@
 {
-  "Generic": [
-    "gdb.rocm/deep-stack.exp",
-    "gdb.rocm/lane-execution.exp",
-    "gdb.rocm/multi-inferior-fork.exp",
-    "gdb.rocm/multi-inferior-gpu.exp"
-  ],
+  "Generic": [],
   "GCC": [],
   "LLVM": [
     "gdb.dwarf2/dw2-case-insensitive.exp",


### PR DESCRIPTION
Remove 4 gdb.rocm test entries from the Generic ignore list that are
no longer failing and were reported as unused by the CI results from
2026-08-04.