### PR TITLE
github: tighten CI workflow security settings

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -26,11 +26,9 @@ jobs:
       therock_ref: ${{ steps.export-ref.outputs.therock_ref }}
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:8616d086df21bcc835aed5112ff0d878530a0cf5433f8f42c7b28b973a75bb19 # 2026-07-27
-      options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
 
@@ -126,7 +124,7 @@ jobs:
             --stage all
 
       - name: Post Build Upload
-        if: always()
+        if: always() && !github.event.pull_request.head.repo.fork
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
@@ -139,7 +137,6 @@ jobs:
     if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -48,7 +48,6 @@ jobs:
       matrix:
         amdgpu_family: [gfx94X-dcgpu]
     uses: ./.github/workflows/therock-ci-linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -106,4 +106,3 @@ jobs:
           matrix.components.test_runner
         }}
       component: ${{ toJSON(matrix.components) }}
-    secrets: inherit


### PR DESCRIPTION
## Summary

- Remove `secrets: inherit` from all reusable workflow calls; no named secrets are referenced and AWS authentication is covered by OIDC
- Remove the `/runner/config` bind-mount and `AWS_SHARED_CREDENTIALS_FILE` env var from the build container
- Guard the Post Build Upload step against fork PRs to prevent unintended S3 uploads

Addresses ROCM-26823.