### PR TITLE
gdb.rocm/alu-exceptions.exp: prevent ROCr core dumps on exceptions

### DIFF
--- a/gdb/testsuite/gdb.rocm/alu-exceptions.exp
+++ b/gdb/testsuite/gdb.rocm/alu-exceptions.exp
@@ -67,6 +67,8 @@ proc do_test { exception_name precise_alu_exceptions_supported } {
 
 	with_rocm_gpu_lock {
 	    gdb_test_no_output "set args $exception_name"
+	    # Prevent ROCr from generating a GPU core dump before calling abort.
+	    gdb_test_no_output "set environment HSA_DISABLE_COREDUMP_ON_EXCEPTION=1"
 	    if {![runto_main]} {
 		return
 	    }
@@ -141,6 +143,8 @@ proc do_test { exception_name precise_alu_exceptions_supported } {
 	with_rocm_gpu_lock {
 	    gdb_test_no_output "set args $exception_name"
 	    gdb_test_no_output "set amdgpu precise-alu-exceptions on"
+	    # Prevent ROCr from generating a GPU core dump before calling abort.
+	    gdb_test_no_output "set environment HSA_DISABLE_COREDUMP_ON_EXCEPTION=1"
 	    if {![runto_main]} {
 		return
 	    }
@@ -164,6 +168,8 @@ with_test_prefix "check_precise_alu_support" {
 
     with_rocm_gpu_lock {
 	gdb_test_no_output "set amdgpu precise-alu-exceptions on"
+	# Prevent ROCr from generating a GPU core dump before calling abort.
+	gdb_test_no_output "set environment HSA_DISABLE_COREDUMP_ON_EXCEPTION=1"
 	if {![runto_main]} {
 	    return
 	}


### PR DESCRIPTION
Use GDB's "set environment" to pass HSA_DISABLE_COREDUMP_ON_EXCEPTION=1
to the inferior, so the ROCr runtime does not generate a core dump when
the ALU exception causes the process to abort.  Using "set environment"
keeps the setting scoped to the inferior and avoids contaminating other
parallel test processes.