### PR TITLE
github: improve TheRock dependency update workflow

### DIFF
--- a/.github/configs.json
+++ b/.github/configs.json
@@ -1,0 +1,6 @@
+{
+  "therock_commit_ref": "2ee541083481e6c93f2ea811f212b61047980b1a",
+  "therock_commit_created": "2026-07-30T10:07:58Z",
+  "build_image": "ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:8616d086df21bcc835aed5112ff0d878530a0cf5433f8f42c7b28b973a75bb19",
+  "build_image_created": "2026-07-27T09:37:30.626203739Z"
+}

--- a/.github/configs.md
+++ b/.github/configs.md
@@ -1,0 +1,36 @@
+# .github/configs.json field reference
+
+`configs.json` holds the TheRock dependency pins used by CI. It is the
+single source of truth for which TheRock commit and build container image
+the CI workflow uses. The automated update workflow
+(`.github/workflows/therock-deps-update.yml`) rewrites this file and opens
+a PR when either pin changes.
+
+## Fields
+
+### `therock_commit_ref`
+
+Full 40-character SHA of the TheRock commit pinned for CI. Read by the
+`resolve` job in `therock-ci-linux.yml` and passed to the TheRock checkout
+step as `THEROCK_COMMIT_REF`.
+
+### `therock_commit_created`
+
+ISO 8601 timestamp of when `therock_commit_ref` was committed, taken from
+the GitHub Commits API (`commit.committer.date`). Not consumed by CI; used
+by the update script to preserve the original timestamp when only the build
+image changes.
+
+### `build_image`
+
+Full container image reference including registry, image name, and digest,
+e.g. `ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:<64-hex-chars>`.
+Read by the `resolve` job and used as `container.image` for the build job.
+Must include the `@sha256:` digest suffix; the resolve job validates this.
+
+### `build_image_created`
+
+ISO 8601 timestamp of when the build container image was created, taken
+from the OCI config blob `created` field. Not consumed by CI; used by the
+update script to preserve the original timestamp when only the TheRock
+commit changes.

--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -1,0 +1,76 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+"""Read and validate fields from .github/configs.json.
+
+Usage: python3 config.py <field> [<field> ...]
+
+Validates each requested field and writes field=value to $GITHUB_OUTPUT.
+Exits non-zero if the config file is missing, malformed, or any field
+fails validation.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Maps each known field name to a (description, validator) pair.
+_VALIDATORS = {
+    "therock_commit_ref": (
+        "40-character lowercase hex SHA",
+        re.compile(r"^[0-9a-f]{40}$").match,
+    ),
+    "build_image": (
+        "ghcr.io image reference with sha256 digest",
+        re.compile(r"^ghcr\.io/[^@]+@sha256:[0-9a-f]{64}$").match,
+    ),
+}
+
+CONFIGS_PATH = Path(".github/configs.json")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: config.py <field> [<field> ...]", file=sys.stderr)
+        sys.exit(1)
+
+    fields = sys.argv[1:]
+
+    for field in fields:
+        if field not in _VALIDATORS:
+            known = ", ".join(sorted(_VALIDATORS))
+            print(f"Unknown field {field!r}. Known fields: {known}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        d = json.loads(CONFIGS_PATH.read_text())
+    except FileNotFoundError:
+        print(f"{CONFIGS_PATH} not found", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"{CONFIGS_PATH} is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    results = {}
+    for field in fields:
+        description, validate = _VALIDATORS[field]
+        value = d.get(field, "")
+        if not isinstance(value, str) or not validate(value):
+            print(
+                f"Invalid {field!r} (expected {description}): {value!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        results[field] = value
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    for field, value in results.items():
+        if github_output:
+            with open(github_output, "a") as f:
+                f.write(f"{field}={value}\n")
+        print(f"{field}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_update_therock_deps.py
+++ b/.github/scripts/test_update_therock_deps.py
@@ -1,0 +1,971 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for update_therock_deps.py."""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Load module under test without triggering __main__, then register it in
+# sys.modules so @patch("update_therock_deps.*") resolves correctly.
+# ---------------------------------------------------------------------------
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "update_therock_deps",
+        Path(__file__).parent / "update_therock_deps.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    with patch("sys.argv", ["update_therock_deps.py"]):
+        spec.loader.exec_module(mod)
+    sys.modules["update_therock_deps"] = mod
+    return mod
+
+
+m = _load_module()
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+SHA = "a" * 40
+SHA2 = "b" * 40
+DIGEST = "sha256:" + "c" * 64
+DIGEST2 = "sha256:" + "d" * 64
+IMAGE = f"ghcr.io/rocm/therock_build_manylinux_x86_64@{DIGEST}"
+IMAGE2 = f"ghcr.io/rocm/therock_build_manylinux_x86_64@{DIGEST2}"
+
+BASE_PINS = {
+    "therock_commit_ref": SHA,
+    "therock_commit_created": "2026-07-30T10:07:58Z",
+    "build_image": IMAGE,
+    "build_image_created": "2026-07-27T09:37:30Z",
+}
+
+
+def _pins(**overrides):
+    return {**BASE_PINS, **overrides}
+
+
+def _make_response(body: bytes | dict, headers: dict | None = None):
+    if isinstance(body, dict):
+        body = json.dumps(body).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.headers = MagicMock()
+    resp.headers.get = lambda key, default="": (headers or {}).get(key, default)
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://x", code=code, msg="err", hdrs={}, fp=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# urlopen_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestUrlOpenWithRetry(unittest.TestCase):
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_success_first_attempt(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.return_value = resp
+        result = m.urlopen_with_retry("http://example.com")
+        self.assertEqual(result, resp)
+        mock_sleep.assert_not_called()
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retries_on_5xx_then_succeeds(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.side_effect = [_http_error(503), _http_error(503), resp]
+        result = m.urlopen_with_retry("http://example.com")
+        self.assertEqual(result, resp)
+        self.assertEqual(mock_open.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_raises_immediately_on_4xx(self, mock_open, mock_sleep):
+        mock_open.side_effect = _http_error(404)
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            m.urlopen_with_retry("http://example.com")
+        self.assertEqual(ctx.exception.code, 404)
+        mock_open.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_raises_immediately_on_401(self, mock_open, mock_sleep):
+        mock_open.side_effect = _http_error(401)
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            m.urlopen_with_retry("http://example.com")
+        self.assertEqual(ctx.exception.code, 401)
+        mock_open.assert_called_once()
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_raises_after_max_retries_on_5xx(self, mock_open, mock_sleep):
+        mock_open.side_effect = _http_error(500)
+        with self.assertRaises(urllib.error.HTTPError):
+            m.urlopen_with_retry("http://example.com")
+        self.assertEqual(mock_open.call_count, m.MAX_RETRIES)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retries_on_url_error(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.side_effect = [urllib.error.URLError("transient"), resp]
+        result = m.urlopen_with_retry("http://example.com")
+        self.assertEqual(result, resp)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_raises_after_max_retries_on_url_error(self, mock_open, mock_sleep):
+        mock_open.side_effect = urllib.error.URLError("connection refused")
+        with self.assertRaises(urllib.error.URLError):
+            m.urlopen_with_retry("http://example.com")
+        self.assertEqual(mock_open.call_count, m.MAX_RETRIES)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_sleep_uses_exponential_backoff(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.side_effect = [
+            urllib.error.URLError("err"),
+            urllib.error.URLError("err"),
+            resp,
+        ]
+        m.urlopen_with_retry("http://example.com")
+        self.assertEqual(mock_sleep.call_args_list[0][0][0], 2)
+        self.assertEqual(mock_sleep.call_args_list[1][0][0], 4)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retries_on_timeout_error(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.side_effect = [TimeoutError("timed out"), resp]
+        result = m.urlopen_with_retry("http://example.com")
+        self.assertEqual(result, resp)
+        self.assertEqual(mock_open.call_count, 2)
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_raises_immediately_on_499(self, mock_open, mock_sleep):
+        mock_open.side_effect = _http_error(499)
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            m.urlopen_with_retry("http://example.com")
+        self.assertEqual(ctx.exception.code, 499)
+        mock_open.assert_called_once()
+
+    @patch("update_therock_deps.time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_retries_on_exactly_500(self, mock_open, mock_sleep):
+        resp = _make_response(b"ok")
+        mock_open.side_effect = [_http_error(500), resp]
+        result = m.urlopen_with_retry("http://example.com")
+        self.assertEqual(result, resp)
+        self.assertEqual(mock_open.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# build_commit_message
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommitMessage(unittest.TestCase):
+    def test_both_changed(self):
+        pins = {"therock_commit_ref": SHA, "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA2, DIGEST2)
+        self.assertIn(f"commit: {SHA[:12]} -> {SHA2[:12]}", msg)
+        self.assertIn("build image:", msg)
+
+    def test_only_commit_changed(self):
+        pins = {"therock_commit_ref": SHA, "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA2, DIGEST)
+        self.assertIn("commit:", msg)
+        self.assertNotIn("build image:", msg)
+
+    def test_only_digest_changed(self):
+        pins = {"therock_commit_ref": SHA, "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA, DIGEST2)
+        self.assertNotIn("commit:", msg)
+        self.assertIn("build image:", msg)
+
+    def test_nothing_changed(self):
+        pins = {"therock_commit_ref": SHA, "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA, DIGEST)
+        self.assertNotIn("commit:", msg)
+        self.assertNotIn("build image:", msg)
+
+    def test_empty_old_commit_shows_none(self):
+        pins = {"therock_commit_ref": "", "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA2, DIGEST)
+        self.assertIn("(none)", msg)
+        self.assertIn(f"-> {SHA2[:12]}", msg)
+
+    def test_missing_old_commit_key_shows_none(self):
+        pins = {"build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA2, DIGEST)
+        self.assertIn("(none)", msg)
+
+    def test_malformed_old_digest_not_shown(self):
+        pins = {"therock_commit_ref": SHA, "build_image": "ghcr.io/foo/bar"}
+        msg = m.build_commit_message(pins, SHA, DIGEST2)
+        self.assertNotIn("build image:", msg)
+
+    def test_old_image_without_at_not_shown(self):
+        pins = {"therock_commit_ref": SHA, "build_image": "ghcr.io/foo/bar:latest"}
+        msg = m.build_commit_message(pins, SHA, DIGEST2)
+        self.assertNotIn("build image:", msg)
+
+    def test_title_always_present(self):
+        msg = m.build_commit_message({}, SHA, DIGEST)
+        self.assertIn("Update TheRock dependencies", msg)
+
+    def test_digest_prefix_shown(self):
+        pins = {"therock_commit_ref": SHA, "build_image": IMAGE}
+        msg = m.build_commit_message(pins, SHA, DIGEST2)
+        self.assertIn(DIGEST[:19], msg)
+        self.assertIn(DIGEST2[:19], msg)
+
+    def test_missing_build_image_key_not_shown(self):
+        pins = {"therock_commit_ref": SHA}
+        msg = m.build_commit_message(pins, SHA, DIGEST2)
+        self.assertNotIn("build image:", msg)
+
+
+# ---------------------------------------------------------------------------
+# read_deps / write_deps
+# ---------------------------------------------------------------------------
+
+
+class TestReadWriteDeps(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(tempfile.mktemp(suffix=".json"))
+        self._orig = m.CONFIG_FILE
+        m.CONFIG_FILE = self._tmp
+
+    def tearDown(self):
+        m.CONFIG_FILE = self._orig
+        self._tmp.unlink(missing_ok=True)
+
+    def test_round_trip(self):
+        m.write_deps(BASE_PINS)
+        result = m.read_deps()
+        self.assertEqual(result, BASE_PINS)
+
+    def test_write_produces_valid_json(self):
+        m.write_deps(BASE_PINS)
+        parsed = json.loads(self._tmp.read_text())
+        self.assertEqual(parsed, BASE_PINS)
+
+    def test_write_adds_trailing_newline(self):
+        m.write_deps(BASE_PINS)
+        self.assertTrue(self._tmp.read_text().endswith("\n"))
+
+    def test_write_uses_indent_2(self):
+        m.write_deps({"k": "v"})
+        content = self._tmp.read_text()
+        self.assertIn("  ", content)
+
+
+# ---------------------------------------------------------------------------
+# ensure_label
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureLabel(unittest.TestCase):
+    @patch("update_therock_deps.run")
+    def test_label_found(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"name": "therock-deps"}]))
+        m.ensure_label("therock-deps")  # should not raise
+
+    @patch("update_therock_deps.run")
+    def test_label_not_found_raises(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"name": "other"}]))
+        with self.assertRaises(ValueError) as ctx:
+            m.ensure_label("therock-deps")
+        self.assertIn("therock-deps", str(ctx.exception))
+
+    @patch("update_therock_deps.run")
+    def test_empty_list_raises(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="[]")
+        with self.assertRaises(ValueError):
+            m.ensure_label("therock-deps")
+
+    @patch("update_therock_deps.run")
+    def test_partial_match_in_list_still_raises(self, mock_run):
+        # "therock-deps-old" is present but not "therock-deps" — must not match as substring
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps([{"name": "therock-deps-old"}])
+        )
+        with self.assertRaises(ValueError):
+            m.ensure_label("therock-deps")
+
+
+# ---------------------------------------------------------------------------
+# find_open_update_pr
+# ---------------------------------------------------------------------------
+
+
+class TestFindOpenUpdatePr(unittest.TestCase):
+    @patch("update_therock_deps.run")
+    def test_returns_url_when_present(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="https://github.com/ROCm/ROCgdb/pull/1\n"
+        )
+        result = m.find_open_update_pr()
+        self.assertEqual(result, "https://github.com/ROCm/ROCgdb/pull/1")
+
+    @patch("update_therock_deps.run")
+    def test_returns_none_when_empty(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        self.assertIsNone(m.find_open_update_pr())
+
+    @patch("update_therock_deps.run")
+    def test_returns_none_on_whitespace(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="   \n")
+        self.assertIsNone(m.find_open_update_pr())
+
+
+# ---------------------------------------------------------------------------
+# get_therock_commit
+# ---------------------------------------------------------------------------
+
+
+class TestGetTheRockCommit(unittest.TestCase):
+    def _branch_resp(self, sha=SHA):
+        return _make_response({"commit": {"sha": sha}})
+
+    def _commit_resp(self, date="2026-08-10T12:34:56Z"):
+        return _make_response({"commit": {"committer": {"date": date}}})
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_returns_sha_and_timestamp(self, mock_open):
+        mock_open.side_effect = [self._branch_resp(), self._commit_resp()]
+        sha, ts = m.get_therock_commit(fetch_timestamp=True)
+        self.assertEqual(sha, SHA)
+        self.assertEqual(ts, "2026-08-10T12:34:56Z")
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_no_timestamp_skips_commits_api(self, mock_open):
+        mock_open.side_effect = [self._branch_resp()]
+        sha, ts = m.get_therock_commit(fetch_timestamp=False)
+        self.assertEqual(sha, SHA)
+        self.assertIsNone(ts)
+        mock_open.assert_called_once()
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_invalid_sha_raises(self, mock_open):
+        mock_open.side_effect = [_make_response({"commit": {"sha": "notasha"}})]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_therock_commit()
+        self.assertIn("Invalid TheRock SHA", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_empty_sha_raises(self, mock_open):
+        mock_open.side_effect = [_make_response({})]
+        with self.assertRaises(ValueError):
+            m.get_therock_commit()
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_null_commit_in_branch_response_raises(self, mock_open):
+        mock_open.side_effect = [_make_response({"commit": None})]
+        with self.assertRaises(ValueError):
+            m.get_therock_commit()
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_missing_commit_object_raises(self, mock_open):
+        mock_open.side_effect = [
+            self._branch_resp(),
+            _make_response({"message": "Not Found"}),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_therock_commit()
+        self.assertIn("no commit object", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_null_committer_raises(self, mock_open):
+        mock_open.side_effect = [
+            self._branch_resp(),
+            _make_response({"commit": {"committer": None}}),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_therock_commit()
+        self.assertIn("no committer", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_missing_committer_date_raises(self, mock_open):
+        mock_open.side_effect = [
+            self._branch_resp(),
+            _make_response({"commit": {"committer": {"name": "Bot"}}}),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_therock_commit()
+        self.assertIn("no committer date", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_uses_gh_token_when_set(self, mock_open):
+        mock_open.side_effect = [self._branch_resp(), self._commit_resp()]
+        with patch.dict("os.environ", {"GH_TOKEN": "mytoken"}):
+            m.get_therock_commit()
+        req = mock_open.call_args_list[0][0][0]
+        self.assertIn("mytoken", req.get_header("Authorization"))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_no_gh_token_no_auth_header(self, mock_open):
+        mock_open.side_effect = [self._branch_resp(), self._commit_resp()]
+        env = {k: v for k, v in __import__("os").environ.items() if k != "GH_TOKEN"}
+        with patch.dict("os.environ", env, clear=True):
+            m.get_therock_commit()
+        req = mock_open.call_args_list[0][0][0]
+        self.assertIsNone(req.get_header("Authorization"))
+
+
+# ---------------------------------------------------------------------------
+# get_build_digest
+# ---------------------------------------------------------------------------
+
+
+class TestGetBuildDigest(unittest.TestCase):
+    CONFIG_DIGEST = "sha256:" + "e" * 64
+
+    def _token_resp(self):
+        return _make_response({"token": "ghcrtoken"})
+
+    def _manifest_resp(self, image_digest=DIGEST, config_digest=None):
+        if config_digest is None:
+            config_digest = self.CONFIG_DIGEST
+        return _make_response(
+            {"config": {"digest": config_digest}},
+            headers={"Docker-Content-Digest": image_digest},
+        )
+
+    def _config_blob_resp(self, created="2026-07-27T09:37:30.626203739Z"):
+        return _make_response({"created": created})
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_returns_digest_and_timestamp(self, mock_open):
+        mock_open.side_effect = [
+            self._token_resp(),
+            self._manifest_resp(),
+            self._config_blob_resp(),
+        ]
+        digest, created = m.get_build_digest(fetch_timestamp=True)
+        self.assertEqual(digest, DIGEST)
+        self.assertEqual(created, "2026-07-27T09:37:30.626203739Z")
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_no_timestamp_skips_config_blob(self, mock_open):
+        mock_open.side_effect = [self._token_resp(), self._manifest_resp()]
+        digest, created = m.get_build_digest(fetch_timestamp=False)
+        self.assertEqual(digest, DIGEST)
+        self.assertIsNone(created)
+        self.assertEqual(mock_open.call_count, 2)
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_missing_token_raises(self, mock_open):
+        mock_open.side_effect = [_make_response({"error": "unauthorized"})]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_build_digest()
+        self.assertIn("no token", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_null_token_raises(self, mock_open):
+        mock_open.side_effect = [_make_response({"token": None})]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_build_digest()
+        self.assertIn("no token", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_invalid_digest_raises(self, mock_open):
+        resp = _make_response(
+            {"config": {"digest": self.CONFIG_DIGEST}},
+            headers={"Docker-Content-Digest": "notadigest"},
+        )
+        mock_open.side_effect = [self._token_resp(), resp]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_build_digest()
+        self.assertIn("Invalid build image digest", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_missing_config_key_raises(self, mock_open):
+        resp = _make_response({}, headers={"Docker-Content-Digest": DIGEST})
+        mock_open.side_effect = [self._token_resp(), resp]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_build_digest()
+        self.assertIn("config blob digest", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_missing_created_field_raises(self, mock_open):
+        mock_open.side_effect = [
+            self._token_resp(),
+            self._manifest_resp(),
+            _make_response({}),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            m.get_build_digest()
+        self.assertIn("'created'", str(ctx.exception))
+
+    @patch("update_therock_deps.urlopen_with_retry")
+    def test_nanosecond_precision_preserved(self, mock_open):
+        ts = "2026-07-27T09:37:30.626203739Z"
+        mock_open.side_effect = [
+            self._token_resp(),
+            self._manifest_resp(),
+            self._config_blob_resp(created=ts),
+        ]
+        _, created = m.get_build_digest()
+        self.assertEqual(created, ts)
+
+
+# ---------------------------------------------------------------------------
+# open_update_pr
+# ---------------------------------------------------------------------------
+
+
+PR_ARGS = (
+    "my-branch",
+    SHA,
+    "2026-08-10T12:34:56Z",
+    False,
+    DIGEST,
+    "2026-08-10T00:00:00Z",
+)
+
+
+class TestOpenUpdatePr(unittest.TestCase):
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.ensure_label")
+    def test_returns_pr_url(self, mock_label, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="https://github.com/ROCm/ROCgdb/pull/42\n"
+        )
+        url = m.open_update_pr(*PR_ARGS)
+        self.assertEqual(url, "https://github.com/ROCm/ROCgdb/pull/42")
+
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.ensure_label")
+    def test_raises_on_empty_url(self, mock_label, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        with self.assertRaises(ValueError) as ctx:
+            m.open_update_pr(*PR_ARGS)
+        self.assertIn("no PR URL", str(ctx.exception))
+
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.ensure_label")
+    def test_calls_ensure_label_before_create(self, mock_label, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="https://github.com/ROCm/ROCgdb/pull/1"
+        )
+        m.open_update_pr(*PR_ARGS)
+        mock_label.assert_called_once_with(m.UPDATE_LABEL)
+
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.ensure_label")
+    def test_body_contains_commit_ref_and_date(self, mock_label, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="https://github.com/ROCm/ROCgdb/pull/1"
+        )
+        m.open_update_pr(
+            "branch", SHA, "2026-08-10T12:34:56Z", False, DIGEST, "2026-08-10T00:00:00Z"
+        )
+        body = mock_run.call_args[0][0][mock_run.call_args[0][0].index("--body") + 1]
+        self.assertIn(SHA[:12], body)
+        self.assertIn("2026-08-10", body)
+        self.assertNotIn("digest", body.lower())
+
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.ensure_label")
+    def test_body_contains_digest_when_digest_changed(self, mock_label, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="https://github.com/ROCm/ROCgdb/pull/1"
+        )
+        m.open_update_pr(
+            "branch", SHA, "2026-08-10T12:34:56Z", True, DIGEST2, "2026-08-11T09:00:00Z"
+        )
+        body = mock_run.call_args[0][0][mock_run.call_args[0][0].index("--body") + 1]
+        self.assertIn(DIGEST2[:19], body)
+        self.assertIn("2026-08-11", body)
+
+
+# ---------------------------------------------------------------------------
+# run_update
+# ---------------------------------------------------------------------------
+
+
+class TestRunUpdate(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(tempfile.mktemp(suffix=".json"))
+        self._orig_cf = m.CONFIG_FILE
+        m.CONFIG_FILE = self._tmp
+
+    def tearDown(self):
+        m.CONFIG_FILE = self._orig_cf
+        self._tmp.unlink(missing_ok=True)
+
+    def _write_pins(self, pins=None):
+        self._tmp.write_text(json.dumps(pins or BASE_PINS, indent=2) + "\n")
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    def test_raises_if_config_missing(self, *_):
+        self._tmp.unlink(missing_ok=True)
+        with self.assertRaises(FileNotFoundError):
+            m.run_update(dry_run=False)
+
+    @patch("update_therock_deps.read_deps")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_skips_if_open_pr_exists(self, mock_find, mock_read):
+        self._write_pins()
+        mock_find.return_value = "https://github.com/ROCm/ROCgdb/pull/99"
+        result = m.run_update(dry_run=False)
+        self.assertEqual(result, "skipped-existing-pr")
+        mock_read.assert_not_called()
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_not_needed_when_nothing_changed(self, mock_find, mock_commit, mock_digest):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA, "2026-07-30T10:07:58Z")
+        mock_digest.return_value = (DIGEST, "2026-07-27T09:37:30Z")
+        result = m.run_update(dry_run=False)
+        self.assertEqual(result, "not-needed")
+        mock_commit.assert_called_once_with(fetch_timestamp=True)
+        mock_digest.assert_called_once_with(fetch_timestamp=True)
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    def test_dry_run_returns_dry_run_when_changed(self, mock_commit, mock_digest):
+        self._write_pins()
+        mock_commit.return_value = (SHA2, None)
+        mock_digest.return_value = (DIGEST2, None)
+        result = m.run_update(dry_run=True)
+        self.assertEqual(result, "dry-run")
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    def test_dry_run_not_needed_when_unchanged(self, mock_commit, mock_digest):
+        self._write_pins()
+        mock_commit.return_value = (SHA, None)
+        mock_digest.return_value = (DIGEST, None)
+        result = m.run_update(dry_run=True)
+        self.assertEqual(result, "not-needed")
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    def test_raises_on_missing_therock_commit_created(self, mock_commit, mock_digest):
+        pins = {k: v for k, v in BASE_PINS.items() if k != "therock_commit_created"}
+        self._write_pins(pins)
+        mock_commit.return_value = (SHA2, None)
+        mock_digest.return_value = (DIGEST2, None)
+        with self.assertRaises(ValueError) as ctx:
+            m.run_update(dry_run=True)
+        self.assertIn("therock_commit_created", str(ctx.exception))
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    def test_raises_on_missing_build_image_created(self, mock_commit, mock_digest):
+        pins = {k: v for k, v in BASE_PINS.items() if k != "build_image_created"}
+        self._write_pins(pins)
+        mock_commit.return_value = (SHA2, None)
+        mock_digest.return_value = (DIGEST2, None)
+        with self.assertRaises(ValueError) as ctx:
+            m.run_update(dry_run=True)
+        self.assertIn("build_image_created", str(ctx.exception))
+
+    @patch("update_therock_deps.open_update_pr")
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_full_update_both_changed_writes_correct_pins(
+        self, mock_find, mock_commit, mock_digest, mock_run, mock_pr
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        mock_pr.return_value = "https://github.com/ROCm/ROCgdb/pull/100"
+
+        result = m.run_update(dry_run=False)
+        self.assertEqual(result, "created")
+
+        written = json.loads(self._tmp.read_text())
+        self.assertEqual(written["therock_commit_ref"], SHA2)
+        self.assertEqual(written["therock_commit_created"], "2026-08-10T12:34:56Z")
+        self.assertIn(DIGEST2, written["build_image"])
+        self.assertEqual(written["build_image_created"], "2026-08-11T00:00:00Z")
+
+    @patch("update_therock_deps.open_update_pr")
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_only_commit_changed_preserves_build_image_created(
+        self, mock_find, mock_commit, mock_digest, mock_run, mock_pr
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST, "2026-08-11T00:00:00Z")
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        mock_pr.return_value = "https://github.com/ROCm/ROCgdb/pull/100"
+
+        m.run_update(dry_run=False)
+        written = json.loads(self._tmp.read_text())
+        self.assertEqual(
+            written["build_image_created"], BASE_PINS["build_image_created"]
+        )
+        self.assertEqual(written["therock_commit_created"], "2026-08-10T12:34:56Z")
+
+    @patch("update_therock_deps.open_update_pr")
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_only_digest_changed_preserves_therock_commit_created(
+        self, mock_find, mock_commit, mock_digest, mock_run, mock_pr
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        mock_pr.return_value = "https://github.com/ROCm/ROCgdb/pull/100"
+
+        m.run_update(dry_run=False)
+        written = json.loads(self._tmp.read_text())
+        self.assertEqual(
+            written["therock_commit_created"], BASE_PINS["therock_commit_created"]
+        )
+        self.assertEqual(written["build_image_created"], "2026-08-11T00:00:00Z")
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_invalid_commit_created_format_raises(
+        self, mock_find, mock_commit, mock_digest
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "not-a-date")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        with self.assertRaises(ValueError) as ctx:
+            m.run_update(dry_run=False)
+        self.assertIn("commit_created format", str(ctx.exception))
+
+    @patch("update_therock_deps.open_update_pr")
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_branch_name_contains_date_and_sha(
+        self, mock_find, mock_commit, mock_digest, mock_run, mock_pr
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        mock_pr.return_value = "https://github.com/ROCm/ROCgdb/pull/100"
+
+        m.run_update(dry_run=False)
+        checkout_cmd = mock_run.call_args_list[0][0][0]
+        branch = checkout_cmd[-1]
+        self.assertIn("2026-08-10", branch)
+        self.assertIn(SHA2[:8], branch)
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_dry_run_does_not_check_for_existing_pr(
+        self, mock_find, mock_commit, mock_digest
+    ):
+        self._write_pins()
+        mock_commit.return_value = (SHA2, None)
+        mock_digest.return_value = (DIGEST2, None)
+        m.run_update(dry_run=True)
+        mock_find.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+class TestRun(unittest.TestCase):
+    def test_raises_on_nonzero_exit_by_default(self):
+        with patch("subprocess.run") as mock_sub:
+            mock_sub.return_value = MagicMock(returncode=1, stdout="", stderr="fail")
+            with self.assertRaises(subprocess.CalledProcessError):
+                m.run(["false"])
+
+    def test_no_raise_when_check_false(self):
+        with patch("subprocess.run") as mock_sub:
+            mock_sub.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            result = m.run(["false"], check=False)
+            self.assertEqual(result.returncode, 1)
+
+    def test_returns_completed_process(self):
+        with patch("subprocess.run") as mock_sub:
+            cp = MagicMock(returncode=0, stdout="hello", stderr="")
+            mock_sub.return_value = cp
+            result = m.run(["echo", "hello"])
+            self.assertEqual(result, cp)
+
+
+import subprocess  # noqa: E402 — needed for CalledProcessError reference above
+
+
+# ---------------------------------------------------------------------------
+# run_update (additional)
+# ---------------------------------------------------------------------------
+
+
+class TestRunUpdateAdditional(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(tempfile.mktemp(suffix=".json"))
+        self._orig_cf = m.CONFIG_FILE
+        m.CONFIG_FILE = self._tmp
+
+    def tearDown(self):
+        m.CONFIG_FILE = self._orig_cf
+        self._tmp.unlink(missing_ok=True)
+
+    def _write_pins(self, pins=None):
+        self._tmp.write_text(json.dumps(pins or BASE_PINS, indent=2) + "\n")
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_fetch_timestamp_true_in_live_mode(
+        self, mock_find, mock_commit, mock_digest
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        with patch("update_therock_deps.run") as mock_run, patch(
+            "update_therock_deps.open_update_pr", return_value="http://pr"
+        ):
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            m.run_update(dry_run=False)
+        mock_commit.assert_called_once_with(fetch_timestamp=True)
+        mock_digest.assert_called_once_with(fetch_timestamp=True)
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_commit_created_none_guard_raises(
+        self, mock_find, mock_commit, mock_digest
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, None)  # None despite live mode
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        with self.assertRaises(ValueError) as ctx:
+            m.run_update(dry_run=False)
+        self.assertIn("commit_created is None", str(ctx.exception))
+
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_build_created_none_guard_raises(self, mock_find, mock_commit, mock_digest):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, None)  # None despite live mode
+        with self.assertRaises(ValueError) as ctx:
+            m.run_update(dry_run=False)
+        self.assertIn("build_created is None", str(ctx.exception))
+
+    @patch("update_therock_deps.open_update_pr")
+    @patch("update_therock_deps.run")
+    @patch("update_therock_deps.get_build_digest")
+    @patch("update_therock_deps.get_therock_commit")
+    @patch("update_therock_deps.find_open_update_pr")
+    def test_build_image_field_has_full_uri(
+        self, mock_find, mock_commit, mock_digest, mock_run, mock_pr
+    ):
+        self._write_pins()
+        mock_find.return_value = None
+        mock_commit.return_value = (SHA2, "2026-08-10T12:34:56Z")
+        mock_digest.return_value = (DIGEST2, "2026-08-11T00:00:00Z")
+        mock_run.return_value = MagicMock(stdout="", returncode=0)
+        mock_pr.return_value = "https://github.com/ROCm/ROCgdb/pull/100"
+
+        m.run_update(dry_run=False)
+        written = json.loads(self._tmp.read_text())
+        self.assertTrue(
+            written["build_image"].startswith(
+                "ghcr.io/rocm/therock_build_manylinux_x86_64@"
+            )
+        )
+        self.assertIn(DIGEST2, written["build_image"])
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    @patch("update_therock_deps.run_update")
+    def test_returns_0_on_success(self, mock_update):
+        mock_update.return_value = "created"
+        with patch("sys.argv", ["update_therock_deps.py"]):
+            rc = m.main()
+        self.assertEqual(rc, 0)
+
+    @patch("update_therock_deps.run_update")
+    def test_returns_1_on_exception(self, mock_update):
+        mock_update.side_effect = ValueError("boom")
+        with patch("sys.argv", ["update_therock_deps.py"]):
+            rc = m.main()
+        self.assertEqual(rc, 1)
+
+    @patch("update_therock_deps.run_update")
+    def test_passes_dry_run_flag(self, mock_update):
+        mock_update.return_value = "dry-run"
+        with patch("sys.argv", ["update_therock_deps.py", "--dry-run"]):
+            m.main()
+        mock_update.assert_called_once_with(True)
+
+    @patch("update_therock_deps.run_update")
+    def test_no_dry_run_by_default(self, mock_update):
+        mock_update.return_value = "not-needed"
+        with patch("sys.argv", ["update_therock_deps.py"]):
+            m.main()
+        mock_update.assert_called_once_with(False)
+
+    @patch("update_therock_deps.run_update")
+    def test_returns_1_on_file_not_found(self, mock_update):
+        mock_update.side_effect = FileNotFoundError("missing")
+        with patch("sys.argv", ["update_therock_deps.py"]):
+            rc = m.main()
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_therock_deps.py
+++ b/.github/scripts/update_therock_deps.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-"""Update TheRock references in ROCgdb's CI workflow.
+"""Update TheRock references in ROCgdb's CI dependency pin file.
 
 Fetches the latest TheRock commit and the latest therock_build_manylinux_x86_64
-container digest, updates .github/workflows/therock-ci-linux.yml, then pushes a
-branch and opens a ROCgdb PR labelled 'therock-deps'. If an update PR already
-carries that label, the run skips without touching git.
+container digest, updates .github/configs.json, then pushes a branch and
+opens a ROCgdb PR labelled 'therock-deps'. If an update PR already carries that
+label, the run skips without touching git.
 
 The test container is not updated here: it is pinned transitively through
-THEROCK_COMMIT_REF (TheRock's fetch_test_configurations.py supplies the test
+therock_commit_ref (TheRock's fetch_test_configurations.py supplies the test
 image), so bumping the commit ref updates it automatically.
 """
 
 import argparse
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -31,9 +32,8 @@ from pathlib import Path
 
 ROCGDB_REPO = "ROCm/ROCgdb"
 BASE_BRANCH = "amd-staging"
-CI_LINUX = Path(".github/workflows/therock-ci-linux.yml")
+CONFIG_FILE = Path(".github/configs.json")
 
-THEROCK_REPO_URL = "https://github.com/ROCm/TheRock.git"
 BUILD_IMAGE = "ghcr.io/rocm/therock_build_manylinux_x86_64"
 
 UPDATE_LABEL = "therock-deps"
@@ -52,16 +52,24 @@ MAX_RETRIES = 3  # number of retries for network requests
 # ---------------------------------------------------------------------------
 
 
-def urlopen_with_retry(req, timeout: int = 30):
-    """Open a URL with retries on transient errors."""
+def urlopen_with_retry(req: str | urllib.request.Request, timeout: int = 30):
+    """Open a URL with retries on transient errors (5xx, timeout); raises immediately on 4xx."""
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             return urllib.request.urlopen(req, timeout=timeout)
+        except urllib.error.HTTPError as exc:
+            if exc.code < 500:
+                raise
+            if attempt == MAX_RETRIES:
+                raise
+            print(f"[RETRY] attempt {attempt}/{MAX_RETRIES} failed: {exc}")
+            time.sleep(2**attempt)
         except (urllib.error.URLError, TimeoutError) as exc:
             if attempt == MAX_RETRIES:
                 raise
             print(f"[RETRY] attempt {attempt}/{MAX_RETRIES} failed: {exc}")
-            time.sleep(2 ** attempt)
+            time.sleep(2**attempt)
+    raise RuntimeError("urlopen_with_retry: unreachable")
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +83,7 @@ def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.stdout:
         print(result.stdout.rstrip())
-    if result.returncode != 0 and result.stderr:
+    if result.stderr:
         print(result.stderr.rstrip(), file=sys.stderr)
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(
@@ -106,7 +114,7 @@ def ensure_label(label: str) -> None:
     )
     existing = [entry["name"] for entry in json.loads(result.stdout or "[]")]
     if label not in existing:
-        raise RuntimeError(
+        raise ValueError(
             f"Label '{label}' not found in {ROCGDB_REPO}. "
             "Please create it in the repo settings before running."
         )
@@ -142,21 +150,58 @@ def find_open_update_pr() -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def get_therock_commit() -> tuple[str, str]:
-    """Return (commit_sha, today) for TheRock's main branch."""
-    result = run(["git", "ls-remote", THEROCK_REPO_URL, "refs/heads/main"])
-    parts = result.stdout.split()
-    commit = parts[0] if parts else ""
+def get_therock_commit(fetch_timestamp: bool = True) -> tuple[str, str | None]:
+    """Return (commit_sha, commit_created) for TheRock's main branch.
+
+    Uses the GitHub branches API so the call goes through urlopen_with_retry.
+    If fetch_timestamp is False, only the SHA is fetched and None is returned
+    in place of the timestamp (useful for dry-run mode).
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    if gh_token := os.environ.get("GH_TOKEN"):
+        headers["Authorization"] = f"Bearer {gh_token}"
+
+    # Use the REST API for the branch HEAD so the call goes through urlopen_with_retry
+    # and benefits from the same retry logic as the other network operations.
+    branch_url = "https://api.github.com/repos/ROCm/TheRock/branches/main"
+    req = urllib.request.Request(branch_url, headers=headers)
+    with urlopen_with_retry(req) as resp:
+        branch_data = json.loads(resp.read())
+    commit = (branch_data.get("commit") or {}).get("sha", "")
     if not SHA_RE.match(commit):
         raise ValueError(f"Invalid TheRock SHA received: {commit!r}")
-    return commit, date.today().isoformat()
+
+    if not fetch_timestamp:
+        return commit, None
+
+    api_url = f"https://api.github.com/repos/ROCm/TheRock/commits/{commit}"
+    req = urllib.request.Request(api_url, headers=headers)
+    with urlopen_with_retry(req) as resp:
+        data = json.loads(resp.read())
+    commit_obj = data.get("commit")
+    if not commit_obj:
+        raise ValueError(
+            f"GitHub API returned no commit object for {commit!r}: {data.get('message', '')!r}"
+        )
+    committer = commit_obj.get("committer")
+    if not committer:
+        raise ValueError(f"GitHub API returned no committer for {commit!r}")
+    commit_created = committer.get("date")
+    if not commit_created:
+        raise ValueError(f"GitHub API returned no committer date for {commit!r}")
+    # e.g. "2026-08-10T12:34:56Z"
+    return commit, commit_created
 
 
-def get_build_digest() -> tuple[str, str]:
-    """Return (digest, today) for the latest build container image.
+def get_build_digest(fetch_timestamp: bool = True) -> tuple[str, str | None]:
+    """Return (digest, build_created) for the latest build container image.
 
     Uses the OCI Distribution API directly — no external tools required.
     The digest comes from the Docker-Content-Digest response header.
+    The image creation timestamp comes from the OCI config blob's 'created' field.
+
+    If fetch_timestamp is False, the config blob is not fetched and None is returned
+    in place of the timestamp (useful for dry-run mode where only the digest is needed).
     """
     # GHCR requires an anonymous bearer token even for public images.
     image_path = BUILD_IMAGE.removeprefix("ghcr.io/")
@@ -164,72 +209,64 @@ def get_build_digest() -> tuple[str, str]:
         f"https://ghcr.io/token?scope=repository:{image_path}:pull&service=ghcr.io"
     )
     with urlopen_with_retry(token_url) as resp:
-        token = json.loads(resp.read())["token"]
+        token_data = json.loads(resp.read())
+    token = token_data.get("token")
+    if not token:
+        raise ValueError(
+            f"GHCR token endpoint returned no token: {token_data.get('error', '')!r}"
+        )
 
+    auth_header = {"Authorization": f"Bearer {token}"}
     req = urllib.request.Request(
         f"https://ghcr.io/v2/{image_path}/manifests/latest",
         headers={
-            "Authorization": f"Bearer {token}",
+            **auth_header,
             "Accept": (
                 "application/vnd.docker.distribution.manifest.v2+json,"
-                "application/vnd.oci.image.manifest.v1+json,"
-                "application/vnd.oci.image.index.v1+json"
+                "application/vnd.oci.image.manifest.v1+json"
             ),
         },
     )
     with urlopen_with_retry(req) as resp:
         digest = resp.headers.get("Docker-Content-Digest", "")
+        manifest = json.loads(resp.read())
 
     if not DIGEST_RE.match(digest):
         raise ValueError(f"Invalid build image digest received: {digest!r}")
-    return digest, date.today().isoformat()
+
+    if not fetch_timestamp:
+        return digest, None
+
+    config_digest = (manifest.get("config") or {}).get("digest")
+    if not config_digest:
+        raise ValueError("Manifest has no config blob digest")
+    config_req = urllib.request.Request(
+        f"https://ghcr.io/v2/{image_path}/blobs/{config_digest}",
+        headers=auth_header,
+    )
+    with urlopen_with_retry(config_req) as config_resp:
+        config = json.loads(config_resp.read())
+
+    created = config.get("created")
+    if not created:
+        raise ValueError("Config blob has no 'created' field")
+
+    return digest, created
 
 
 # ---------------------------------------------------------------------------
-# File update
+# Dependency file read / write
 # ---------------------------------------------------------------------------
 
 
-def read_current(content: str) -> dict[str, str]:
-    """Extract the current commit ref and build digest from the CI workflow content."""
-    values: dict[str, str] = {}
-    commit = re.search(r"THEROCK_COMMIT_REF:\s+([0-9a-f]{40})", content)
-    if commit:
-        values["commit"] = commit.group(1)
-    digest = re.search(re.escape(BUILD_IMAGE) + r"@(sha256:[0-9a-f]{64})", content)
-    if digest:
-        values["build_digest"] = digest.group(1)
-    return values
+def read_deps() -> dict[str, str]:
+    """Read and return the current dependency pins from CONFIG_FILE."""
+    return json.loads(CONFIG_FILE.read_text())
 
 
-def render_ci_linux(
-    content: str, commit: str, commit_date: str, build_digest: str, build_date: str
-) -> str:
-    """Return updated content for the CI workflow.
-
-    Pure: does not write to disk. Raises if either expected pattern is not found.
-    """
-    updated, n = re.subn(
-        r"THEROCK_COMMIT_REF: .* # .*",
-        f"THEROCK_COMMIT_REF: {commit} # {commit_date}",
-        content,
-    )
-    if n != 1:
-        raise ValueError(
-            f"Expected exactly 1 match for THEROCK_COMMIT_REF pattern, got {n}. "
-            "Check that the line has a trailing '# date' comment."
-        )
-    updated, n = re.subn(
-        re.escape(BUILD_IMAGE) + r"@sha256:[0-9a-f]+ # .*",
-        f"{BUILD_IMAGE}@{build_digest} # {build_date}",
-        updated,
-    )
-    if n != 1:
-        raise ValueError(
-            f"Expected exactly 1 match for build image pattern, got {n}. "
-            "Check that the line has a trailing '# date' comment."
-        )
-    return updated
+def write_deps(pins: dict[str, str]) -> None:
+    """Write updated dependency pins to CONFIG_FILE."""
+    CONFIG_FILE.write_text(json.dumps(pins, indent=2) + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -237,27 +274,40 @@ def render_ci_linux(
 # ---------------------------------------------------------------------------
 
 
-def build_commit_message(old: dict[str, str], commit: str, digest: str) -> str:
+def build_commit_message(pins: dict[str, str], commit: str, digest: str) -> str:
     lines = ["Update TheRock dependencies and container images", ""]
-    old_commit = old.get("commit")
-    if old_commit and old_commit != commit:
-        lines.append(f"commit: {old_commit[:12]} -> {commit[:12]}")
-    old_digest = old.get("build_digest")
-    if old_digest and old_digest != digest:
+    old_commit = pins.get("therock_commit_ref", "")
+    if old_commit != commit:
+        old_commit_display = old_commit[:12] if old_commit else "(none)"
+        lines.append(f"commit: {old_commit_display} -> {commit[:12]}")
+    old_image = pins.get("build_image", "")
+    old_digest = old_image.split("@", 1)[1] if "@" in old_image else ""
+    if old_digest and old_digest != digest and DIGEST_RE.match(old_digest):
         lines.append(f"build image: {old_digest[:19]}... -> {digest[:19]}...")
     return "\n".join(lines)
 
 
-def open_update_pr(branch: str, commit: str) -> str:
-    title = f"Update TheRock dependencies ({date.today().isoformat()})"
+def open_update_pr(
+    branch: str,
+    commit: str,
+    commit_created: str,
+    digest_changed: bool,
+    build_digest: str,
+    build_created: str,
+) -> str:
+    title = f"Automated TheRock dependency update ({date.today().isoformat()})"
+    commit_date = commit_created[:10]
+    changes = [f"* Bump `therock_commit_ref` to `{commit[:12]}` ({commit_date})"]
+    if digest_changed:
+        build_date = build_created[:10]
+        changes.append(
+            f"* Bump `therock_build_manylinux_x86_64` digest to"
+            f" `{build_digest[:19]}...` ({build_date})"
+        )
     body = (
-        "## Automated TheRock dependency update\n\n"
-        f"Bumps `THEROCK_COMMIT_REF` to `{commit[:12]}` and refreshes the "
-        "`therock_build_manylinux_x86_64` build container digest in "
-        "`.github/workflows/therock-ci-linux.yml`.\n\n"
+        "\n".join(changes) + "\n\n"
         "Opened automatically by the TheRock dependency update workflow. "
-        "Please kick CI manually (close and reopen, or push an empty commit), "
-        "then merge."
+        "Please validate CI and merge."
     )
     ensure_label(UPDATE_LABEL)
     result = run(
@@ -279,7 +329,10 @@ def open_update_pr(branch: str, commit: str) -> str:
             UPDATE_LABEL,
         ],
     )
-    return result.stdout.strip()
+    pr = result.stdout.strip()
+    if not pr:
+        raise ValueError("gh pr create succeeded but returned no PR URL")
+    return pr
 
 
 # ---------------------------------------------------------------------------
@@ -295,8 +348,8 @@ def summary(result: str, pr: str | None = None) -> None:
 
 
 def run_update(dry_run: bool) -> str:
-    if not CI_LINUX.exists():
-        raise FileNotFoundError(f"{CI_LINUX} not found; run from the repo root.")
+    if not CONFIG_FILE.exists():
+        raise FileNotFoundError(f"{CONFIG_FILE} not found; run from the repo root.")
 
     if not dry_run:
         existing = find_open_update_pr()
@@ -305,53 +358,101 @@ def run_update(dry_run: bool) -> str:
             summary("skipped-existing-pr", existing)
             return "skipped-existing-pr"
 
-    content = CI_LINUX.read_text()
-    old = read_current(content)
-    commit, commit_date = get_therock_commit()
-    build_digest, build_date = get_build_digest()
+    pins = read_deps()
 
-    updated = render_ci_linux(content, commit, commit_date, build_digest, build_date)
-    if updated == content:
-        print("\nReferences already current; nothing to update.")
+    # Validate required keys before any git side-effects.
+    if "therock_commit_created" not in pins:
+        raise ValueError("therock_commit_created missing from configs.json")
+    if "build_image_created" not in pins:
+        raise ValueError("build_image_created missing from configs.json")
+
+    commit, commit_created = get_therock_commit(fetch_timestamp=not dry_run)
+    build_digest, build_created = get_build_digest(fetch_timestamp=not dry_run)
+
+    old_commit = pins.get("therock_commit_ref", "")
+    old_image = pins.get("build_image", "")
+    old_digest = old_image.split("@", 1)[1] if "@" in old_image else ""
+    old_digest_valid = bool(DIGEST_RE.match(old_digest))
+    commit_changed = old_commit != commit
+    digest_changed = old_digest != build_digest
+
+    print("\n=== TheRock dependency update ===\n")
+    if commit_changed:
+        old_commit_display = old_commit[:12] if old_commit else "(none)"
+        print(f"TheRock ref update:      {old_commit_display} -> {commit[:12]}")
+    else:
+        print(f"TheRock ref:             unchanged ({commit[:12]})")
+    if digest_changed:
+        old_digest_display = (
+            f"{old_digest[:19]}..." if old_digest_valid else "(unknown)"
+        )
+        print(
+            f"Build container digest:  {old_digest_display} -> {build_digest[:19]}..."
+        )
+    else:
+        print(f"Build container digest:  unchanged ({build_digest[:19]}...)")
+
+    if not commit_changed and not digest_changed:
+        print("\nNo updates: TheRock ref and build container digest are both current.")
         summary("not-needed")
         return "not-needed"
 
-    print("\nUpdating references:")
-    if old.get("commit") != commit:
-        print(f"  commit:      {old.get('commit', '?')[:12]} -> {commit[:12]}")
-    if old.get("build_digest") != build_digest:
-        print(
-            f"  build image: {old.get('build_digest', '?')[:19]}... "
-            f"-> {build_digest[:19]}..."
-        )
-
     if dry_run:
+        changes = []
+        if commit_changed:
+            changes.append("TheRock ref")
+        if digest_changed:
+            changes.append("build container digest")
+        print(f"\nDry run: would update {' and '.join(changes)}.")
         summary("dry-run")
         return "dry-run"
 
-    branch = f"{BRANCH_PREFIX}-{commit_date}-{commit[:8]}"
-    message = build_commit_message(old, commit, build_digest)
+    if commit_created is None:
+        raise ValueError("commit_created is None despite fetch_timestamp=True")
+    if build_created is None:
+        raise ValueError("build_created is None despite fetch_timestamp=True")
+    date_prefix = commit_created[:10]
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_prefix):
+        raise ValueError(f"Unexpected commit_created format: {commit_created!r}")
+    branch = f"{BRANCH_PREFIX}-{date_prefix}-{commit[:8]}"
+    message = build_commit_message(pins, commit, build_digest)
 
     run(["git", "checkout", "-B", branch])
-    CI_LINUX.write_text(updated)
-    run(["git", "add", str(CI_LINUX)])
+    updated = dict(pins)
+    updated["therock_commit_ref"] = commit
+    updated["therock_commit_created"] = (
+        commit_created if commit_changed else pins["therock_commit_created"]
+    )
+    updated["build_image"] = f"{BUILD_IMAGE}@{build_digest}"
+    updated["build_image_created"] = (
+        build_created if digest_changed else pins["build_image_created"]
+    )
+    write_deps(updated)
+    run(["git", "add", str(CONFIG_FILE)])
     run(["git", "commit", "-m", message])
     run(["git", "push", "origin", branch])
 
-    pr = open_update_pr(branch, commit)
+    pr = open_update_pr(
+        branch,
+        commit,
+        commit_created,
+        digest_changed,
+        build_digest,
+        build_created,
+    )
     summary("created", pr)
     return "created"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Update TheRock references in ROCgdb's CI workflow."
+        description="Update TheRock references in ROCgdb's CI dependency pin file."
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Fetch and update the file, print the diff, but skip branch, "
-        "commit, push and PR creation.",
+        help="Fetch and compute changes, print what would be updated, but skip "
+        "branch, commit, push and PR creation.",
     )
     args = parser.parse_args()
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -16,35 +16,45 @@ on:
 permissions:
   contents: read
 
-env:
-  THEROCK_COMMIT_REF: 2ee541083481e6c93f2ea811f212b61047980b1a # 2026-07-30
-
 jobs:
+  resolve:
+    name: Resolve TheRock references
+    runs-on: ubuntu-24.04
+    outputs:
+      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
+      build_image: ${{ steps.read.outputs.build_image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read TheRock dependency pins
+        id: read
+        run: python3 .github/scripts/config.py therock_commit_ref build_image
+
   therock-build-linux:
     name: Build Linux Packages
+    needs: resolve
     runs-on: ${{ inputs.build_runs_on }}
     permissions:
+      contents: read
       id-token: write
     outputs:
-      therock_ref: ${{ steps.export-ref.outputs.therock_ref }}
+      therock_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:8616d086df21bcc835aed5112ff0d878530a0cf5433f8f42c7b28b973a75bb19 # 2026-07-27
+      image: ${{ needs.resolve.outputs.build_image }}
     env:
+      THEROCK_COMMIT_REF: ${{ needs.resolve.outputs.therock_commit_ref }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
 
     steps:
-      - name: Export TheRock ref
-        id: export-ref
-        run: echo "therock_ref=${{ env.THEROCK_COMMIT_REF }}" >> $GITHUB_OUTPUT
-
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ env.THEROCK_COMMIT_REF }}
+          ref: ${{ needs.resolve.outputs.therock_commit_ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Move `THEROCK_COMMIT_REF` and the build container digest out of
`therock-ci-linux.yml` and into `.github/configs.json`, a plain data
file documented in `.github/configs.md`. A `resolve` job reads and
validates the pins and exposes them as outputs; the build job references
those outputs for `container.image` and `THEROCK_COMMIT_REF`. This lets
the automated update workflow push changes with only `contents: write`
on the `GITHUB_TOKEN`.

The update script is reworked accordingly:

- Fetch the TheRock branch HEAD and committer timestamp from the GitHub
  REST API (retried on transient failures) instead of `git ls-remote`
  and a separate commit lookup.
- Fetch the build container digest and creation timestamp via the OCI
  Distribution API, removing the dependency on `skopeo`.
- Skip opening a new PR if one labelled `therock-deps` is already open.
- Write a dry-run summary to stdout instead of exiting early.

A new `.github/scripts/config.py` helper reads and validates named
fields from `configs.json` and writes them to `GITHUB_OUTPUT`, following
the same pattern as `select_runner.py`. This avoids inline Python in the
workflow YAML, which breaks GitHub Actions' parser for reusable
workflows.

Fixes the YAML parse error that caused TheRock CI to fail for all PRs
after the original commit was merged.