### PR TITLE
[ci] Fetch build and CPU test runner dynamically from therock-ci-config

### DIFF
--- a/.github/scripts/select_runner.py
+++ b/.github/scripts/select_runner.py
@@ -1,0 +1,51 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+"""Select a GitHub Actions runner label from therock-ci-config.
+
+Usage: python select_runner.py <output_var> [ci_config_path]
+
+Writes <output_var>=<label> to GITHUB_OUTPUT and prints it to stdout.
+Falls back to aws-linux-scale-rocm-prod if the config is unavailable.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: select_runner.py <output_var> [ci_config_path]", file=sys.stderr)
+        sys.exit(1)
+
+    output_var = sys.argv[1]
+    ci_config = Path(sys.argv[2] if len(sys.argv) > 2 else "ci-config")
+    default_runner = "aws-linux-scale-rocm-prod"
+
+    label = default_runner
+    if (ci_config / "runner-config.json").exists():
+        try:
+            sys.path.insert(0, str(ci_config))
+            from ci_config_api import load_config_v1
+
+            config = load_config_v1(ci_config)
+            candidates = config.build_runners.get("linux", {}).get("default", [])
+            best = max(candidates, key=lambda e: e["weight"], default=None)
+            if best:
+                label = best["label"]
+        except Exception as e:
+            print(
+                f"Failed to load ci_config_api, using default: {e}", file=sys.stderr
+            )
+    else:
+        print(
+            f"ci-config not found, using default: {default_runner}", file=sys.stderr
+        )
+
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        f.write(f"{output_var}={label}\n")
+    print(f"{output_var}={label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,9 @@ on:
         type: string
       extra_cmake_options:
         type: string
+      build_runs_on:
+        type: string
+        default: aws-linux-scale-rocm-prod
 
 permissions:
   contents: read
@@ -19,7 +22,7 @@ env:
 jobs:
   therock-build-linux:
     name: Build Linux Packages
-    runs-on: azure-linux-scale-rocm
+    runs-on: ${{ inputs.build_runs_on }}
     permissions:
       id-token: write
     outputs:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -22,6 +22,7 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
+      build_runs_on: ${{ steps.runner.outputs.build_runs_on }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,6 +32,18 @@ jobs:
       - name: "Configuring CI options"
         id: configure
         run: python .github/scripts/therock_configure_ci.py
+
+      - name: Checkout CI config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
+
+      - name: Select build runner
+        id: runner
+        run: python3 .github/scripts/select_runner.py build_runs_on
 
   therock-ci-linux:
     name: TheRock CI Linux
@@ -47,6 +60,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
+      build_runs_on: ${{ needs.setup.outputs.build_runs_on }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       components: ${{ steps.patch-scripts.outputs.components }}
+      cpu_runs_on: ${{ steps.runner.outputs.cpu_runs_on }}
     steps:
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -56,6 +57,17 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
+
+      - name: Checkout ROCgdb (scripts only)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROCm/ROCgdb
+          sparse-checkout: .github/scripts
+          path: rocgdb-scripts
+
+      - name: Select CPU runner
+        id: runner
+        run: python3 rocgdb-scripts/.github/scripts/select_runner.py cpu_runs_on
 
       - name: Configure test matrix
         env:
@@ -97,12 +109,12 @@ jobs:
       therock_ref: ${{ inputs.therock_ref }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       # Per-component runner selection:
-      #   1. CPU-only components use a standard Linux scale runner
-      #   2. Per-component GPU runner (set by fetch_test_configurations.py)
+      #   1. CPU-only components use the runner from therock-ci-config
+      #   2. GPU components use the per-component runner from fetch_test_configurations.py
       test_runs_on: >-
         ${{
           (matrix.components.linux_cpu_runner == true &&
-            'aws-linux-scale-rocm-prod') ||
+            needs.configure_test_matrix.outputs.cpu_runs_on) ||
           matrix.components.test_runner
         }}
       component: ${{ toJSON(matrix.components) }}


### PR DESCRIPTION
## Summary

- Replace hardcoded \`azure-linux-scale-rocm\` (Azure) in the build job and \`aws-linux-scale-rocm-prod\` (AWS) in the CPU test job with dynamic runner selection driven by \`ROCm/therock-ci-config\`'s \`runner-config.json\` (\`build_runners.linux.default\`, highest-weight entry).
- The \`setup\` job in \`therock-ci.yml\` checks out \`therock-ci-config\` and selects the runner via \`ci_config_api.py\`, passing it as a new \`build_runs_on\` input to \`therock-ci-linux.yml\`.
- \`therock-test-packages.yml\`'s \`configure_test_matrix\` job applies the same logic and exposes \`cpu_runs_on\` for the CPU component's \`test_runs_on\` expression.
- Both runner-selection steps fall back to \`aws-linux-scale-rocm-prod\` if \`therock-ci-config\` is unavailable (e.g., in forks).
- Runner-selection logic extracted into \`.github/scripts/select_runner.py\` to avoid duplication between the two workflows.

## Test plan

- [x] Verify CI triggers on this PR and the build job picks up the correct runner label from \`therock-ci-config\`
- [x] Verify CPU test component routes to the dynamically selected runner
- [x] Verify GPU test component still uses the per-component runner from \`fetch_test_configurations.py\`
- [x] Verify fallback behaviour by temporarily breaking the ci-config checkout (\`continue-on-error: true\` already set)