### PR TITLE
[amd-staging-rocgdb-16] ROCgdb cherry picks from origin/amd-staging (2026-08-10)

### DIFF
--- a/.github/scripts/rocgdb_ignore_list.json
+++ b/.github/scripts/rocgdb_ignore_list.json
@@ -1,10 +1,5 @@
 {
-  "Generic": [
-    "gdb.rocm/deep-stack.exp",
-    "gdb.rocm/lane-execution.exp",
-    "gdb.rocm/multi-inferior-fork.exp",
-    "gdb.rocm/multi-inferior-gpu.exp"
-  ],
+  "Generic": [],
   "GCC": [],
   "LLVM": [
     "gdb.dwarf2/dw2-case-insensitive.exp",

--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -55,6 +55,15 @@ ONE_BY_ONE_DEFAULT_WALL_CLOCK_TIMEOUT = 3600
 # ignored at runtime, so listing extras here is harmless.
 SANITIZERS = ("asan", "tsan", "ubsan", "msan", "lsan", "hwasan")
 
+# Supported toolchains, keyed by the identifier the toolchain option accepts.
+# Each one maps to the compiler label (a load bearing key used across results
+# and ignore lists) and the C, C++, and Fortran executables we pass to the
+# testsuite. Insertion order defines the default run order.
+TOOLCHAINS = {
+    "gnu": {"label": "GCC", "cc": "gcc", "cxx": "g++", "fc": "gfortran"},
+    "llvm": {"label": "LLVM", "cc": "clang", "cxx": "clang++", "fc": "flang"},
+}
+
 # Patterns for parsing DejaGnu .sum lines.
 RESULT_LINE_RE = re.compile(
     r"^(PASS|FAIL|XFAIL|UNTESTED|UNSUPPORTED|KFAIL|UNRESOLVED): (.+)$"
@@ -253,6 +262,25 @@ def load_ignore_list_from_json(json_path: Path) -> Dict[str, List[str]]:
     return data
 
 
+def select_toolchains(requested: Optional[List[str]]) -> List[str]:
+    """
+    Resolve the list of toolchain identifiers to run.
+
+    When no toolchain is requested, all of them run in definition order.
+    Repeated names are dropped while keeping the first occurrence so the same
+    toolchain never runs twice.
+
+    Args:
+        requested: Toolchain identifiers from --toolchain, or None when the
+            flag was omitted.
+
+    Returns:
+        Toolchain identifiers to run, in order, with duplicates removed.
+    """
+    names = requested if requested is not None else list(TOOLCHAINS.keys())
+    return list(dict.fromkeys(names))
+
+
 def _non_negative_int(value: str) -> int:
     """
     Validate argument is a non-negative integer.
@@ -345,6 +373,7 @@ def parse_arguments() -> argparse.Namespace:
   python %(prog)s --skip-failed-test-log
   python %(prog)s --output-ignore-list-file custom_ignore_list.json
   python %(prog)s --one-by-one --tests gdb.rocm/foo.exp
+  python %(prog)s --toolchain llvm
 
         """,
     )
@@ -382,6 +411,18 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default="",
         help="Optimization level to pass to compiler (e.g., -O0, -Os, -Og).",
+    )
+    parser.add_argument(
+        "--toolchain",
+        nargs="+",
+        default=None,
+        metavar="NAME",
+        choices=list(TOOLCHAINS.keys()),
+        help="Toolchain(s) to run tests against. Choices: "
+        f"{', '.join(TOOLCHAINS.keys())}. Accepts one or more values; the flag "
+        "requires at least one. If omitted, all toolchains run and the results "
+        "are compared. Passing a single toolchain (e.g. --toolchain llvm) runs "
+        "only that toolchain and skips the cross-compiler comparison.",
     )
     parser.add_argument(
         "--parallel", action="store_true", help="Run tests in parallel. Default is off."
@@ -2007,6 +2048,9 @@ def main() -> None:
     # Print Python information.
     print_python_info()
 
+    # Build the compiler configurations from the selected toolchains.
+    selected_toolchains = select_toolchains(args.toolchain)
+
     # Show configuration summary.
     print_configuration(
         rocgdb_bin,
@@ -2016,6 +2060,7 @@ def main() -> None:
         args,
         ignore_list_file_status,
         output_ignore_list_file_status,
+        selected_toolchains,
     )
 
     # Load ignore list from JSON file.
@@ -2039,22 +2084,15 @@ def main() -> None:
 
     # Validate that we can run rocgdb.
     validate_rocgdb(rocgdb_bin, env_vars)
-
-    # Verify executables presence.
-    check_executables(
-        [
-            "make",
-            "amdclang++",
-            "gcc",
-            "g++",
-            "gfortran",
-            "clang",
-            "clang++",
-            "flang",
-            "runtest",
-        ],
-        env_vars,
-    )
+    compilers = [
+        (
+            TOOLCHAINS[name]["cc"],
+            TOOLCHAINS[name]["cxx"],
+            TOOLCHAINS[name]["fc"],
+            TOOLCHAINS[name]["label"],
+        )
+        for name in selected_toolchains
+    ]
 
     print_section("Expanding test paths")
     tests = expand_test_paths(args.tests, rocgdb_testsuite_dir)
@@ -2062,11 +2100,19 @@ def main() -> None:
     if not tests:
         _log_error_and_exit("No test files found")
 
-    # Compiler configurations.
-    compilers = [
-        ("gcc", "g++", "gfortran", "GCC"),
-        ("clang", "clang++", "flang", "LLVM"),
-    ]
+    # Verify executables presence. We only require the compilers of the selected
+    # toolchains, in first seen order with duplicates dropped, so a run of one
+    # toolchain does not fail because another toolchain's compilers are absent.
+    # amdclang++ is needed to compile GPU kernels for gdb.rocm tests; require it
+    # whenever any gdb.rocm test is in scope.
+    toolchain_executables = list(
+        dict.fromkeys(exe for cc, cxx, fc, _ in compilers for exe in (cc, cxx, fc))
+    )
+    has_rocm_tests = any(t.startswith("gdb.rocm/") or t == "gdb.rocm" for t in tests)
+    required_executables = ["make", *toolchain_executables, "runtest"]
+    if has_rocm_tests:
+        required_executables.insert(1, "amdclang++")
+    check_executables(required_executables, env_vars)
 
     # Initialize test result tracking.
     test_results = TestResults()
@@ -2094,6 +2140,14 @@ def main() -> None:
 
     # Generate and write output ignore list if requested.
     if args.output_ignore_list_file is not None:
+        if len(selected_toolchains) < 2:
+            logger.warning(
+                f"{STATUS_WARN} --output-ignore-list-file with a single toolchain "
+                "produces no Generic entries. Failures that would be Generic in a "
+                "two-toolchain run are filed under the single compiler label only, "
+                "so the generated list will not suppress those tests when run with "
+                "all toolchains."
+            )
         ignore_list = test_results.generate_ignore_list()
         try:
             with open(args.output_ignore_list_file, "w", encoding="utf-8") as f:
@@ -2396,6 +2450,7 @@ def print_configuration(
     args: argparse.Namespace,
     ignore_list_file_status: str,
     output_ignore_list_file_status: str,
+    selected_toolchains: List[str],
 ) -> None:
     """
     Display the ROCgdb test configuration in a formatted table.
@@ -2408,6 +2463,7 @@ def print_configuration(
         args: Parsed command-line arguments containing additional configuration values.
         ignore_list_file_status: Status message for ignore list file.
         output_ignore_list_file_status: Status message for output ignore list file.
+        selected_toolchains: Resolved toolchain identifiers to display, in run order.
 
     Returns:
         None
@@ -2431,6 +2487,10 @@ def print_configuration(
         else "Dejagnu's default"
     )
 
+    toolchains_display = ", ".join(
+        f"{name} ({TOOLCHAINS[name]['label']})" for name in selected_toolchains
+    )
+
     one_by_one_timeout_display = (
         f"{args.one_by_one_test_timeout} seconds"
         if args.one_by_one_test_timeout is not None
@@ -2444,6 +2504,7 @@ def print_configuration(
         ("Testsuite Directory", testsuite_dir),
         ("Configure Script", configure_script),
         ("Tests", " ".join(args.tests)),
+        ("Toolchains", toolchains_display),
         ("Check Type", args.check_type),
         ("Parallel Execution", parallel_info),
         ("One-by-one Mode", "Enabled" if args.one_by_one else "Disabled"),

--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -56,13 +56,15 @@ ONE_BY_ONE_DEFAULT_WALL_CLOCK_TIMEOUT = 3600
 SANITIZERS = ("asan", "tsan", "ubsan", "msan", "lsan", "hwasan")
 
 # Supported toolchains, keyed by the identifier the toolchain option accepts.
-# Each one maps to the compiler label (a load bearing key used across results
-# and ignore lists) and the C, C++, and Fortran executables we pass to the
-# testsuite. Insertion order defines the default run order.
+# Each one maps to the compiler label (a load bearing key used across results,
+# ignore lists, and timing output) and the C, C++, and Fortran executables we
+# pass to the testsuite. Insertion order defines the default run order.
 TOOLCHAINS = {
     "gnu": {"label": "GCC", "cc": "gcc", "cxx": "g++", "fc": "gfortran"},
     "llvm": {"label": "LLVM", "cc": "clang", "cxx": "clang++", "fc": "flang"},
 }
+
+TIMING_LOG_FILENAME = "rocgdb_timing.log"
 
 # Patterns for parsing DejaGnu .sum lines.
 RESULT_LINE_RE = re.compile(
@@ -373,6 +375,7 @@ def parse_arguments() -> argparse.Namespace:
   python %(prog)s --skip-failed-test-log
   python %(prog)s --output-ignore-list-file custom_ignore_list.json
   python %(prog)s --one-by-one --tests gdb.rocm/foo.exp
+  python %(prog)s --timing --gpu-tests
   python %(prog)s --toolchain llvm
 
         """,
@@ -564,8 +567,32 @@ def parse_arguments() -> argparse.Namespace:
         help="Wall-clock timeout (seconds) per individual `make check` invocation "
         "in --one-by-one mode. Defaults to 3600.",
     )
+    parser.add_argument(
+        "--timing",
+        action="store_true",
+        help="Record each test's wall-clock duration and write rocgdb_timing.log "
+        "grouped by compiler and directory, sorted from longest to shortest "
+        "running test. Implies --one-by-one. The recorded duration is the "
+        "maximum time of a successful run; tests that never passed show N/A.",
+    )
+    parser.add_argument(
+        "--timing-log-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Output path for the timing log. Default: "
+        "<testsuite_dir>/rocgdb_timing.log. Requires --timing.",
+    )
 
     args = parser.parse_args()
+
+    # --timing is a specialization of one-by-one mode; enable it implicitly so
+    # a single flag turns on the timing run. Set before the one-by-one /
+    # parallel validation below so --timing --parallel is rejected too.
+    if args.timing:
+        args.one_by_one = True
+    if args.timing_log_file is not None and not args.timing:
+        _log_error_and_exit("--timing-log-file requires --timing.")
 
     # Validate that -j/--jobs is only used with --parallel.
     if args.jobs is not None and not args.parallel:
@@ -627,6 +654,42 @@ class TestResults:
         # "Running ....exp") per compiler_label. Replaced on each
         # update_results call so it reflects the most recent run's state.
         self.harness_errors: Dict[str, List[str]] = defaultdict(list)
+
+        # Per-test timings for --timing mode, keyed by compiler_label then
+        # test file. Value is the maximum duration (seconds) of a *successful*
+        # run, or None if the test ran but never passed. Populated by
+        # _execute_one_by_one via record_timing.
+        self.timings: Dict[str, Dict[str, Optional[float]]] = defaultdict(dict)
+
+    def record_timing(
+        self, compiler_label: str, test_file: str, duration: float, passed: bool
+    ) -> None:
+        """
+        Record a per-test wall-clock duration for --timing mode.
+
+        For a successful run, keep the maximum duration seen across all runs
+        (both compilers' retries), since the goal is spotting slow tests and
+        worst-case is the useful signal. A failed run never overwrites a
+        recorded success; a test that only ever fails is stored as None so the
+        report can show N/A.
+
+        Args:
+            compiler_label: Compiler identifier (e.g., "GCC", "LLVM").
+            test_file: Test file path (e.g., "gdb.rocm/simple.exp").
+            duration: Wall-clock duration of this run in seconds.
+            passed: Whether this run completed successfully.
+
+        Returns:
+            None
+        """
+        per_compiler = self.timings[compiler_label]
+        if passed:
+            prev = per_compiler.get(test_file)
+            if prev is None or duration > prev:
+                per_compiler[test_file] = duration
+        elif test_file not in per_compiler:
+            # Record the failure only if no successful timing exists yet.
+            per_compiler[test_file] = None
 
     def cleanup_old_entries(self, compiler_label: str, tests: List[str]) -> None:
         """
@@ -1793,6 +1856,7 @@ def run_tests(
                 compiler_label,
                 iteration,
                 wall_clock,
+                test_results if args.timing else None,
             )
         else:
             cmd = [
@@ -2138,6 +2202,14 @@ def main() -> None:
     test_results.print_all_summaries()
     overall_pass = test_results.print_final_status(xfailed_tests, args.no_xfail)
 
+    # Write the per-test timing log if requested.
+    if args.timing:
+        timing_path = args.timing_log_file or (
+            rocgdb_testsuite_dir / TIMING_LOG_FILENAME
+        )
+        write_timing_log(test_results.timings, timing_path)
+        logger.info(f"{STATUS_PASS} Timing log written to {timing_path}")
+
     # Generate and write output ignore list if requested.
     if args.output_ignore_list_file is not None:
         if len(selected_toolchains) < 2:
@@ -2222,6 +2294,7 @@ def _execute_one_by_one(
     compiler_label: str,
     iteration: int,
     wall_clock_timeout: int,
+    test_results: Optional["TestResults"] = None,
 ) -> None:
     """
     Run each test in its own `make check` invocation, capturing per-test
@@ -2245,6 +2318,8 @@ def _execute_one_by_one(
         compiler_label: Compiler identifier (e.g., "GCC").
         iteration: Current retry iteration (1-based) — controls log filename suffix.
         wall_clock_timeout: Wall-clock timeout (seconds) for each `make check`.
+        test_results: When supplied (--timing mode), each test's duration is
+            recorded via record_timing. None disables timing collection.
 
     Returns:
         None
@@ -2338,6 +2413,12 @@ def _execute_one_by_one(
             elif line.startswith("FAIL:"):
                 has_fail = True
         test_failed = wall_clock_timed_out or has_fail or has_unresolved or has_error
+
+        if test_results is not None:
+            test_results.record_timing(
+                compiler_label, test, duration, passed=not test_failed
+            )
+
         status_dir = "fail" if test_failed else "pass"
         if wall_clock_timed_out:
             status_text = "TIMEOUT"
@@ -2390,6 +2471,86 @@ def _execute_one_by_one(
         aggregated_sum.write_text("\n".join(aggregated_lines) + "\n", encoding="utf-8")
     except OSError as e:
         _log_error_and_exit(f"Failed to write aggregated gdb.sum: {e}")
+
+
+def _timing_entries_total(entries: List[Tuple[str, Optional[float]]]) -> float:
+    """
+    Sum the measured durations in a list of (test_file, duration) entries.
+
+    Entries whose duration is None (the test ran but never passed) contribute
+    nothing, so a directory of only such entries totals zero and sorts last.
+
+    Args:
+        entries: List of (test_file, duration) pairs for one directory.
+
+    Returns:
+        Total measured duration in seconds.
+    """
+    return sum(duration for _, duration in entries if duration is not None)
+
+
+def write_timing_log(
+    timings: Dict[str, Dict[str, Optional[float]]], out_path: Path
+) -> None:
+    """
+    Write the per-test timing log for --timing mode.
+
+    Entries are grouped by compiler, then by test directory (e.g. gdb.rocm),
+    and within each directory sorted by duration descending (longest-running
+    test first). Tests that ran but never passed are shown as N/A and sorted
+    after all timed tests.
+
+    Args:
+        timings: Nested mapping compiler_label -> test_file -> duration (or
+            None if the test never passed).
+        out_path: Destination path for the timing log.
+
+    Exits:
+        Code 1 if the file cannot be written.
+    """
+    lines: List[str] = [
+        "# ROCgdb per-test timing (one-by-one mode)",
+        "# Duration is the maximum wall-clock time of a successful run.",
+        "# N/A means the test ran but never passed.",
+    ]
+
+    print_width = 80
+    for compiler_label in timings.keys():
+        per_compiler = timings[compiler_label]
+        lines.append("")
+        lines.append("=" * print_width)
+        lines.append(f"Compiler: {compiler_label}")
+        lines.append("=" * print_width)
+
+        # Group this compiler's tests by directory.
+        grouped: Dict[str, List[Tuple[str, Optional[float]]]] = defaultdict(list)
+        for test_file, duration in per_compiler.items():
+            directory = os.path.dirname(test_file) or "."
+            grouped[directory].append((test_file, duration))
+
+        # Order directories by total measured time descending. A directory with
+        # only N/A entries totals zero and sorts last.
+        dir_totals = {d: _timing_entries_total(grouped[d]) for d in grouped}
+        for directory in sorted(grouped, key=dir_totals.__getitem__, reverse=True):
+            total = dir_totals[directory]
+            lines.append(f"\n{directory}  (total {total:.2f}s)")
+            # Timed tests first (longest to shortest), then N/A tests by name.
+            # Two-pass stable sort: name ascending first, then duration
+            # descending, so N/A ties break alphabetically.
+            entries = sorted(grouped[directory], key=lambda item: item[0])
+            entries = sorted(
+                entries,
+                key=lambda item: (item[1] is not None, item[1] or 0.0),
+                reverse=True,
+            )
+            for test_file, duration in entries:
+                value = f"{duration:10.2f}s" if duration is not None else f"{'N/A':>11}"
+                lines.append(f"  {value}  {test_file}")
+
+    try:
+        out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except OSError as e:
+        _log_error_and_exit(f"Failed to write timing log to {out_path}: {e}")
 
 
 def print_python_info() -> None:
@@ -2517,6 +2678,13 @@ def print_configuration(
             )
         )
         fields.append(("One-by-one Test Timeout", one_by_one_timeout_display))
+    if args.timing:
+        fields.append(
+            (
+                "Timing Log",
+                args.timing_log_file or (testsuite_dir / TIMING_LOG_FILENAME),
+            )
+        )
     fields.extend(
         [
             ("Use FAIL ignore list", "Not using" if args.no_xfail else "Using"),

--- a/.github/scripts/test_rocgdb.py
+++ b/.github/scripts/test_rocgdb.py
@@ -50,6 +50,12 @@ TEST_CATEGORIES = [
 # --one-by-one mode when --one-by-one-test-timeout is not provided.
 ONE_BY_ONE_DEFAULT_WALL_CLOCK_TIMEOUT = 3600
 
+# Default wall-clock timeout (seconds) for each --sanity-check probe when
+# --sanity-check-timeout is not provided. A trivial known-good HIP kernel
+# should return near-instantly; this is a starting value to be tuned
+# experimentally on real hardware.
+SANITY_CHECK_DEFAULT_TIMEOUT = 10
+
 # Sanitizers we pre-configure on every run. If rocgdb wasn't built with the
 # corresponding -fsanitize=..., the matching *_OPTIONS env var is silently
 # ignored at runtime, so listing extras here is harmless.
@@ -375,6 +381,7 @@ def parse_arguments() -> argparse.Namespace:
   python %(prog)s --skip-failed-test-log
   python %(prog)s --output-ignore-list-file custom_ignore_list.json
   python %(prog)s --one-by-one --tests gdb.rocm/foo.exp
+  python %(prog)s --one-by-one --sanity-check --gpu-tests
   python %(prog)s --timing --gpu-tests
   python %(prog)s --toolchain llvm
 
@@ -568,6 +575,23 @@ def parse_arguments() -> argparse.Namespace:
         "in --one-by-one mode. Defaults to 3600.",
     )
     parser.add_argument(
+        "--sanity-check",
+        action="store_true",
+        help="Before each one-by-one test, run a known-good HIP program "
+        "(built once per run from gdb.rocm/simple.cpp) and bail out if the GPU stops "
+        "responding. If the probe times out or exits non-zero, the system is "
+        "declared unreliable: a dmesg.log is captured under the one-by-one log "
+        "dir and the run aborts. Requires --one-by-one.",
+    )
+    parser.add_argument(
+        "--sanity-check-timeout",
+        type=_positive_nonzero_int,
+        default=None,
+        metavar="SECS",
+        help="Wall-clock timeout (seconds) for each --sanity-check probe. "
+        f"Defaults to {SANITY_CHECK_DEFAULT_TIMEOUT}. Requires --sanity-check.",
+    )
+    parser.add_argument(
         "--timing",
         action="store_true",
         help="Record each test's wall-clock duration and write rocgdb_timing.log "
@@ -609,6 +633,25 @@ def parse_arguments() -> argparse.Namespace:
         _log_error_and_exit(
             "--one-by-one-log-dir / --one-by-one-test-timeout require --one-by-one."
         )
+
+    # Validate --sanity-check constraints. The probe is only meaningful in
+    # one-by-one mode, where it runs between per-test `make check` invocations.
+    # Check the --parallel conflict first so the message points at the real
+    # incompatibility instead of suggesting the user add --one-by-one (which
+    # would then trip the mutual-exclusion error above).
+    if args.sanity_check and args.parallel:
+        _log_error_and_exit(
+            "--sanity-check cannot be combined with --parallel "
+            "(it runs in --one-by-one mode)."
+        )
+    if args.sanity_check and not args.one_by_one:
+        _log_error_and_exit("--sanity-check requires --one-by-one.")
+    if args.sanity_check_timeout is not None and not args.sanity_check:
+        _log_error_and_exit("--sanity-check-timeout requires --sanity-check.")
+    # Resolve the effective probe timeout now that the "set without
+    # --sanity-check" case has been rejected, so downstream code sees a value.
+    if args.sanity_check_timeout is None:
+        args.sanity_check_timeout = SANITY_CHECK_DEFAULT_TIMEOUT
 
     # Validate paths independently if provided. Either flag may be supplied
     # alone; whichever is omitted is auto-discovered in _resolve_rocm_paths.
@@ -1782,6 +1825,7 @@ def run_tests(
     test_results: "TestResults",
     args: argparse.Namespace,
     xfailed_tests: Optional[Dict[str, List[str]]] = None,
+    sanity_check_exe: Optional[Path] = None,
 ) -> None:
     """
     Run ROCgdb test suite with retry logic for failed tests.
@@ -1799,6 +1843,9 @@ def run_tests(
         args: Parsed command-line arguments.
         xfailed_tests: Compiler labels mapped to expected failing test paths.
             Used to skip retrying ignored tests when --retry-ignored-tests is off.
+        sanity_check_exe: When supplied (--sanity-check mode), the pre-built
+            known-good HIP executable run before each test in one-by-one mode.
+            None disables the probe.
 
     Returns:
         None
@@ -1845,6 +1892,7 @@ def run_tests(
                     f"(override with --one-by-one-test-timeout)"
                 )
             log_dir = args.one_by_one_log_dir or (test_suite_dir / "one_by_one_logs")
+
             _execute_one_by_one(
                 test_suite_dir,
                 current_tests,
@@ -1857,6 +1905,8 @@ def run_tests(
                 iteration,
                 wall_clock,
                 test_results if args.timing else None,
+                sanity_check_exe,
+                args.sanity_check_timeout,
             )
         else:
             cmd = [
@@ -2178,6 +2228,25 @@ def main() -> None:
         required_executables.insert(1, "amdclang++")
     check_executables(required_executables, env_vars)
 
+    # The sanity check probes the GPU with a HIP program, so it is only
+    # meaningful when gdb.rocm tests will actually run. Reject the combination
+    # early rather than compiling a HIP program for a CPU-only run.
+    if args.sanity_check and not has_rocm_tests:
+        _log_error_and_exit(
+            "--sanity-check requires gdb.rocm tests to be in scope, but none "
+            "were selected."
+        )
+
+    # Build the sanity-check executable once per invocation. It is rebuilt
+    # unconditionally so a binary left over from a previous run (possibly for a
+    # different GPU) can never cause a spurious "system unreliable" abort.
+    sanity_check_exe = None
+    if args.sanity_check:
+        log_dir = args.one_by_one_log_dir or (rocgdb_testsuite_dir / "one_by_one_logs")
+        sanity_check_exe = _build_sanity_check_executable(
+            rocgdb_testsuite_dir, log_dir, env_vars
+        )
+
     # Initialize test result tracking.
     test_results = TestResults()
     test_results.group_results = args.group_results
@@ -2196,6 +2265,7 @@ def main() -> None:
             test_results,
             args,
             xfailed_tests,
+            sanity_check_exe,
         )
 
     # Final summaries.
@@ -2283,6 +2353,214 @@ def _build_runtestflags(
     return " ".join(parts)
 
 
+def _decode_stream(data: Union[str, bytes, None]) -> str:
+    """
+    Normalize a captured subprocess stream to text.
+
+    TimeoutExpired.stdout/stderr may be bytes, str, or None depending on how
+    far communicate() progressed; coerce all three to a string for logging.
+
+    Args:
+        data: A captured stream value (str, bytes, or None).
+
+    Returns:
+        The decoded text, or "" when there was nothing captured.
+    """
+    if data is None:
+        return ""
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="replace")
+    return data
+
+
+def _build_sanity_check_executable(
+    test_suite_dir: Path, log_dir: Path, env_vars: Dict[str, str]
+) -> Path:
+    """
+    Build the sanity-check HIP executable from gdb.rocm/simple.cpp.
+
+    simple.cpp is a self-contained HIP program with its own main() that launches
+    a trivial kernel and asserts the result, so it compiles directly with
+    amdclang++ and needs none of the testsuite's wrapper/driver machinery. The
+    executable is written to <log_dir>/sanity_check and rebuilt unconditionally
+    on every invocation: --offload-arch=native bakes in the build-time GPU, so
+    a binary left over from a previous run (possibly on different hardware)
+    must never be reused, or it could cause a spurious "system unreliable"
+    abort.
+
+    Args:
+        test_suite_dir: Path to the testsuite directory (source of simple.cpp).
+        log_dir: One-by-one log dir root; the executable is written here so it
+            sits next to any dmesg.log the probe writes.
+        env_vars: Prepared environment for the compile. Supplies the same
+            PATH/LD_LIBRARY_PATH as the testsuite run so amdclang++ and its HIP
+            toolchain resolve identically.
+
+    Returns:
+        Path to the freshly built sanity-check executable.
+
+    Exits:
+        Code 1 if the source is missing or the compile fails (a setup error,
+        distinct from the unreliable-system condition the probe detects).
+    """
+    src = test_suite_dir / "gdb.rocm" / "simple.cpp"
+    if not src.is_file():
+        _log_error_and_exit(f"Sanity-check source not found: {src}")
+
+    out = log_dir / "sanity_check"
+
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _log_error_and_exit(f"Failed to create sanity-check log dir {log_dir}: {e}")
+
+    # Mirror the essential flags the testsuite uses to build gdb.rocm programs
+    # (see gdb/testsuite/boards/hip.exp and the command echoed by simple.exp):
+    #
+    # . -x hip puts amdclang++ in HIP mode so the device headers and toolchain
+    #   are on the include path. Without it the source is compiled as host C++
+    #   and <hip/hip_runtime.h> is not found (and --offload-arch is reported as
+    #   an unused argument).
+    # . --offload-arch=native auto-detects the installed GPU.
+    # . -mllvm=-amdgpu-spill-cfi-saved-regs matches the known-good recipe.
+    # . -Wno-unused-command-line-argument / -Wno-unknown-warning-option keep the
+    #   HIP link step quiet, as the board file does.
+    cmd = [
+        "amdclang++",
+        "-x",
+        "hip",
+        "--offload-arch=native",
+        "-mllvm=-amdgpu-spill-cfi-saved-regs",
+        "-Wno-unused-command-line-argument",
+        "-Wno-unknown-warning-option",
+        str(src),
+        "-o",
+        str(out),
+    ]
+    logger.info(f"Building sanity-check executable: {shlex.join(cmd)}")
+    result = _run_command(env=env_vars, cmd=cmd, capture_output=True, check=False)
+    if result.returncode != 0:
+        _log_error_and_exit(
+            f"Failed to build sanity-check executable from {src}: {result.stderr}"
+        )
+    logger.info(f"{STATUS_PASS} Sanity-check executable built at {out}")
+    return out
+
+
+def _dump_dmesg(log_dir: Path, env_vars: Dict[str, str]) -> None:
+    """
+    Capture kernel ring buffer output to <log_dir>/dmesg.log.
+
+    On many systems reading the kernel log is restricted
+    (kernel.dmesg_restrict), so a plain `dmesg` fails for non-root users. We
+    first try `dmesg`, then fall back to non-interactive `sudo -n dmesg` (which
+    never blocks on a password prompt). If neither yields output, we warn and
+    write nothing rather than saving a misleading file containing only the
+    permission error.
+
+    Best-effort throughout: a missing binary, a non-zero exit, or a write
+    failure is warned about but never raised, so it cannot mask the
+    unreliable-system exit that calls it.
+
+    Args:
+        log_dir: Directory to write dmesg.log into.
+        env_vars: Prepared environment for the dmesg invocation.
+
+    Returns:
+        None
+    """
+    dmesg_path = log_dir / "dmesg.log"
+
+    def _try(cmd: List[str]) -> Optional[str]:
+        try:
+            result = _run_command(cmd, env=env_vars, capture_output=True, check=False)
+        except SystemExit:
+            # _run_command calls _log_error_and_exit on OSError (e.g. the
+            # binary is missing) even with no error_msg; treat that as "this
+            # command is unavailable" so diagnostics never abort the abort.
+            return None
+        if result.returncode == 0 and result.stdout:
+            return result.stdout
+        return None
+
+    output = _try(["dmesg"]) or _try(["sudo", "-n", "dmesg"])
+    if not output:
+        logger.warning(
+            f"{STATUS_WARN} Could not capture dmesg (missing binary or "
+            f"insufficient privileges); skipping {dmesg_path}."
+        )
+        return
+
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        dmesg_path.write_text(output, encoding="utf-8")
+        logger.info(f"{STATUS_WARN} dmesg captured to {dmesg_path}")
+    except OSError as e:
+        logger.warning(f"{STATUS_WARN} Failed to write {dmesg_path}: {e}")
+
+
+def _run_sanity_check(
+    exe: Path, timeout: int, env_vars: Dict[str, str], log_dir: Path
+) -> None:
+    """
+    Run the sanity-check executable as a GPU health probe.
+
+    A trivial known-good HIP kernel should return well within `timeout`. If it
+    times out or exits non-zero, the system is declared unreliable: dmesg is
+    captured and the run aborts immediately (sys.exit(1)) rather than letting
+    every remaining test fail for reasons unrelated to the code under test.
+
+    Args:
+        exe: Path to the sanity-check executable.
+        timeout: Wall-clock timeout (seconds) for the probe.
+        env_vars: Prepared environment for the probe.
+        log_dir: One-by-one log dir root; dmesg.log is written here on failure.
+
+    Returns:
+        None on success.
+
+    Exits:
+        Code 1 if the probe times out or exits non-zero.
+    """
+    reason: Optional[str] = None
+    output = ""
+    start = time.perf_counter()
+    try:
+        result = _run_command(
+            [str(exe)],
+            env=env_vars,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+            kill_process_group=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        reason = f"sanity check timed out after {timeout}s"
+        # TimeoutExpired carries whatever the child emitted before the kill;
+        # it may be bytes or str depending on how far communicate() got.
+        output = _decode_stream(exc.stdout) + _decode_stream(exc.stderr)
+    else:
+        if result.returncode != 0:
+            reason = f"sanity check exited with code {result.returncode}"
+            output = (result.stdout or "") + (result.stderr or "")
+    duration = time.perf_counter() - start
+
+    if reason is not None:
+        logger.error(
+            f"{STATUS_FAIL} System has become unreliable: {reason}. "
+            f"Aborting the test run."
+        )
+        output = output.strip()
+        if output:
+            logger.error(f"{STATUS_FAIL} Sanity check output:")
+            for line in output.splitlines():
+                logger.error(f"       {line}")
+        _dump_dmesg(log_dir, env_vars)
+        sys.exit(1)
+
+    print_section(f"{STATUS_PASS} Sanity check passed in {duration:.2f}s")
+
+
 def _execute_one_by_one(
     test_suite_dir: Path,
     tests: List[str],
@@ -2294,7 +2572,9 @@ def _execute_one_by_one(
     compiler_label: str,
     iteration: int,
     wall_clock_timeout: int,
-    test_results: Optional["TestResults"] = None,
+    test_results: Optional["TestResults"],
+    sanity_check_exe: Optional[Path],
+    sanity_check_timeout: int,
 ) -> None:
     """
     Run each test in its own `make check` invocation, capturing per-test
@@ -2320,18 +2600,28 @@ def _execute_one_by_one(
         wall_clock_timeout: Wall-clock timeout (seconds) for each `make check`.
         test_results: When supplied (--timing mode), each test's duration is
             recorded via record_timing. None disables timing collection.
+        sanity_check_exe: When supplied (--sanity-check mode), the pre-built
+            known-good HIP executable run before each test as a GPU health
+            probe. None disables the probe.
+        sanity_check_timeout: Wall-clock timeout (seconds) for each probe.
 
     Returns:
         None
 
     Exits:
-        Code 1 if the aggregated gdb.sum cannot be written.
+        Code 1 if the aggregated gdb.sum cannot be written, or if a sanity-check
+        probe declares the system unreliable.
     """
     aggregated_lines: List[str] = []
     retry_number = iteration - 1
     base_suffix = "" if retry_number == 0 else f".retry-{retry_number}"
 
     for test in tests:
+        # Probe the GPU before each test. Bails out (sys.exit(1)) if the system
+        # has become unreliable, capturing dmesg.log under log_dir.
+        if sanity_check_exe is not None:
+            _run_sanity_check(sanity_check_exe, sanity_check_timeout, env_vars, log_dir)
+
         cmd = [
             "make",
             check_type,
@@ -2678,6 +2968,11 @@ def print_configuration(
             )
         )
         fields.append(("One-by-one Test Timeout", one_by_one_timeout_display))
+        if args.sanity_check:
+            fields.append(("Sanity Check", "Enabled"))
+            fields.append(
+                ("Sanity Check Timeout", f"{args.sanity_check_timeout} seconds")
+            )
     if args.timing:
         fields.append(
             (

--- a/.github/scripts/update_therock_deps.py
+++ b/.github/scripts/update_therock_deps.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Update TheRock references in ROCgdb's CI workflow.
+
+Fetches the latest TheRock commit and the latest therock_build_manylinux_x86_64
+container digest, updates .github/workflows/therock-ci-linux.yml, then pushes a
+branch and opens a ROCgdb PR labelled 'therock-deps'. If an update PR already
+carries that label, the run skips without touching git.
+
+The test container is not updated here: it is pinned transitively through
+THEROCK_COMMIT_REF (TheRock's fetch_test_configurations.py supplies the test
+image), so bumping the commit ref updates it automatically.
+"""
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+ROCGDB_REPO = "ROCm/ROCgdb"
+BASE_BRANCH = "amd-staging"
+CI_LINUX = Path(".github/workflows/therock-ci-linux.yml")
+
+THEROCK_REPO_URL = "https://github.com/ROCm/TheRock.git"
+BUILD_IMAGE = "ghcr.io/rocm/therock_build_manylinux_x86_64"
+
+UPDATE_LABEL = "therock-deps"
+BRANCH_PREFIX = "users/github/update-therock-refs"
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+MAX_RETRIES = 3  # number of retries for network requests
+
+# Never pass secrets as CLI args — use env vars (e.g. GH_TOKEN) instead.
+
+
+# ---------------------------------------------------------------------------
+# Network helper
+# ---------------------------------------------------------------------------
+
+
+def urlopen_with_retry(req, timeout: int = 30):
+    """Open a URL with retries on transient errors."""
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            if attempt == MAX_RETRIES:
+                raise
+            print(f"[RETRY] attempt {attempt}/{MAX_RETRIES} failed: {exc}")
+            time.sleep(2 ** attempt)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helper
+# ---------------------------------------------------------------------------
+
+
+def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run a subprocess, printing the command that is executed."""
+    print(f"[RUN] {' '.join(shlex.quote(str(a)) for a in cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.returncode != 0 and result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, result.stdout, result.stderr
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (gh CLI)
+# ---------------------------------------------------------------------------
+
+
+def ensure_label(label: str) -> None:
+    """Verify that the label exists in the repo; raise if it does not."""
+    result = run(
+        [
+            "gh",
+            "label",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--search",
+            label,
+            "--json",
+            "name",
+        ],
+    )
+    existing = [entry["name"] for entry in json.loads(result.stdout or "[]")]
+    if label not in existing:
+        raise RuntimeError(
+            f"Label '{label}' not found in {ROCGDB_REPO}. "
+            "Please create it in the repo settings before running."
+        )
+
+
+def find_open_update_pr() -> str | None:
+    """Return the URL of an open, labelled update PR if one exists, else None."""
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            BASE_BRANCH,
+            "--state",
+            "open",
+            "--label",
+            UPDATE_LABEL,
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+    )
+    url = (result.stdout or "").strip()
+    return url if url else None
+
+
+# ---------------------------------------------------------------------------
+# Fetch latest references
+# ---------------------------------------------------------------------------
+
+
+def get_therock_commit() -> tuple[str, str]:
+    """Return (commit_sha, today) for TheRock's main branch."""
+    result = run(["git", "ls-remote", THEROCK_REPO_URL, "refs/heads/main"])
+    parts = result.stdout.split()
+    commit = parts[0] if parts else ""
+    if not SHA_RE.match(commit):
+        raise ValueError(f"Invalid TheRock SHA received: {commit!r}")
+    return commit, date.today().isoformat()
+
+
+def get_build_digest() -> tuple[str, str]:
+    """Return (digest, today) for the latest build container image.
+
+    Uses the OCI Distribution API directly — no external tools required.
+    The digest comes from the Docker-Content-Digest response header.
+    """
+    # GHCR requires an anonymous bearer token even for public images.
+    image_path = BUILD_IMAGE.removeprefix("ghcr.io/")
+    token_url = (
+        f"https://ghcr.io/token?scope=repository:{image_path}:pull&service=ghcr.io"
+    )
+    with urlopen_with_retry(token_url) as resp:
+        token = json.loads(resp.read())["token"]
+
+    req = urllib.request.Request(
+        f"https://ghcr.io/v2/{image_path}/manifests/latest",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": (
+                "application/vnd.docker.distribution.manifest.v2+json,"
+                "application/vnd.oci.image.manifest.v1+json,"
+                "application/vnd.oci.image.index.v1+json"
+            ),
+        },
+    )
+    with urlopen_with_retry(req) as resp:
+        digest = resp.headers.get("Docker-Content-Digest", "")
+
+    if not DIGEST_RE.match(digest):
+        raise ValueError(f"Invalid build image digest received: {digest!r}")
+    return digest, date.today().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# File update
+# ---------------------------------------------------------------------------
+
+
+def read_current(content: str) -> dict[str, str]:
+    """Extract the current commit ref and build digest from the CI workflow content."""
+    values: dict[str, str] = {}
+    commit = re.search(r"THEROCK_COMMIT_REF:\s+([0-9a-f]{40})", content)
+    if commit:
+        values["commit"] = commit.group(1)
+    digest = re.search(re.escape(BUILD_IMAGE) + r"@(sha256:[0-9a-f]{64})", content)
+    if digest:
+        values["build_digest"] = digest.group(1)
+    return values
+
+
+def render_ci_linux(
+    content: str, commit: str, commit_date: str, build_digest: str, build_date: str
+) -> str:
+    """Return updated content for the CI workflow.
+
+    Pure: does not write to disk. Raises if either expected pattern is not found.
+    """
+    updated, n = re.subn(
+        r"THEROCK_COMMIT_REF: .* # .*",
+        f"THEROCK_COMMIT_REF: {commit} # {commit_date}",
+        content,
+    )
+    if n != 1:
+        raise ValueError(
+            f"Expected exactly 1 match for THEROCK_COMMIT_REF pattern, got {n}. "
+            "Check that the line has a trailing '# date' comment."
+        )
+    updated, n = re.subn(
+        re.escape(BUILD_IMAGE) + r"@sha256:[0-9a-f]+ # .*",
+        f"{BUILD_IMAGE}@{build_digest} # {build_date}",
+        updated,
+    )
+    if n != 1:
+        raise ValueError(
+            f"Expected exactly 1 match for build image pattern, got {n}. "
+            "Check that the line has a trailing '# date' comment."
+        )
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Branch / commit / PR
+# ---------------------------------------------------------------------------
+
+
+def build_commit_message(old: dict[str, str], commit: str, digest: str) -> str:
+    lines = ["Update TheRock dependencies and container images", ""]
+    old_commit = old.get("commit")
+    if old_commit and old_commit != commit:
+        lines.append(f"commit: {old_commit[:12]} -> {commit[:12]}")
+    old_digest = old.get("build_digest")
+    if old_digest and old_digest != digest:
+        lines.append(f"build image: {old_digest[:19]}... -> {digest[:19]}...")
+    return "\n".join(lines)
+
+
+def open_update_pr(branch: str, commit: str) -> str:
+    title = f"Update TheRock dependencies ({date.today().isoformat()})"
+    body = (
+        "## Automated TheRock dependency update\n\n"
+        f"Bumps `THEROCK_COMMIT_REF` to `{commit[:12]}` and refreshes the "
+        "`therock_build_manylinux_x86_64` build container digest in "
+        "`.github/workflows/therock-ci-linux.yml`.\n\n"
+        "Opened automatically by the TheRock dependency update workflow. "
+        "Please kick CI manually (close and reopen, or push an empty commit), "
+        "then merge."
+    )
+    ensure_label(UPDATE_LABEL)
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            ROCGDB_REPO,
+            "--base",
+            BASE_BRANCH,
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            UPDATE_LABEL,
+        ],
+    )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def summary(result: str, pr: str | None = None) -> None:
+    print("\n=== Summary ===")
+    print(f"Result: {result}")
+    if pr:
+        print(f"PR: {pr}")
+
+
+def run_update(dry_run: bool) -> str:
+    if not CI_LINUX.exists():
+        raise FileNotFoundError(f"{CI_LINUX} not found; run from the repo root.")
+
+    if not dry_run:
+        existing = find_open_update_pr()
+        if existing:
+            print(f"Open update PR already exists: {existing}")
+            summary("skipped-existing-pr", existing)
+            return "skipped-existing-pr"
+
+    content = CI_LINUX.read_text()
+    old = read_current(content)
+    commit, commit_date = get_therock_commit()
+    build_digest, build_date = get_build_digest()
+
+    updated = render_ci_linux(content, commit, commit_date, build_digest, build_date)
+    if updated == content:
+        print("\nReferences already current; nothing to update.")
+        summary("not-needed")
+        return "not-needed"
+
+    print("\nUpdating references:")
+    if old.get("commit") != commit:
+        print(f"  commit:      {old.get('commit', '?')[:12]} -> {commit[:12]}")
+    if old.get("build_digest") != build_digest:
+        print(
+            f"  build image: {old.get('build_digest', '?')[:19]}... "
+            f"-> {build_digest[:19]}..."
+        )
+
+    if dry_run:
+        summary("dry-run")
+        return "dry-run"
+
+    branch = f"{BRANCH_PREFIX}-{commit_date}-{commit[:8]}"
+    message = build_commit_message(old, commit, build_digest)
+
+    run(["git", "checkout", "-B", branch])
+    CI_LINUX.write_text(updated)
+    run(["git", "add", str(CI_LINUX)])
+    run(["git", "commit", "-m", message])
+    run(["git", "push", "origin", branch])
+
+    pr = open_update_pr(branch, commit)
+    summary("created", pr)
+    return "created"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update TheRock references in ROCgdb's CI workflow."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and update the file, print the diff, but skip branch, "
+        "commit, push and PR creation.",
+    )
+    args = parser.parse_args()
+
+    try:
+        run_update(args.dry_run)
+        return 0
+    except Exception as exc:  # noqa: BLE001 - surface any failure as a red run
+        print(f"Error: {exc}", file=sys.stderr)
+        summary("error")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  THEROCK_COMMIT_REF: 013e3cb9928a76b2eea52151b29dc18473a8cdbe # 2026-07-23
+  THEROCK_COMMIT_REF: 2ee541083481e6c93f2ea811f212b61047980b1a # 2026-07-30
 
 jobs:
   therock-build-linux:
@@ -25,7 +25,7 @@ jobs:
     outputs:
       therock_ref: ${{ steps.export-ref.outputs.therock_ref }}
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6 # 2026-06-11
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:8616d086df21bcc835aed5112ff0d878530a0cf5433f8f42c7b28b973a75bb19 # 2026-07-27
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/therock-deps-update.yml
+++ b/.github/workflows/therock-deps-update.yml
@@ -1,0 +1,41 @@
+name: Update TheRock Dependencies
+
+on:
+  # schedule: # runs twice daily (03:17 and 15:17 UTC)
+  #   - cron: '17 3 * * *'
+  #   - cron: '17 15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (fetch and print changes, but skip branch/commit/push/PR creation)'
+        type: boolean
+        default: true
+
+# Deny-all by default; grant writes only on the job that needs them.
+permissions: {}
+
+concurrency:
+  group: therock-deps-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure git identity and credentials
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global credential.helper "!gh auth git-credential"
+
+      - name: Update TheRock references
+        run: |
+          python3 .github/scripts/update_therock_deps.py ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -7,6 +7,11 @@ Full documentation for ROCgdb is available at
 
 ### Added
 
+- The "catch hiperr" feature is now exposed to MI too, with a new
+  `-catch-hiperr` command and related fields in `*stopped` records.
+  See the "HIP Runtime Error" subsection of the "GDB/MI Catchpoint
+  Commands" section in the ROCgdb manual.
+
 - Dumping core of AMD GPU programs with the "gcore" command is now
   significantly faster, particularly for kernels that use small
   amounts of VRAM.

--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -1828,15 +1828,15 @@ amd64_linux_remove_non_address_bits_watchpoint (gdbarch *gdbarch,
   return (addr & amd64_linux_lam_untag_mask ());
 }
 
-/* The AMD64 Linux ABI version of fetch_hiperr_parameters.  */
+/* The AMD64 Linux ABI version of fetch_hiperr_info.  */
 
-static std::optional<hiperr_parameters>
-amd64_linux_fetch_hiperr_parameters (frame_info_ptr frame)
+static std::optional<hiperr_info>
+amd64_linux_fetch_hiperr_info (frame_info_ptr frame)
 {
   CORE_ADDR struct_addr
     = value_as_address (value_of_register (AMD64_RDI_REGNUM, frame));
 
-  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+  return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
 static void
@@ -1894,9 +1894,9 @@ amd64_linux_init_abi_common(struct gdbarch_info info, struct gdbarch *gdbarch,
   set_gdbarch_remove_non_address_bits_watchpoint
     (gdbarch, amd64_linux_remove_non_address_bits_watchpoint);
 
-  /* Extract hiperr parameters for 'catch hiperr'.  */
-  set_gdbarch_fetch_hiperr_parameters
-    (gdbarch, amd64_linux_fetch_hiperr_parameters);
+  /* Extract hiperr info for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_info
+    (gdbarch, amd64_linux_fetch_hiperr_info);
 }
 
 static void

--- a/gdb/amd64-tdep.c
+++ b/gdb/amd64-tdep.c
@@ -1061,10 +1061,10 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
 }
 
 
-/* Extract HIP error parameters from the STRUCT_ADDR which is
-   a struct address passed to "__hipOnError ()" as an argument.
+/* Extract HIP error info from the STRUCT_ADDR which is a struct
+   address passed to "__hipOnError ()" as an argument.
 
-   Only when all the parameters are retrieved successfully, return
+   Only when all the fields are retrieved successfully, return
    them as the result.  Otherwise [1], return an std::nullopt.
 
    [1]
@@ -1073,10 +1073,10 @@ amd64_push_dummy_call (struct gdbarch *gdbarch, struct value *function,
    - Not all the strings were read successfully
 */
 
-std::optional<hiperr_parameters>
-amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
+std::optional<hiperr_info>
+amd64_fetch_hiperr_info (frame_info_ptr frame, CORE_ADDR struct_addr)
 {
-  /* The HIP error parameters are packed in a struct with the following format:
+  /* The HIP error info is packed in a struct with the following format:
 
      struct {
 	uint32_t version;
@@ -1088,7 +1088,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
     The "version" is bumped when more fields are added to the structure.
     Newer versions must keep backward compatibility with the previous ones,
     by only tacking new fields at the end of the structure, so that older
-    clients can still extract the parameters they know.
+    clients can still extract the fields they know.
   */
 
   /* Cover the version (4), number (4) and two pointers (2*8).  */
@@ -1109,7 +1109,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
      compatible.  See note above.  */
   if (version < 1)
     {
-      warning (_("version '%s' for HIP error parameters is not supported."),
+      warning (_("version '%s' for HIP error info is not supported."),
 	       pulongest (version));
       return std::nullopt;
     }
@@ -1131,7 +1131,7 @@ amd64_fetch_hiperr_parameters (frame_info_ptr frame, CORE_ADDR struct_addr)
     return std::nullopt;
   err_str = std::move (str);
 
-  return hiperr_parameters {err_no, std::move (err_name), std::move (err_str)};
+  return hiperr_info {err_no, std::move (err_name), std::move (err_str)};
 }
 
 

--- a/gdb/amd64-tdep.h
+++ b/gdb/amd64-tdep.h
@@ -134,10 +134,10 @@ extern void amd64_collect_fxsave (const struct regcache *regcache, int regnum,
 extern void amd64_collect_xsave (const struct regcache *regcache,
 				 int regnum, void *xsave, int gcore);
 
-/* Helper routine to fetch error parameters of a HIP error from the
-   STRUCT_ADDR within the FRAME context.  */
+/* Helper routine to fetch HIP error information from the STRUCT_ADDR
+   within the FRAME context.  */
 
-extern std::optional<hiperr_parameters> amd64_fetch_hiperr_parameters
+extern std::optional<hiperr_info> amd64_fetch_hiperr_info
   (frame_info_ptr frame, CORE_ADDR struct_addr);
 
 /* Floating-point register set. */

--- a/gdb/amd64-windows-tdep.c
+++ b/gdb/amd64-windows-tdep.c
@@ -1280,15 +1280,15 @@ amd64_windows_auto_wide_charset (void)
   return "UTF-16";
 }
 
-/* The AMD64 Windows ABI version of fetch_hiperr_parameters.  */
+/* The AMD64 Windows ABI version of fetch_hiperr_info.  */
 
-static std::optional<hiperr_parameters>
-amd64_windows_fetch_hiperr_parameters (frame_info_ptr frame)
+static std::optional<hiperr_info>
+amd64_windows_fetch_hiperr_info (frame_info_ptr frame)
 {
   CORE_ADDR struct_addr
     = value_as_address (value_of_register (AMD64_RCX_REGNUM, frame));
 
-  return amd64_fetch_hiperr_parameters (frame, struct_addr);
+  return amd64_fetch_hiperr_info (frame, struct_addr);
 }
 
 /* Common parts for gdbarch initialization for Windows and Cygwin on AMD64.  */
@@ -1335,9 +1335,9 @@ amd64_windows_init_abi_common (gdbarch_info info, struct gdbarch *gdbarch)
 
   set_gdbarch_auto_wide_charset (gdbarch, amd64_windows_auto_wide_charset);
 
-  /* Extract hiperr parameters for 'catch hiperr'.  */
-  set_gdbarch_fetch_hiperr_parameters
-    (gdbarch, amd64_windows_fetch_hiperr_parameters);
+  /* Extract hiperr info for 'catch hiperr'.  */
+  set_gdbarch_fetch_hiperr_info
+    (gdbarch, amd64_windows_fetch_hiperr_info);
 }
 
 /* gdbarch initialization for Windows on AMD64.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -144,29 +144,6 @@ hiperr_frame_p (frame_info_ptr frame)
   return true;
 }
 
-/* Format the HIP error info as a string (with newline) for printing.
-   Returns an empty string if the information cannot be fetched.  */
-
-static std::string
-hiperr_info_string (struct gdbarch *gdbarch)
-{
-  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
-
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
-    return std::string ();
-
-  std::optional<hiperr_info> err_info
-    = gdbarch_fetch_hiperr_info (gdbarch, frame);
-
-  if (!err_info.has_value ())
-    return std::string ();
-
-  return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
-			err_info->err_name.get (),
-			err_info->err_no,
-			err_info->err_str.get ());
-}
-
 /* Message printed when the breakpoint is hit.  */
 
 enum print_stop_action
@@ -185,10 +162,19 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
   print_num_locno (bs, uiout);
   uiout->text (" (HIP error)\n");
 
-  const std::string hiperr_info_str
-    = hiperr_info_string (bs->bp_location_at->gdbarch);
-  if (!hiperr_info_str.empty ())
+  std::optional<hiperr_info> err_info;
+  frame_info_ptr frame = get_selected_frame (_("No frame selected"));
+  struct gdbarch *barch = bs->bp_location_at->gdbarch;
+  if (hiperr_frame_p (frame) && gdbarch_fetch_hiperr_info_p (barch))
+    err_info = gdbarch_fetch_hiperr_info (barch, frame);
+
+  if (err_info.has_value ())
     {
+      const std::string hiperr_info_str
+	= string_printf (_("HIP API call failed with error %s (%u): %s\n"),
+			 err_info->err_name.get (),
+			 err_info->err_no,
+			 err_info->err_str.get ());
       uiout->text (hiperr_info_str.c_str ());
       uiout->text
 	("\nThe $_hiperr convenience variable holds the error number.\n");
@@ -201,9 +187,26 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
       uiout->field_string ("reason",
 			   async_reason_lookup (EXEC_ASYNC_BREAKPOINT_HIT));
       uiout->field_string ("disp", bpdisp_text (disposition));
+
+      if (err_info.has_value ())
+	{
+	  uiout->field_unsigned ("hiperr-code", err_info->err_no);
+	  uiout->field_string ("hiperr-name", err_info->err_name.get ());
+	  uiout->field_string ("hiperr-str", err_info->err_str.get ());
+	}
     }
 
   return PRINT_NOTHING;
+}
+
+/* Instantiate a hiperr_catchpoint.  */
+
+void
+add_catch_hiperr (const char *condition, bool tempflag)
+{
+  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
+						  tempflag, condition);
+  install_breakpoint (0, std::move (hcp), 1);
 }
 
 /* Implementation of "catch hiperr" command.  */
@@ -224,10 +227,7 @@ catch_hiperr_command (const char *arg,
   if ((*arg != '\0') && !isspace (*arg))
     error (_("Junk at the end of arguments."));
 
-  auto hcp = std::make_unique<hiperr_catchpoint> (get_current_arch (),
-						  tempflag, cond_string);
-
-  install_breakpoint (0, std::move (hcp), 1);
+  add_catch_hiperr (cond_string, tempflag);
 }
 
 

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -148,26 +148,26 @@ hiperr_frame_p (frame_info_ptr frame)
 }
 
 /* Format the HIP error info as a string (with newline) for printing.
-   Returns an empty string if the parameters cannot be fetched.  */
+   Returns an empty string if the information cannot be fetched.  */
 
 static std::string
 hiperr_info_string (struct gdbarch *gdbarch)
 {
   frame_info_ptr frame = get_selected_frame (_("No frame selected"));
 
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
     return std::string ();
 
-  std::optional<hiperr_parameters> err_params
-    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+  std::optional<hiperr_info> err_info
+    = gdbarch_fetch_hiperr_info (gdbarch, frame);
 
-  if (!err_params.has_value ())
+  if (!err_info.has_value ())
     return std::string ();
 
   return string_printf (_("HIP API call failed with error %s (%u): %s\n"),
-			err_params->err_name.get (),
-			err_params->err_no,
-			err_params->err_str.get ());
+			err_info->err_name.get (),
+			err_info->err_no,
+			err_info->err_str.get ());
 }
 
 /* Message printed when the breakpoint is hit.  */
@@ -188,11 +188,11 @@ hiperr_catchpoint::print_it (const bpstat *bs) const
   print_num_locno (bs, uiout);
   uiout->text (" (HIP error)\n");
 
-  const std::string hiperr_info
+  const std::string hiperr_info_str
     = hiperr_info_string (bs->bp_location_at->gdbarch);
-  if (!hiperr_info.empty ())
+  if (!hiperr_info_str.empty ())
     {
-      uiout->text (hiperr_info.c_str ());
+      uiout->text (hiperr_info_str.c_str ());
       uiout->text
 	("\nThe $_hiperr convenience variable holds the error number.\n");
     }
@@ -244,13 +244,13 @@ compute_hiperr (struct gdbarch *gdbarch,
 {
   frame_info_ptr frame = get_selected_frame (_("No frame selected"));
 
-  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_parameters_p (gdbarch))
+  if (!hiperr_frame_p (frame) || !gdbarch_fetch_hiperr_info_p (gdbarch))
     return value::allocate (builtin_type (gdbarch)->builtin_void);
 
-  std::optional<hiperr_parameters> err_params
-    = gdbarch_fetch_hiperr_parameters (gdbarch, frame);
+  std::optional<hiperr_info> err_info
+    = gdbarch_fetch_hiperr_info (gdbarch, frame);
 
-  if (!err_params.has_value ())
+  if (!err_info.has_value ())
     return value::allocate (builtin_type (gdbarch)->builtin_void);
 
   /* If there's a "hipError_t" type in the debug symbols that is
@@ -263,13 +263,13 @@ compute_hiperr (struct gdbarch *gdbarch,
     {
       gdb_byte err_no[4];
       const bfd_endian byte_order = gdbarch_byte_order (gdbarch);
-      store_unsigned_integer (err_no, 4, byte_order, err_params->err_no);
+      store_unsigned_integer (err_no, 4, byte_order, err_info->err_no);
       return value_from_contents (bs.symbol->type (), err_no);
     }
 
   /* Return hiperr as an unsigned int.  */
   return value_from_ulongest (builtin_type (gdbarch)->builtin_uint32,
-			      err_params->err_no);
+			      err_info->err_no);
 }
 
 /* Implementation of the '$_hiperr' variable.  */

--- a/gdb/break-catch-hiperr.c
+++ b/gdb/break-catch-hiperr.c
@@ -36,11 +36,6 @@ struct hiperr_catchpoint : public code_breakpoint
 		     const char *cond_string)
     : code_breakpoint (gdbarch, bp_catchpoint, temp, cond_string)
   {
-    /* Make sure "locspec" is initialized, irrespective of the
-       "__hipOnError ()" symbol being found.  This allows listing the
-       breakpoint as a pending one when the binary is not loaded yet.
-       Otherwise, "info breakpoints" is going to trigger an assert.  */
-    locspec = new_explicit_location_spec_function ("__hipOnError");
     pspace = current_program_space;
     re_set (nullptr);
   }
@@ -71,7 +66,9 @@ hiperr_catchpoint::re_set (program_space * /*ps*/)
 
   try
     {
-      sals = this->decode_location_spec (this->locspec.get (),
+      location_spec_up locspec
+	= new_explicit_location_spec_function ("__hipOnError");
+      sals = this->decode_location_spec (locspec.get (),
 					 current_program_space);
     }
   catch (const gdb_exception_error &ex)

--- a/gdb/breakpoint.h
+++ b/gdb/breakpoint.h
@@ -2094,6 +2094,13 @@ extern void catch_exception_event (enum exception_event_kind ex_event,
 				   const char *regex, bool tempflag,
 				   int from_tty);
 
+/* Catch a HIP error according to the input arguments.  If CONDITION is
+   provided, only failures that satisfy it will trigger the catchpoint.
+   If TEMPFLAG is set, the catchpoint is triggered once and then it
+   is removed.  */
+
+extern void add_catch_hiperr (const char *condition, bool tempflag);
+
 /* Return true if BPT is of any hardware watchpoint kind.  */
 
 bool is_hardware_watchpoint (const struct breakpoint *bpt);

--- a/gdb/doc/gdb.texinfo
+++ b/gdb/doc/gdb.texinfo
@@ -36164,6 +36164,7 @@ catchpoints.
 * Shared Library GDB/MI Catchpoint Commands::
 * Ada Exception GDB/MI Catchpoint Commands::
 * C++ Exception GDB/MI Catchpoint Commands::
+* HIP Runtime Error GDB/MI Catchpoint Commands::
 @end menu
 
 @node Shared Library GDB/MI Catchpoint Commands
@@ -36501,6 +36502,74 @@ and @samp{tcatch catch} (@pxref{Set Catchpoints}).
   thread-id="1",stopped-threads="all",core="6"
 (gdb)
 @end smallexample
+
+@node HIP Runtime Error GDB/MI Catchpoint Commands
+@subsection HIP Runtime Error @sc{gdb/mi} Catchpoints
+
+The following @sc{gdb/mi} commands can be used to create catchpoints
+that stop the execution when HIP runtime errors are being returned.
+
+@findex -catch-hiperr
+@subheading The @code{-catch-hiperr} Command
+
+@subsubheading Synopsis
+
+@smallexample
+ -catch-hiperr [ -c @var{condition} ] [ -t ]
+@end smallexample
+
+Stop when the debuggee catches a HIP runtime error.
+
+@table @samp
+@item -c @var{condition}
+Make the catchpoint conditional on @var{condition}.
+@item -t
+Create a temporary catchpoint.
+@end table
+
+@subsubheading @value{GDBN} Command
+
+The corresponding @value{GDBN} commands are @samp{catch hiperr} and
+@samp{tcatch hiperr} (@pxref{catch hiperr}).
+
+@subsubheading Example
+
+@smallexample
+-catch-hiperr -c $_hiperr==hipErrorInvalidDevice -t
+^done,bkpt=@{number="1",type="catchpoint",disp="del",enabled="y",
+  what="catch hiperr",catch-type="hiperr",
+  cond="$_hiperr==hipErrorInvalidDevice",times="0"@}
+(gdb)
+-exec-run
+^running
+(gdb)
+~"\n"
+~"Thread 1 \"hip\" hit Temporary catchpoint 1 (HIP error)\n"
+~"HIP API call failed with error hipErrorInvalidDevice (101):
+  invalid device ordinal\n"
+~"\n"
+~"The $_hiperr convenience variable holds the error number.\n"
+*stopped,bkptno="1",reason="breakpoint-hit",disp="del",
+  hiperr-code="101",hiperr-name="hipErrorInvalidDevice",
+  hiperr-str="invalid device ordinal",thread-id="1",
+  stopped-threads="all",core="0"
+=breakpoint-deleted,id="1"
+@end smallexample
+
+The @samp{*stopped} record is extended with three fields:
+
+@table @samp
+
+@item hiperr-code
+The error number.
+
+@item hiperr-name
+The name of the error.
+
+@item hiperr-str
+The descriptive text about the error.
+
+@end table
 
 @c %%%%%%%%%%%%%%%%%%%%%%%%%%%% SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 @node GDB/MI Program Context

--- a/gdb/gcore.c
+++ b/gdb/gcore.c
@@ -772,6 +772,12 @@ sparse_bfd_set_section_contents (bfd *obfd, asection *osec,
   return true;
 }
 
+/* Fallback page size to use when target_read_memory fails when attempting
+   to read MAX_COPY_BYTES in gcore_copy_callback.  4KB is the correct size
+   to use for x86 and most other architectures.  Some may have larger pages,
+   but this size will still work at the cost of more syscalls.  */
+#define FALLBACK_PAGE_SIZE 0x1000
+
 static void
 gcore_copy_callback (bfd *obfd, asection *osec)
 {
@@ -794,15 +800,45 @@ gcore_copy_callback (bfd *obfd, asection *osec)
       if (size > total_size)
 	size = total_size;
 
-      if (target_read_memory (bfd_section_vma (osec) + offset,
-			      memhunk.data (), size) != 0)
+      CORE_ADDR vma = bfd_section_vma (osec) + offset;
+
+      if (target_read_memory (vma, memhunk.data (), size) != 0)
 	{
-	  warning (_("Memory read failed for corefile "
-		     "section, %s bytes at %s."),
-		   plongest (size),
-		   paddress (current_inferior ()->arch (),
-			     bfd_section_vma (osec)));
-	  break;
+	  /* Large read failed.  This can happen when the memory region
+	     contains unreadable pages (such as guard pages embedded within
+	     a larger mapping).  Fall back to reading page by page, filling
+	     unreadable pages with zeros.  */
+	  gdb_byte *p = memhunk.data ();
+	  bfd_size_type remaining = size;
+	  CORE_ADDR addr = vma;
+	  bool at_least_one_page_read = false;
+
+	  while (remaining > 0)
+	    {
+	      bfd_size_type chunk_size
+		= std::min (remaining, (bfd_size_type) FALLBACK_PAGE_SIZE);
+
+	      if (target_read_memory (addr, p, chunk_size) != 0)
+		{
+		  /* Failed to read this page.  Fill with zeros.  This
+		     handles guard pages and other unreadable regions
+		     that may exist within a larger readable mapping.  */
+		  memset (p, 0, chunk_size);
+		}
+	      else
+		at_least_one_page_read = true;
+
+	      p += chunk_size;
+	      addr += chunk_size;
+	      remaining -= chunk_size;
+	    }
+	  /* Warn only if the entire region was unreadable - this
+	     indicates a real problem, not just embedded guard pages. */
+	  if (!at_least_one_page_read)
+	    warning (_("Memory read failed for corefile "
+		       "section, %s bytes at %s."),
+		     plongest (size),
+		     paddress (current_inferior ()->arch (), vma));
 	}
 
       if (!sparse_bfd_set_section_contents (obfd, osec, memhunk.data (),

--- a/gdb/gcore.c
+++ b/gdb/gcore.c
@@ -38,6 +38,7 @@
 #include "gdbsupport/gdb_unlinker.h"
 #include "gdbsupport/byte-vector.h"
 #include "gdbsupport/scope-exit.h"
+#include "auxv.h"
 
 /* To generate sparse cores, we look at the data to write in chunks of
    this size when considering whether to skip the write.  Only if we
@@ -795,6 +796,11 @@ gcore_copy_callback (bfd *obfd, asection *osec)
   size = std::min (total_size, (bfd_size_type) MAX_COPY_BYTES);
   gdb::byte_vector memhunk (size);
 
+  bfd_size_type page_size = FALLBACK_PAGE_SIZE;
+  CORE_ADDR at_pagesz;
+  if (target_auxv_search (AT_PAGESZ, &at_pagesz) > 0)
+    page_size = (bfd_size_type) at_pagesz;
+
   while (total_size > 0)
     {
       if (size > total_size)
@@ -815,8 +821,7 @@ gcore_copy_callback (bfd *obfd, asection *osec)
 
 	  while (remaining > 0)
 	    {
-	      bfd_size_type chunk_size
-		= std::min (remaining, (bfd_size_type) FALLBACK_PAGE_SIZE);
+	      bfd_size_type chunk_size = std::min (remaining, page_size);
 
 	      if (target_read_memory (addr, p, chunk_size) != 0)
 		{

--- a/gdb/gdbarch-gen.c
+++ b/gdb/gdbarch-gen.c
@@ -184,7 +184,7 @@ struct gdbarch
   gdbarch_address_class_name_to_type_flags_ftype *address_class_name_to_type_flags = nullptr;
   gdbarch_register_reggroup_p_ftype *register_reggroup_p = default_register_reggroup_p;
   gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument = nullptr;
-  gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters = nullptr;
+  gdbarch_fetch_hiperr_info_ftype *fetch_hiperr_info = nullptr;
   gdbarch_iterate_over_regset_sections_ftype *iterate_over_regset_sections = nullptr;
   gdbarch_make_corefile_notes_ftype *make_corefile_notes = nullptr;
   gdbarch_find_memory_regions_ftype *find_memory_regions = nullptr;
@@ -473,7 +473,7 @@ verify_gdbarch (struct gdbarch *gdbarch)
   /* Skip verify of address_class_name_to_type_flags, has predicate.  */
   /* Skip verify of register_reggroup_p, invalid_p == 0.  */
   /* Skip verify of fetch_pointer_argument, has predicate.  */
-  /* Skip verify of fetch_hiperr_parameters, has predicate.  */
+  /* Skip verify of fetch_hiperr_info, has predicate.  */
   /* Skip verify of iterate_over_regset_sections, has predicate.  */
   /* Skip verify of make_corefile_notes, has predicate.  */
   /* Skip verify of find_memory_regions, has predicate.  */
@@ -1100,11 +1100,11 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
 	      "gdbarch_dump: fetch_pointer_argument = <%s>\n",
 	      host_address_to_string (gdbarch->fetch_pointer_argument));
   gdb_printf (file,
-	      "gdbarch_dump: gdbarch_fetch_hiperr_parameters_p() = %d\n",
-	      gdbarch_fetch_hiperr_parameters_p (gdbarch));
+	      "gdbarch_dump: gdbarch_fetch_hiperr_info_p() = %d\n",
+	      gdbarch_fetch_hiperr_info_p (gdbarch));
   gdb_printf (file,
-	      "gdbarch_dump: fetch_hiperr_parameters = <%s>\n",
-	      host_address_to_string (gdbarch->fetch_hiperr_parameters));
+	      "gdbarch_dump: fetch_hiperr_info = <%s>\n",
+	      host_address_to_string (gdbarch->fetch_hiperr_info));
   gdb_printf (file,
 	      "gdbarch_dump: gdbarch_iterate_over_regset_sections_p() = %d\n",
 	      gdbarch_iterate_over_regset_sections_p (gdbarch));
@@ -4055,27 +4055,27 @@ set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch,
 }
 
 bool
-gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch)
+gdbarch_fetch_hiperr_info_p (struct gdbarch *gdbarch)
 {
   gdb_assert (gdbarch != NULL);
-  return gdbarch->fetch_hiperr_parameters != NULL;
+  return gdbarch->fetch_hiperr_info != NULL;
 }
 
-std::optional<hiperr_parameters>
-gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame)
+std::optional<hiperr_info>
+gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, frame_info_ptr frame)
 {
   gdb_assert (gdbarch != NULL);
-  gdb_assert (gdbarch->fetch_hiperr_parameters != NULL);
+  gdb_assert (gdbarch->fetch_hiperr_info != NULL);
   if (gdbarch_debug >= 2)
-    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_parameters called\n");
-  return gdbarch->fetch_hiperr_parameters (frame);
+    gdb_printf (gdb_stdlog, "gdbarch_fetch_hiperr_info called\n");
+  return gdbarch->fetch_hiperr_info (frame);
 }
 
 void
-set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch,
-				     gdbarch_fetch_hiperr_parameters_ftype fetch_hiperr_parameters)
+set_gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch,
+			       gdbarch_fetch_hiperr_info_ftype fetch_hiperr_info)
 {
-  gdbarch->fetch_hiperr_parameters = fetch_hiperr_parameters;
+  gdbarch->fetch_hiperr_info = fetch_hiperr_info;
 }
 
 bool

--- a/gdb/gdbarch-gen.h
+++ b/gdb/gdbarch-gen.h
@@ -1040,15 +1040,15 @@ typedef CORE_ADDR (gdbarch_fetch_pointer_argument_ftype) (const frame_info_ptr &
 extern CORE_ADDR gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, const frame_info_ptr &frame, int argi, struct type *type);
 extern void set_gdbarch_fetch_pointer_argument (struct gdbarch *gdbarch, gdbarch_fetch_pointer_argument_ftype *fetch_pointer_argument);
 
-/* Fetch HIP error parameters from the FRAME's function arguments.
+/* Fetch HIP error information from the FRAME's function arguments.
    FRAME is the frame of a "__hipOnError ()" function.  On a successful
-   run, return the parameters.  Otherwise, return a std::nullopt. */
+   run, return the info.  Otherwise, return a std::nullopt. */
 
-extern bool gdbarch_fetch_hiperr_parameters_p (struct gdbarch *gdbarch);
+extern bool gdbarch_fetch_hiperr_info_p (struct gdbarch *gdbarch);
 
-typedef std::optional<hiperr_parameters> (gdbarch_fetch_hiperr_parameters_ftype) (frame_info_ptr frame);
-extern std::optional<hiperr_parameters> gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, frame_info_ptr frame);
-extern void set_gdbarch_fetch_hiperr_parameters (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_parameters_ftype *fetch_hiperr_parameters);
+typedef std::optional<hiperr_info> (gdbarch_fetch_hiperr_info_ftype) (frame_info_ptr frame);
+extern std::optional<hiperr_info> gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, frame_info_ptr frame);
+extern void set_gdbarch_fetch_hiperr_info (struct gdbarch *gdbarch, gdbarch_fetch_hiperr_info_ftype *fetch_hiperr_info);
 
 /* Iterate over all supported register notes in a core file.  For each
    supported register note section, the iterator must call CB and pass

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -152,9 +152,9 @@ enum call_dummy_location_type
   AT_ENTRY_POINT,
 };
 
-/* The data structure holding the HIP error parameters.  */
+/* The data structure holding the HIP error information.  */
 
-struct hiperr_parameters
+struct hiperr_info
 {
   /* The error number.  */
   uint32_t err_no;
@@ -162,7 +162,7 @@ struct hiperr_parameters
   /* The string representing the error name.  */
   gdb::unique_xmalloc_ptr<char> err_name;
 
-  /* The string describing the error name.  */
+  /* The descriptive text about the error name.  */
   gdb::unique_xmalloc_ptr<char> err_str;
 };
 

--- a/gdb/gdbarch_components.py
+++ b/gdb/gdbarch_components.py
@@ -1781,12 +1781,12 @@ Fetch the pointer to the ith function argument.
 
 Function(
     comment="""
-Fetch HIP error parameters from the FRAME's function arguments.
+Fetch HIP error information from the FRAME's function arguments.
 FRAME is the frame of a "__hipOnError ()" function.  On a successful
-run, return the parameters.  Otherwise, return a std::nullopt.
+run, return the info.  Otherwise, return a std::nullopt.
 """,
-    type="std::optional<hiperr_parameters>",
-    name="fetch_hiperr_parameters",
+    type="std::optional<hiperr_info>",
+    name="fetch_hiperr_info",
     params=[
         ("frame_info_ptr", "frame"),
     ],

--- a/gdb/mi/mi-cmd-catch.c
+++ b/gdb/mi/mi-cmd-catch.c
@@ -359,3 +359,47 @@ mi_cmd_catch_catch (const char *cmd, const char *const *argv, int argc)
   mi_cmd_catch_exception_event (EX_EVENT_CATCH, cmd, argv, argc);
 }
 
+/* Handler for -catch-hiperr.  */
+
+void
+mi_cmd_catch_hiperr (const char *cmd, const char *const *argv, int argc)
+{
+  bool temp = false;
+  const char *condition = nullptr;
+
+  int oind = 0;
+  const char *oarg;
+
+  enum opt
+    {
+      OPT_CONDITION,
+      OPT_TEMP,
+    };
+  static const struct mi_opt opts[] =
+    {
+      { "c", OPT_CONDITION, 1 },
+      { "t", OPT_TEMP, 0 },
+      { 0, 0, 0 }
+    };
+
+  for (;;)
+    {
+      int opt = mi_getopt (cmd, argc, argv, opts, &oind, &oarg);
+
+      if (opt < 0)
+	break;
+
+      switch ((enum opt) opt)
+	{
+	case OPT_CONDITION:
+	  condition = oarg;
+	  break;
+	case OPT_TEMP:
+	  temp = true;
+	  break;
+	}
+    }
+
+  scoped_restore restore_breakpoint_reporting = setup_breakpoint_reporting ();
+  add_catch_hiperr (condition, temp);
+}

--- a/gdb/mi/mi-cmds.c
+++ b/gdb/mi/mi-cmds.c
@@ -238,6 +238,8 @@ add_builtin_mi_commands ()
 		 &mi_suppress_notification.breakpoint),
   add_mi_cmd_mi ("catch-catch", mi_cmd_catch_catch,
 		 &mi_suppress_notification.breakpoint),
+  add_mi_cmd_mi ("catch-hiperr", mi_cmd_catch_hiperr,
+		 &mi_suppress_notification.breakpoint),
   add_mi_cmd_mi ("complete", mi_cmd_complete);
   add_mi_cmd_mi ("data-disassemble", mi_cmd_disassemble);
   add_mi_cmd_mi ("data-evaluate-expression", mi_cmd_data_evaluate_expression);

--- a/gdb/mi/mi-cmds.h
+++ b/gdb/mi/mi-cmds.h
@@ -55,6 +55,7 @@ extern mi_cmd_argv_ftype mi_cmd_catch_unload;
 extern mi_cmd_argv_ftype mi_cmd_catch_throw;
 extern mi_cmd_argv_ftype mi_cmd_catch_rethrow;
 extern mi_cmd_argv_ftype mi_cmd_catch_catch;
+extern mi_cmd_argv_ftype mi_cmd_catch_hiperr;
 extern mi_cmd_argv_ftype mi_cmd_disassemble;
 extern mi_cmd_argv_ftype mi_cmd_data_evaluate_expression;
 extern mi_cmd_argv_ftype mi_cmd_data_list_register_names;

--- a/gdb/testsuite/gdb.debuginfod/corefile-mapped-file.exp
+++ b/gdb/testsuite/gdb.debuginfod/corefile-mapped-file.exp
@@ -345,7 +345,7 @@ gdb_assert { $ptr_value eq "unavailable" } \
 # shared library from debuginfod and use that to provide the file backed
 # mapping.
 if {![allow_debuginfod_tests]} {
-    untested "skippig debuginfod parts of this test"
+    untested "skipping debuginfod parts of this test"
     return
 }
 

--- a/gdb/testsuite/gdb.debuginfod/solib-with-soname.exp
+++ b/gdb/testsuite/gdb.debuginfod/solib-with-soname.exp
@@ -256,7 +256,7 @@ load_exec_and_core_file false false \
 # Setup a debuginfod server which can serve the original shared
 # library file.
 if {![allow_debuginfod_tests]} {
-    untested "skippig debuginfod parts of this test"
+    untested "skipping debuginfod parts of this test"
     return
 }
 

--- a/gdb/testsuite/gdb.rocm/alu-exceptions.exp
+++ b/gdb/testsuite/gdb.rocm/alu-exceptions.exp
@@ -23,6 +23,11 @@ load_lib rocm.exp
 
 require allow_hip_tests
 
+# With optimized device code, the compiler may promote integer division to
+# floating-point, so enabling the integer divide-by-zero exception mode does
+# not trigger a SIGFPE.  Skip for optimized builds.
+require no_optimized_code
+
 standard_testfile .cpp
 
 if {[build_executable "failed to prepare $testfile" $testfile $srcfile \

--- a/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-variables.exp
@@ -88,7 +88,7 @@ proc check_builtin_variables_values {} {
 	set num_z [set ${ref}_z]
 
 	gdb_test "p $var3d" "= {x = $num_x, y = $num_y, z = $num_z}" \
-	    "$var3d == $ref"
+	    "$var3d == \$$ref"
 	gdb_test "p ${var3d}.x" "$num_x" "${var3d}.x == $num_x"
 	gdb_test "p ${var3d}.y" "$num_y" "${var3d}.y == $num_y"
 	gdb_test "p ${var3d}.z" "$num_z" "${var3d}.z == $num_z"

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -21,10 +21,10 @@
 #include <hip/hip_runtime.h>
 #include "rocm-test-utils.h"
 
-/* If set, the "hip_* ()" functions will record the error parameters.  */
+/* If set, the "hip_* ()" functions will record the error info.  */
 static bool gen_ref = false;
 
-struct hiperr_params_ref
+struct hiperr_info_ref
 {
   volatile int no;  /* Prevent the optimizer from keeping this in a register.  */
   const char *name;
@@ -39,9 +39,9 @@ struct hiperr_params_ref
 };
 
 /* Reference values for the test.  */
-static hiperr_params_ref hip_set_device_err;
-static hiperr_params_ref hip_get_device_err;
-static hiperr_params_ref hip_launch_kernel_err;
+static hiperr_info_ref hip_set_device_err;
+static hiperr_info_ref hip_get_device_err;
+static hiperr_info_ref hip_launch_kernel_err;
 
 /* Get the maximum number of threads per block.  */
 
@@ -70,7 +70,7 @@ kernel ()
 }
 
 /* The purpose of these "hip_* ()" functions is to produce some errors
-   and have the error parameters recorded.  GDB can use these recorded
+   and have the error info recorded.  GDB can use these recorded
    values as references to verify the catchpoints outputs.  */
 
 /* Dispatch a kernel via the triple chevron syntax with an oversized

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -30,7 +30,7 @@ struct hiperr_info_ref
   const char *name;
   const char *str;
 
-  void save (hipError_t err_no)
+  void save (hipError_t err_no) volatile
   {
     no = static_cast <int> (err_no);
     name = hipGetErrorName (err_no);
@@ -39,9 +39,9 @@ struct hiperr_info_ref
 };
 
 /* Reference values for the test.  */
-static hiperr_info_ref hip_set_device_err;
-static hiperr_info_ref hip_get_device_err;
-static hiperr_info_ref hip_launch_kernel_err;
+volatile static hiperr_info_ref hip_set_device_err;
+volatile static hiperr_info_ref hip_get_device_err;
+volatile static hiperr_info_ref hip_launch_kernel_err;
 
 /* Get the maximum number of threads per block.  */
 
@@ -130,7 +130,8 @@ main (int argc, const char **argv)
       hip_set_device ();
       hip_get_device ();
       hip_launch_kernel ();
-      asm volatile ("" ::: "memory"); /* Break after reference initialization.  */
+      /* Break after reference initialization.  */
+      HOST_NOP;
     }
   else if (test == "one")
     hip_set_device ();

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.cpp
@@ -26,7 +26,7 @@ static bool gen_ref = false;
 
 struct hiperr_params_ref
 {
-  int no;
+  volatile int no;  /* Prevent the optimizer from keeping this in a register.  */
   const char *name;
   const char *str;
 
@@ -130,7 +130,7 @@ main (int argc, const char **argv)
       hip_set_device ();
       hip_get_device ();
       hip_launch_kernel ();
-      /* Break after reference initialization.  */
+      asm volatile ("" ::: "memory"); /* Break after reference initialization.  */
     }
   else if (test == "one")
     hip_set_device ();

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -16,20 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Test catching HIP's API errors:
+# Test catching HIP's API errors.  Test goals are:
 #
-# 1. The executable is loaded and started.
-# 2. The executable is loaded but not started.
-# 3. There's no executable set yet.
-# 4. Two API errors are returned and caught.
-# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
-# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
-# 7. Temporary catch of the first error, while there are 2 errors.
-# 8. $_hiperr is printed correctly when debug symbols are available.
-# 9. $_hiperr is printed correctly without debug symbols.
-#    This one checks if "catch hiperr" works without debug symbols as well.
+# - CLI: check catchpoints, either simple or complex (conditional or
+# temporary) are getting triggered correctly.  Also try without debug
+# symbols.
+#
+# - MI: parsing for the "-catch-hiperr ..." command.
+# - MI: catchpoints are set correctly and reported correctly when
+# triggered.
 
 load_lib rocm.exp
+load_lib mi-support.exp
 
 require allow_hip_tests
 
@@ -77,21 +75,29 @@ proc get_string_valueof {exp default} {
 }
 
 # Get the reference values from the program (which is run with "ref" argument)
+# Return true when all references are initialized; false, otherwise.
 
 proc init_reference_hip_errors {} {
     foreach func {set_device get_device launch_kernel} {
+	set sum 0
+
 	set ::hip_${func}_err_no [get_integer_valueof "hip_${func}_err.no" bad]
-	gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
-	    "hip_${func}_err_no initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_no] != "bad"} \
+		      "hip_${func}_err_no initialized"]
 
 	set ::hip_${func}_err_name [get_string_valueof "hip_${func}_err.name" bad]
-	gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
-	    "hip_${func}_err_name initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_name] != "bad"} \
+		      "hip_${func}_err_name initialized"]
 
 	set ::hip_${func}_err_str [get_string_valueof "hip_${func}_err.str" bad]
-	gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
-	    "hip_${func}_err_str initialized"
+	incr sum [gdb_assert {[set ::hip_${func}_err_str] != "bad"} \
+		      "hip_${func}_err_str initialized"]
+
+	if {$sum != 3} {
+	    return false
+	}
     }
+    return true
 }
 
 # Set a hiperr catchpoint and check if it set accordingly.  If TEMP is
@@ -187,12 +193,14 @@ proc check_hip_launch_kernel_err {cmd} {
 	$::hip_launch_kernel_err_str
 }
 
-proc do_test {} {
-    with_rocm_gpu_lock {
+# Check for __hipOnError symbol existence and initialize references
+# using the test program.  Return false if anything goes wrong.
 
+proc_with_prefix preparation_test {} {
+    with_rocm_gpu_lock {
 	clean_restart ${::testfile}.dbg
 	if {![runto_main]} {
-	    return
+	    return false
 	}
 	gdb_test_multiple "info symbol __hipOnError" \
 	    "check if __hipOnError symbol exists" {
@@ -201,21 +209,39 @@ proc do_test {} {
 	    }
 	    -re -wrap ".*" {
 		unsupported "no __hipOnError symbol was found"
-		return
+		return false
 	    }
 	}
 
 	# Let all the errors occur and their values be recorded by the program.
-	with_test_prefix "getting reference values" {
+	with_test_prefix "get ref vals" {
 	    clean_restart ${::testfile}.dbg
 	    gdb_test_no_output "set args ref"
 	    if {![runto [gdb_get_line_number \
 			    "Break after reference initialization"]]} {
-		return
+		return false
 	    }
-	    init_reference_hip_errors
+	    set res [init_reference_hip_errors]
 	}
+    }
+    return $res
+}
 
+# Test catching HIP's API errors (through CLI interface):
+#
+# 1. The executable is loaded and started.
+# 2. The executable is loaded but not started.
+# 3. There's no executable set yet.
+# 4. Two API errors are returned and caught.
+# 5. Implicit (stub) execution in the form of "kernel<<<...>>>();"
+# 6. Conditional catch of 1 error, using $_hiperr, while there are 2 errors.
+# 7. Temporary catch of the first error, while there are 2 errors.
+# 8. $_hiperr is printed correctly when debug symbols are available.
+# 9. $_hiperr is printed correctly without debug symbols.
+#    This one checks if "catch hiperr" works without debug symbols as well.
+
+proc_with_prefix cli_test {} {
+    with_rocm_gpu_lock {
 	with_test_prefix "after starting" {
 	    clean_restart ${::testfile}.dbg
 	    gdb_test_no_output "set args one"
@@ -329,6 +355,188 @@ proc do_test {} {
 		"print as $::hip_launch_kernel_err_no"
 	}
     }
+    gdb_exit
 }
 
-do_test
+# Return a string that looks like:
+#
+#   number="BP_NUM",type="catchpoint",disp="DISP",enabled="y",
+#   what="catch hiperr",catch-type="hiperr",cond="COND",
+#   times="0"
+#
+# The 'cond=...' field is added only if the provided COND is
+# not an empty string.
+
+proc hiperr_bkpt_re {bp_num disp cond} {
+    append bkpt "number=\"$bp_num\",type=\"catchpoint\",disp=\"$disp\","
+    append bkpt "enabled=\"y\",what=\"catch hiperr\",catch-type=\"hiperr\","
+    if {$cond != ""} {
+	append bkpt "cond=\"$cond\","
+    }
+    append bkpt "times=\"0\""
+    return $bkpt
+}
+
+
+# Check if the following commands are handled correctly:
+#
+# -catch-hiperr -c "$_hiperr == hipErrorInvalidDevice -t" -t
+# -catch-hiperr -c
+# -catch-hiperr -abc
+# -catch-hiperr one two three
+
+proc_with_prefix mi_parsing {} {
+    mi_clean_restart
+
+    # Each element is {TEST OPTIONS DISP COND ERR}, where TEST is the
+    # test name, OPTIONS are the extra "-catch-hiperr" options to
+    # test, DISP is the expected disposition ("keep" or "del"),
+    # COND is the expected condition ("" for none), and ERR is the
+    # expected error ("" for none) after issuing the MI command.
+    #
+    # Note that in the first case the "-t" embedded in the -c argument
+    # is part of the condition, while the trailing -t is what makes
+    # the catchpoint temporary.
+    set tests {
+	{ "trailing -t in condition"
+	  {-c "$_hiperr == hipErrorInvalidDevice -t" -t}
+	  del
+	  {$_hiperr == hipErrorInvalidDevice -t}
+	  "" }
+
+	{ "dangling -c"
+	  "-c"
+	  keep
+	  ""
+	  "Option -c requires an argument" }
+
+	{ "unknown option"
+	  "-abc"
+	  keep
+	  ""
+	  "Unknown option \`\`abc''" }
+
+	{ "trailing junk"
+	  "-t one two three"
+	  del
+	  ""
+	  "" }
+    }
+
+    set bp_num 0
+    foreach t $tests {
+	lassign $t test options disp cond err
+
+	if {$err == ""} {
+	    incr bp_num
+	    set cond_re [expr {$cond eq "" ? "" : [string_to_regexp $cond]}]
+	    set params [hiperr_bkpt_re $bp_num $disp $cond_re]
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^done,bkpt=\{$params\}" \
+		"$test: mi-catch-hiperr"
+
+	    mi_gdb_test "-break-info $bp_num" \
+		".*\{$params\}.*" \
+		"$test: breakpoint info"
+	} else {
+	    set err_re [expr {$err eq "" ? "" : [string_to_regexp $err]}]
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^error,msg=\"catch-hiperr: $err_re\"" \
+		"$test: mi-catch-hiperr"
+	}
+    }
+    mi_gdb_exit
+}
+
+# Test different combinations of "-catch-hiperr [-c <condition>] [-t]"
+#
+# 1. -catch-hiperr
+# 2. -catch-hiperr -t
+# 3. -catch-hiperr -c $_hiperr==101
+# 4. -catch-hiperr -c $_hiperr==101 -t
+#
+# Check if they're set correctly and also hit accordingly.
+
+proc_with_prefix mi_test {} {
+    with_rocm_gpu_lock {
+
+	mi_clean_restart
+
+	# Each element is {TEST OPTIONS DISP COND}, where TEST is the
+	# test name, OPTIONS are the extra "-catch-hiperr" options to
+	# test, DISP is the expected disposition ("keep" or "del"),
+	# and COND is the expected condition ("" for none).
+	set tests {
+	    { "simple catch"
+	      ""
+	      keep
+	      "" }
+
+	    { "temporary catch"
+	      "-t"
+	      del
+	      "" }
+
+	    { "conditional catch"
+	      {-c "$_hiperr == 101"}
+	      keep
+	      {$_hiperr == 101} }
+
+	    { "temporary conditional catch"
+	      {-c "$_hiperr == hipErrorInvalidDevice" -t}
+	      del
+	      {$_hiperr == hipErrorInvalidDevice} }
+	}
+
+	# The relevant part of MI stop after catching a hiperr.
+	append hiperr_stop_re "\\*stopped,bkptno=\"1\","
+	append hiperr_stop_re "reason=\"breakpoint-hit\".*hiperr-code=\"$::hip_set_device_err_no\","
+	append hiperr_stop_re "hiperr-name=\"$::hip_set_device_err_name\","
+	append hiperr_stop_re "hiperr-str=\"$::hip_set_device_err_str\".*"
+
+	foreach t $tests {
+	    lassign $t test options disp cond
+	    set cond_re [expr {$cond eq "" ? "" : [string_to_regexp $cond]}]
+	    set params [hiperr_bkpt_re 1 $disp $cond_re]
+
+	    mi_clean_restart
+	    mi_gdb_load $::binfile.dbg
+
+	    mi_gdb_test "-catch-hiperr $options" \
+		"\\^done,bkpt=\{$params\}" \
+		"$test: mi-catch-hiperr"
+
+	    mi_gdb_test "-break-info" \
+		".*\{$params\}.*" \
+		"$test: breakpoint info"
+
+	    # Run the test program to trigger one hipErrorInvalidDevice error.
+	    mi_gdb_test "-exec-arguments one" "\\^done" "$test: set argument"
+	    mi_run_cmd
+
+	    # Check for the async stop.  mi_expect_stop cannot be used because
+	    # it is breakpoint oriented with arguments like "func", "args", ...
+	    # and no checking for the "hiperr-*" fields.
+	    gdb_expect {
+		-re $hiperr_stop_re {
+		    pass $test
+		} -re ".*\r\n$::mi_gdb_prompt$" {
+		    fail "$test (unexpected output)"
+		} timeout {
+		    fail "$test (timeout)"
+		}
+	    }
+	}
+	mi_gdb_exit
+    }
+}
+
+# Start with "mi_parsing" because it doesn't need "preparation_test".
+mi_parsing
+if {![preparation_test]} {
+    return
+}
+cli_test
+mi_test

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -252,8 +252,10 @@ proc do_test {} {
 	    gdb_test_no_output "set args launch"
 	    catch_hiperr
 	    check_hip_launch_kernel_err "run"
+	    # __device_stub__kernel is inlined into hip_launch_kernel at
+	    # higher optimization levels and may not appear in the backtrace.
 	    gdb_test "backtrace" \
-		".*__hipOnError.*hipLaunchKernel.*__device_stub__kernel.*" \
+		".*__hipOnError.*hipLaunchKernel.*" \
 		"call stack"
 	}
 

--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -45,7 +45,7 @@ if {[prepare_for_testing "failed to prepare non-debug version of ${testfile}" \
     return -1
 }
 
-# Reference error parameters for HIP API calls:
+# Reference error info for HIP API calls:
 #   hipSetDevice (...)
 #   hipGetDevice (...)
 #   hipLaunchKernel (...)

--- a/gdb/testsuite/gdb.rocm/omp-target-basic.exp
+++ b/gdb/testsuite/gdb.rocm/omp-target-basic.exp
@@ -60,6 +60,10 @@ with_rocm_gpu_lock {
     # Still stopped at the first statement in the region (out_arr is
     # not written yet), so the data-sharing values are deterministic.
     with_test_prefix "locals" {
+	# The compiler emits unsigned long instead of int for the
+	# firstprivate argument variable.  The test may pass or fail
+	# depending on the surrounding values/memory.
+	setup_xfail "*-*-*"
 	gdb_test "print firstpriv_val" "= 42" "firstprivate value"
 	gdb_test "print in_arr\[0\]" "= 100" "mapped-to in_arr\[0\]"
 	gdb_test "print in_arr\[7\]" "= 107" "mapped-to in_arr\[7\]"

--- a/gdb/testsuite/gdb.rocm/rocm-test-utils.h
+++ b/gdb/testsuite/gdb.rocm/rocm-test-utils.h
@@ -42,4 +42,9 @@
 
 #define NOP(N) asm volatile ("s_nop " #N)
 
+/* Insert host "nop" into the code.  It's useful for adding pieces of code
+   that we can set a breakpoint on without getting optimized away.  */
+
+#define HOST_NOP asm volatile ("nop")
+
 #endif /* ROCM_TEST_UTILS_H */

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -62,7 +62,7 @@ proc do_test { fault core_type output_type } {
     set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
-	set coredump [rocm_core_find $::binfile {} $fault $use_pipe]
+	set coredump [rocm_core_find $::binfile {} $fault "/dev/null" $use_pipe]
     }
 
     if {$coredump eq ""} {

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -101,14 +101,19 @@ proc do_test { fault core_type output_type } {
     # chunk, causing a greedy pattern listed first to consume past the line
     # intended for the second pattern.  A single pattern sidesteps that by
     # iterating over all AMDGPU Wave lines with exp_continue and classifying
-    # each in Tcl.  The leading "*" identifies the selected (faulty) wave, and
-    # the quoted thread name identifies the auxiliary wave.
+    # each in Tcl.  The leading "*" identifies the selected (faulty) wave.
+    # The auxiliary wave is identified by the function call aux_kernel () on the line.
+    # The quoted thread name is not used because gfx90a does not initialize ttmps by
+    # default, so the thread name can be absent.
     gdb_test_multiple "info thread" "identify waves" {
-	-re "(\\\*?) *($::decimal) *AMDGPU Wave \[^\r\n\]* \"(\[^\"]+)\" \[^\r\n\]*\r\n" {
-	    if {$expect_out(1,string) eq "*"} {
-		set faulty_wave $expect_out(2,string)
-	    } elseif {$expect_out(3,string) eq "aux_kernel"} {
-		set aux_wave $expect_out(2,string)
+	-re "(\\\*?) *($::decimal) *AMDGPU Wave (\[^\r\n\]*)\r\n" {
+	    set marker $expect_out(1,string)
+	    set thread_num $expect_out(2,string)
+	    set wave_info $expect_out(3,string)
+	    if {$marker eq "*"} {
+		set faulty_wave $thread_num
+	    } elseif {[regexp {aux_kernel \(\)} $wave_info]} {
+		set aux_wave $thread_num
 	    }
 	    exp_continue
 	}

--- a/gdb/testsuite/gdb.rocm/runtime-core.exp
+++ b/gdb/testsuite/gdb.rocm/runtime-core.exp
@@ -50,7 +50,7 @@ set success_count 0
 #   Run the test exercising generation of a core dump on fault FAULT
 #   using a file or a pipe.
 #
-# FAULT is one of "page", "abort",  or "assert", and selects which
+# FAULT is one of "pagefault", "abort", or "assert", and selects which
 #   fault the application should generate.
 #
 # CORE_TYPE is one of "full" or "lightweight".
@@ -62,7 +62,7 @@ proc do_test { fault core_type output_type } {
     set use_pipe [expr {$output_type eq "pipe"}]
     save_vars { ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) } {
 	set ::env(HSA_ENABLE_LIGHTWEIGHT_COREDUMP) [expr {$core_type == "lightweight"}]
-	set coredump [rocm_core_find $::binfile {} $fault "/dev/null" $use_pipe]
+	set coredump [rocm_core_find $::binfile {} $fault $use_pipe]
     }
 
     if {$coredump eq ""} {
@@ -79,13 +79,8 @@ proc do_test { fault core_type output_type } {
 
     if {$fault == "pagefault"} {
 	set gpusig "SIGSEGV"
-	set fault_loc "pagefault_kernel"
-    } elseif {$fault == "abort"} {
+    } else {
 	set gpusig "SIGABRT"
-	set fault_loc "abort"
-    } elseif {$fault == "assert"} {
-	set gpusig "SIGABRT"
-	set fault_loc "__assert_fail"
     }
 
     clean_restart
@@ -100,16 +95,24 @@ proc do_test { fault core_type output_type } {
 
     set faulty_wave 0
     set aux_wave 0
-    gdb_test_multiple "info thread" "identify waves" -lbl {
-	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]*$fault_loc \[^\r\n\]*(?=\r\n)" {
-	    set faulty_wave $expect_out(1,string)
+    # Use a single pattern to match any AMDGPU Wave line regardless of which
+    # kernel it belongs to.  Using two separate patterns (one per kernel name)
+    # is unreliable because the entire "info thread" output can arrive as one
+    # chunk, causing a greedy pattern listed first to consume past the line
+    # intended for the second pattern.  A single pattern sidesteps that by
+    # iterating over all AMDGPU Wave lines with exp_continue and classifying
+    # each in Tcl.  The leading "*" identifies the selected (faulty) wave, and
+    # the quoted thread name identifies the auxiliary wave.
+    gdb_test_multiple "info thread" "identify waves" {
+	-re "(\\\*?) *($::decimal) *AMDGPU Wave \[^\r\n\]* \"(\[^\"]+)\" \[^\r\n\]*\r\n" {
+	    if {$expect_out(1,string) eq "*"} {
+		set faulty_wave $expect_out(2,string)
+	    } elseif {$expect_out(3,string) eq "aux_kernel"} {
+		set aux_wave $expect_out(2,string)
+	    }
 	    exp_continue
 	}
-	-re "^\r\n\[^\r\n\]+($::decimal) *AMDGPU Wave \[^\r\n\]* aux_kernel \[^\r\n\]*(?=\r\n)" {
-	    set aux_wave $expect_out(1,string)
-	    exp_continue
-	}
-	-re "^\r\n$::gdb_prompt $" {
+	-re "$::gdb_prompt $" {
 	    gdb_assert {($faulty_wave != 0) && ($aux_wave != 0)} $gdb_test_name
 	}
     }

--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -6177,6 +6177,19 @@ proc gdb_compile {source dest type options} {
 	set omp_early_flags "-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa\
 			     -mllvm=-amdgpu-spill-cfi-saved-regs"
 
+	# The benign __keep_alive warning pruned below is emitted by the
+	# device ld.lld at link time.  Newer lld (e.g. LLVM 23) defaults
+	# --color-diagnostics to "auto" and colorizes when spawned under a
+	# pty (as DejaGnu does), inserting ANSI escapes between "ld.lld:"
+	# and "warning:" that would stop the anchored regexp from matching.
+	# Tell the offload (device) linker not to colorize; only on the
+	# link step, so the compile step does not warn about an unused
+	# argument.  -Wl, would only reach the host linker, not the device
+	# ld.lld that emits this warning.
+	if {$type eq "executable"} {
+	    append omp_early_flags " -Xoffload-linker --no-color-diagnostics"
+	}
+
 	# amdflang does not understand some clang-only diagnostic
 	# flags, so only pass them on the C/C++ (non-f90) paths.
 	if {[lsearch -exact $options f90] == -1} {


### PR DESCRIPTION
Commits:
cff819c6e85 github: add daily TheRock dependency update workflow
f215dd684dc gdb.rocm/omp-target-basic: xfail firstprivate value test
f863c2698f2 gdb/testsuite/runtime-core: Fix wave identification for gfx90a
3cdd39db310 gdb: add -catch-hiperr to the Machine Interface (MI)
4dc955aa1c2 hiperr_catchpoint: stop setting "locspec" during construction
84ee926abac gdb.rocm/hip-catch-errors: make the test optimization tolerant
2960487ef97 catch hiperr: turn "parameters" wordings into "information"
f3e3e9299aa [gdb/testsuite] Fix gdb.rocm tests for optimized builds
a1be307feaf gdb/testsuite: disable device ld.lld color diagnostics for omp-rocm
ed5a060e27d gdb/testsuite/runtime-core: Fix unreliable wave identification
398928e6c58 [ROCgdb] Update ignore list: remove unused gdb.rocm entries
cc292996c43 gdb/testsuite: fix pipe iteration of gdb.rocm/runtime-core.exp
f2e2513b269 Update TheRock dependencies and container images
0d982f6028e test_rocgdb: add --sanity-check GPU health probe
d2f64037a26 test_rocgdb: add --timing mode
99471bec25a test_rocgdb: add --toolchain mode
7dd7567a75b gdb.rocm/hip-builtin-variables: add '$' for Tcl vars in messages
8c16d5b0061 gdb, testsuite: fix typo "skippig"
defcf6ef084 gcore: Query auxv for AT_PAGESZ in gcore_copy_callback
435070d9550 gcore: Handle unreadable pages within readable memory regions