### PR TITLE
gdb.rocm/hip-builtin-completions: consider multi choices for completions

### DIFF
--- a/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
+++ b/gdb/testsuite/gdb.rocm/hip-builtin-completions.exp
@@ -51,8 +51,29 @@ proc all_hip_completions {} {
     foreach var {threadIdx blockIdx blockDim gridDim warpSize} {
 	# threadI blockI blockD gridD warpSi
 	set substr [string range $var 0 [expr {[string length $var] - 3}]]
-	gdb_test "complete print $substr" "print $var"
-	gdb_test "complete break main if $substr" "break main if $var"
+
+	set seen false
+	gdb_test_multiple "complete print $substr" "print $substr" {
+	    -re "print $var\r\n" {
+		set seen true
+		exp_continue
+	    }
+	    -re "$::gdb_prompt $" {
+		gdb_assert {$seen} $gdb_test_name
+	    }
+	}
+
+	set seen false
+	gdb_test_multiple "complete break main if $substr" \
+	    "break main if $substr" {
+	    -re "break main if $var\r\n" {
+		set seen true
+		exp_continue
+	    }
+	    -re "$::gdb_prompt $" {
+		gdb_assert {$seen} $gdb_test_name
+	    }
+	}
     }
 
     # ".x", ".y" and ".z" completions for three-dimensional built-ins.


### PR DESCRIPTION
```
Current implementation of the test assumes one "suggestion" per
completion.  This can go awry if there are symbols that have
commonality in their names with the symbols that the test cares
about, like "threadIdx" and "threadIndex" [1].

This change adjust the checks as such to look for the desired
symbol name in the output of "complete" command, assuming that
there can be one or more entries.

[1]
Due to the missing step of stripping ".symtab" from libLLVM.so, a
"threadIndex" variable comes into GDB's scope.  This collides with
the expected tab-completion of "threadI" to become "threadIdx".
The symbol from libLLVM.so is loaded through these shared objects
dependencies:

  test
    libamdhip64.so
      libamd_comgr.so
        libclang-cpp.so
          libLLVM.so

Bug: LCOMPILER-2585
```