### PR TITLE
gdb, testsuite: fix 'no such variable' error in gdb.rocm/hip-catch-er…

### DIFF
--- a/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
+++ b/gdb/testsuite/gdb.rocm/hip-catch-errors.exp
@@ -197,10 +197,14 @@ proc check_hip_launch_kernel_err {cmd} {
 # using the test program.  Return false if anything goes wrong.
 
 proc_with_prefix preparation_test {} {
+    # The return statements below return to this level.  Hence keep
+    # the state in a variable.
+    set res false
+
     with_rocm_gpu_lock {
 	clean_restart ${::testfile}.dbg
 	if {![runto_main]} {
-	    return false
+	    return
 	}
 	gdb_test_multiple "info symbol __hipOnError" \
 	    "check if __hipOnError symbol exists" {
@@ -209,7 +213,7 @@ proc_with_prefix preparation_test {} {
 	    }
 	    -re -wrap ".*" {
 		unsupported "no __hipOnError symbol was found"
-		return false
+		return
 	    }
 	}
 
@@ -219,7 +223,7 @@ proc_with_prefix preparation_test {} {
 	    gdb_test_no_output "set args ref"
 	    if {![runto [gdb_get_line_number \
 			    "Break after reference initialization"]]} {
-		return false
+		return
 	    }
 	    set res [init_reference_hip_errors]
 	}


### PR DESCRIPTION
Running gdb.rocm/hip-catch-errors.exp in an environment where the `__hipOnError` symbol is not defined gives

```
  ERROR: tcl error sourcing <path-to>/gdb/testsuite/gdb.rocm/hip-catch-errors.exp.
  ERROR: can't read "res": no such variable
      while executing
  "return $res"
      ("uplevel" body line 27)
        invoked from within
  "uplevel 1 $body"
      invoked from within
  "with_test_prefix preparation_test {
      with_rocm_gpu_lock {
          clean_restart ${::testfile}.dbg
          if {![runto_main]} {
            return false
          }
          gdb_test_mul..."
```

Fix this by defining "res" at an earlier point.

The problem here is in fact deeper.  The code body that is used in `preparation_test` has `return` statements.  One would expect the `return` statements to actually return from `preparation_test` early and not even reach `return $res`, but that's not happening because of how `with_rocm_gpu_lock` and `with_lock` are defined and use Tcl's uplevel. Fixing them will be more involved and should be addressed separately.
