### PR TITLE
Fix typos and add a codespell exception

### DIFF
--- a/gdb/contrib/codespell-ignore-words.txt
+++ b/gdb/contrib/codespell-ignore-words.txt
@@ -58,3 +58,5 @@ endianity
 # Downstream ROCgdb lingo.
 HSA
 offen
+# Name pattern of AMD GPU device files.
+renderD

--- a/gdb/gdbthread.h
+++ b/gdb/gdbthread.h
@@ -653,7 +653,7 @@ private:
 
      If SIMD is supported by the architecture, changing this attribute
      switches the focus between different SIMD lanes within a thread.
-     This field is tigthly bound to the active SIMD lanes mask, which
+     This field is tightly bound to the active SIMD lanes mask, which
      indicates lanes that are currently active.
 
      If SIMD is not supported, we pretend there's only one lane, with

--- a/gdb/testsuite/gdb.dwarf2/dw2-llvm-info-address.exp
+++ b/gdb/testsuite/gdb.dwarf2/dw2-llvm-info-address.exp
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Test if all LLVM DWARF extensions for heterogenous debugging
+# Test if all LLVM DWARF extensions for heterogeneous debugging
 # (https://llvm.org/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.html) show
 # up in "info address" command.
 #


### PR DESCRIPTION
Fix a couple typos caught by codespell and except a third one that is just the name pattern of AMD GPU device files.