### PR TITLE
gdb, amdgpu: pass process id to amd_dbgapi_convert_address_space

### DIFF
--- a/gdb/amdgpu-tdep.c
+++ b/gdb/amdgpu-tdep.c
@@ -1900,7 +1900,11 @@ amdgpu_get_watchable_aliases (struct gdbarch *gdbarch,
       /* Try to convert the address to an address in the
 	 default address space.  */
       if (amd_dbgapi_convert_address_space
-	    (wave_id, simd_lane, dbgapi_from_addr_space_id,
+	    (
+#if AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID
+	     get_amd_dbgapi_process_id (current_inferior ()),
+#endif
+	     wave_id, simd_lane, dbgapi_from_addr_space_id,
 	     (amd_dbgapi_segment_address_t) addr,
 	     dbgapi_to_addr_space_id, &to_offset, &converted_size)
 	    != AMD_DBGAPI_STATUS_SUCCESS)

--- a/gdb/config.in
+++ b/gdb/config.in
@@ -6,6 +6,9 @@
 /* Additional directories to look for separate debug info. */
 #undef ADDITIONAL_DEBUG_DIRS
 
+/* Define if amd_dbgapi_convert_address_space needs a process_id */
+#undef AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID
+
 /* Directories from which to load auto-loaded scripts. */
 #undef AUTO_LOAD_DIR
 

--- a/gdb/configure
+++ b/gdb/configure
@@ -25457,6 +25457,46 @@ $as_echo "#define HAVE_AMD_DBGAPI 1" >>confdefs.h
 	as_fn_error $? "amd-dbgapi not supported for host ${gdb_host}" "$LINENO" 5
 	;;
     esac
+
+    # Detect if process id can be passed to convert_address_space.
+    save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $AMD_DBGAPI_CFLAGS"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether amd_dbgapi_convert_address_space takes a process id" >&5
+$as_echo_n "checking whether amd_dbgapi_convert_address_space takes a process id... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <amd-dbgapi/amd-dbgapi.h>
+int
+main ()
+{
+amd_dbgapi_process_id_t p;
+	  amd_dbgapi_wave_id_t w;
+	  amd_dbgapi_lane_id_t l;
+	  amd_dbgapi_address_space_id_t s, d;
+	  amd_dbgapi_convert_address_space (p, w, l, s, 0, d, NULL, NULL);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  amd_dbgapi_convert_aspace_needs_process_id=yes
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  amd_dbgapi_convert_aspace_needs_process_id=no
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CPPFLAGS="$save_CPPFLAGS"
+
+    if test "x${amd_dbgapi_convert_aspace_needs_process_id}" = "xyes"; then
+
+$as_echo "#define AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID 1" >>confdefs.h
+
+    fi
+
   elif test "$gdb_require_amd_dbgapi" = true -o "$with_amd_dbgapi" = yes; then
     # amd-dbgapi was not found and...
     #

--- a/gdb/configure.ac
+++ b/gdb/configure.ac
@@ -354,6 +354,31 @@ if test "$gdb_require_amd_dbgapi" = true \
 	AC_MSG_ERROR([amd-dbgapi not supported for host ${gdb_host}])
 	;;
     esac
+
+    # Detect if process id can be passed to convert_address_space.
+    save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $AMD_DBGAPI_CFLAGS"
+    AC_MSG_CHECKING([whether amd_dbgapi_convert_address_space takes a process id])
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+	[[#include <amd-dbgapi/amd-dbgapi.h>]],
+	[[amd_dbgapi_process_id_t p;
+	  amd_dbgapi_wave_id_t w;
+	  amd_dbgapi_lane_id_t l;
+	  amd_dbgapi_address_space_id_t s, d;
+	  amd_dbgapi_convert_address_space (p, w, l, s, 0, d, NULL, NULL);]]
+       )],
+       [amd_dbgapi_convert_aspace_needs_process_id=yes
+	AC_MSG_RESULT([yes])],
+       [amd_dbgapi_convert_aspace_needs_process_id=no
+	AC_MSG_RESULT([no])])
+    CPPFLAGS="$save_CPPFLAGS"
+
+    if test "x${amd_dbgapi_convert_aspace_needs_process_id}" = "xyes"; then
+      AC_DEFINE(AMD_DBGAPI_CONVERT_ASPACE_NEED_PROCESS_ID, 1,
+		[Define if amd_dbgapi_convert_address_space needs a process_id])
+    fi
+
   elif test "$gdb_require_amd_dbgapi" = true -o "$with_amd_dbgapi" = yes; then
     # amd-dbgapi was not found and...
     #


### PR DESCRIPTION
Starting with version 0.81, dbgapi expects a process id as the first argument to amd_dbgapi_convert_address_space.
