### PR TITLE
gdb.rocm/runtime-core.exp: Fix unreliable wave identification

### DIFF
--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -50,7 +50,7 @@ set success_count 0
 #   Run the test exercising generation of a core dump on fault FAULT
 #   using a file or a pipe.
 #
-# FAULT is one of "page", "abort",  or "assert", and selects which
+# FAULT is one of "pagefault", "abort", or "assert", and selects which
 #   fault the application should generate.
 #
 # CORE_TYPE is one of "full" or "lightweight".
@@ -79,13 +79,8 @@ proc do_test { fault core_type output_type } {
 
     if {$fault == "pagefault"} {
 	set gpusig "SIGSEGV"
-	set fault_loc "pagefault_kernel"
-    } elseif {$fault == "abort"} {
+    } else {
 	set gpusig "SIGABRT"
-	set fault_loc "abort"
-    } elseif {$fault == "assert"} {
-	set gpusig "SIGABRT"
-	set fault_loc "__assert_fail"
     }
 
     clean_restart
@@ -100,16 +95,24 @@ proc do_test { fault core_type output_type } {
 
     set faulty_wave 0
     set aux_wave 0
-    gdb_test_multiple "info thread" "identify waves" -lbl {
-	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\r\n\]*(?=\r\n)" {
-	    set faulty_wave $expect_out(1,string)
+    # Use a single pattern to match any AMDGPU Wave line regardless of which
+    # kernel it belongs to.  Using two separate patterns (one per kernel name)
+    # is unreliable because the entire "info thread" output can arrive as one
+    # chunk, causing a greedy pattern listed first to consume past the line
+    # intended for the second pattern.  A single pattern sidesteps that by
+    # iterating over all AMDGPU Wave lines with exp_continue and classifying
+    # each in Tcl.  The leading "*" identifies the selected (faulty) wave, and
+    # the quoted thread name identifies the auxiliary wave.
+    gdb_test_multiple "info thread" "identify waves" {
+	-re "(\\\*?) *($::decimal) *AMDGPU Wave \[^\r\n\]* \"(\[^\"]+)\" \[^\r\n\]*\r\n" {
+	    if {$expect_out(1,string) eq "*"} {
+		set faulty_wave $expect_out(2,string)
+	    } elseif {$expect_out(3,string) eq "aux_kernel"} {
+		set aux_wave $expect_out(2,string)
+	    }
 	    exp_continue
 	}
-	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\r\n\]*(?=\r\n)" {
-	    set aux_wave $expect_out(1,string)
-	    exp_continue
-	}
-	-re "^\r\n$::gdb_prompt $" {
+	-re "$::gdb_prompt $" {
 	    gdb_assert {($faulty_wave != 0) && ($aux_wave != 0)} $gdb_test_name
 	}
     }


### PR DESCRIPTION
## Summary
- The "identify waves" block used two separate patterns anchored with ^
  to match GPU wave threads from "info thread" output, which fails when
  the entire output arrives as a single chunk (^ only anchors to the
  buffer start, not individual lines).
- Even without the anchor, two competing patterns cause the first-listed
  one to greedily consume past the line intended for the second.
- Fix by using a single pattern matching any AMDGPU Wave line, then
  classifying in Tcl using the leading "*" (selected/faulty wave) and
  the quoted thread name (aux_kernel). Robust regardless of output
  chunking.
- Also removes the now-unused fault_loc variable, simplifies the gpusig
  conditional, and fixes a typo in the do_test comment.

## Test plan
- [x] Verify passes on mi300x (gfx942)
- [x] Verify passes on mi300a (gfx942)
- [x] Verify passes on gfx1201