### PR TITLE
github: remove push triggers, run CI only on PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
     branches:
       - amd-staging
       - 'amd-staging-rocgdb-*'
@@ -24,12 +23,7 @@ jobs:
       - name: Determine base ref
         id: base-ref
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-          else
-            # For push events, use the current branch name
-            BASE_REF="${{ github.ref_name }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
           echo "base_ref=${BASE_REF}" >> $GITHUB_OUTPUT
           echo "Base ref: ${BASE_REF}"
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,10 +1,6 @@
 name: TheRock CI for rocgdb
 
 on:
-  push:
-    branches:
-      - amd-staging
-      - amd-staging-rocgdb-*
   pull_request:
     branches:
       - amd-staging


### PR DESCRIPTION
## Summary
- Remove `push` trigger from `therock-ci.yml` — TheRock CI was running
  redundantly on every push to `amd-staging` in addition to per-PR runs
- Remove `push` trigger from `pre-commit.yml` for the same reason, and
  simplify the base ref logic now that push events are no longer handled
- Removing the `push` trigger from `pre-commit.yml` reparents the existing
  `branches` filter onto `pull_request`, restricting pre-commit to PRs
  targeting `amd-staging` and `amd-staging-rocgdb-*`, consistent with
  `therock-ci.yml`

## Test plan
- [ ] Verify TheRock CI and pre-commit run on new PRs targeting `amd-staging`
- [ ] Verify no CI runs are triggered on direct pushes to `amd-staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)