### PR TITLE
testsuite: hip: fix -Wpointer-bool-conversion warnings in hip-driver.cc

### DIFF
--- a/gdb/testsuite/lib/hip/hip-driver.cc
+++ b/gdb/testsuite/lib/hip/hip-driver.cc
@@ -63,19 +63,19 @@ kernel (unsigned char *malloc_buffer,
 
   /* See comments in hip-test-main.h.  gdb_hip_test_main is weak -- we
      call the version that is defined by the testcase.  */
-  if (auto &m = static_cast<int (&)(int, char **, char **)>(gdb_hip_test_main))
+  if (auto *m = static_cast<int (*)(int, char **, char **)>(gdb_hip_test_main))
     *res = m (argc, argv, envp);
 
-  else if (auto &m = static_cast<int (&)(int, char **)>(gdb_hip_test_main))
+  else if (auto *m = static_cast<int (*)(int, char **)>(gdb_hip_test_main))
     *res = m (argc, argv);
 
-  else if (auto &m = static_cast<int (&)(int, const char **)>(gdb_hip_test_main))
+  else if (auto *m = static_cast<int (*)(int, const char **)>(gdb_hip_test_main))
     *res = m (argc, (const char **) argv);
 
-  else if (auto &m = static_cast<int (&)(int, char *const *)>(gdb_hip_test_main))
+  else if (auto *m = static_cast<int (*)(int, char *const *)>(gdb_hip_test_main))
     *res = m (argc, argv);
 
-  else if (auto &m = static_cast<int (&)()>(gdb_hip_test_main))
+  else if (auto *m = static_cast<int (*)()>(gdb_hip_test_main))
     *res = m ();
 
   else


### PR DESCRIPTION
Fix compilation warnings on Ubuntu 24.04 with newer Clang:

  warning: address of function 'm' will always evaluate to 'true'
  [-Wpointer-bool-conversion]

The kernel() function in hip-driver.cc checks which overload of the
weak symbol gdb_hip_test_main is defined by casting it and testing
the result in an if condition.  The original code used function
references (int (&)(...)), but a reference to a function can never
be null, so the condition always evaluates to true.

Fix this by using function pointers (int (*)(...)) instead.  A
function pointer for an undefined weak symbol is null, so the
if/else if chain correctly identifies the defined overload.