### PR TITLE
gdb.rocm: prevent ROCr core dumps on exceptions

### DIFF
--- a/gdb/testsuite/gdb.rocm/illegal-insn-sigill.exp
+++ b/gdb/testsuite/gdb.rocm/illegal-insn-sigill.exp
@@ -35,6 +35,8 @@ proc do_test { } {
     gdb_load $::binfile
 
     with_rocm_gpu_lock {
+	# Prevent ROCr from generating a GPU core dump.
+	gdb_test_no_output "set environment HSA_DISABLE_COREDUMP_ON_EXCEPTION=1"
 	if {![runto_main]} {
 	    return
 	}


### PR DESCRIPTION
Set HSA_DISABLE_COREDUMP_ON_EXCEPTION=1 in tests that trigger GPU
exceptions which cause the ROCr runtime to generate a core dump before
calling abort.

Tests updated:
- gdb.rocm/illegal-insn-sigill.exp
- gdb.rocm/step-abort.exp (pursued upstream)