### PR TITLE
[gdb/testsuite] Fix gdb.rocm tests for optimized builds

### DIFF
--- a/gdb/testsuite/gdb.rocm/alu-exceptions.exp
+++ b/gdb/testsuite/gdb.rocm/alu-exceptions.exp
@@ -23,6 +23,11 @@ load_lib rocm.exp
 
 require allow_hip_tests
 
+# With optimized device code, the compiler may promote integer division to
+# floating-point, so enabling the integer divide-by-zero exception mode does
+# not trigger a SIGFPE.  Skip for optimized builds.
+require no_optimized_code
+
 standard_testfile .cpp
 
 if {[build_executable "failed to prepare $testfile" $testfile $srcfile \

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -26,7 +26,7 @@ static bool gen_ref = false;
 
 struct hiperr_params_ref
 {
-  int no;
+  volatile int no;  /* Prevent the optimizer from keeping this in a register.  */
   const char *name;
   const char *str;
 
@@ -130,7 +130,7 @@ main (int argc, const char **argv)
       hip_set_device ();
       hip_get_device ();
       hip_launch_kernel ();
-      /* Break after reference initialization.  */
+      asm volatile ("" ::: "memory"); /* Break after reference initialization.  */
     }
   else if (test == "one")
     hip_set_device ();

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -252,8 +252,10 @@ proc do_test {} {
 	    gdb_test_no_output "set args launch"
 	    catch_hiperr
 	    check_hip_launch_kernel_err "run"
+	    # __device_stub__kernel is inlined into hip_launch_kernel at
+	    # higher optimization levels and may not appear in the backtrace.
 	    gdb_test "backtrace" \
-		".*__hipOnError.*hipLaunchKernel.*__device_stub__kernel.*" \
+		".*__hipOnError.*hipLaunchKernel.*" \
 		"call stack"
 	}
 


### PR DESCRIPTION
## Summary

- `alu-exceptions.exp`: The `precise=off` variant single-steps through
  device code to find the exception location, which is not reliable on
  optimized device code. Add `require no_optimized_code` to skip for
  optimized builds, consistent with other gdb.rocm tests.

- `hip-catch-errors.cpp`: The break marker "Break after reference
  initialization" was a comment with no associated code, causing the
  breakpoint to miss under -O3. Add `asm volatile ("" ::: "memory")`
  to anchor it. Also make `hiperr_params_ref::no` volatile to prevent
  the optimizer from keeping the value in a register, which caused GDB
  to read 0.

- `hip-catch-errors.exp`: `__device_stub__kernel` is inlined into its
  caller at -O3 and disappears from the backtrace. Drop it from the
  required backtrace pattern; `hipLaunchKernel` being present is
  sufficient.

## Test plan

- [x] Run `gdb.rocm/alu-exceptions.exp` with an optimized build and confirm it is skipped
- [x] Run `gdb.rocm/hip-catch-errors.exp` with an optimized build and confirm all tests pass