### PR TITLE
github: add rocgdb-corefile to the test workflow

### DIFF
--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Configure test matrix
         env:
-          PROJECTS_TO_TEST: "rocgdb-cpu,rocgdb-gpu"
+          PROJECTS_TO_TEST: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           CI_CONFIG_PATH: ci-config
         id: configure


### PR DESCRIPTION
Add rocgdb-corefile to the list of projects tested in the TheRock test
packages workflow, alongside rocgdb-cpu and rocgdb-gpu.