### PR TITLE
github: schedule therock deps update to run weekly on Mondays

### DIFF
--- a/.github/workflows/therock-deps-update.yml
+++ b/.github/workflows/therock-deps-update.yml
@@ -1,9 +1,8 @@
 name: Update TheRock Dependencies
 
 on:
-  # schedule: # runs twice daily (03:17 and 15:17 UTC)
-  #   - cron: '17 3 * * *'
-  #   - cron: '17 15 * * *'
+  schedule: # runs weekly on Mondays at 03:17 UTC
+    - cron: '17 3 * * 1'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -38,4 +37,4 @@ jobs:
 
       - name: Update TheRock references
         run: |
-          python3 .github/scripts/update_therock_deps.py ${{ inputs.dry_run && '--dry-run' || '' }}
+          python3 .github/scripts/update_therock_deps.py ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
## Summary

- Enable the scheduled trigger in `therock-deps-update.yml`, set to run every Monday at 03:17 UTC.
- Gate the `--dry-run` flag explicitly on `workflow_dispatch` so scheduled runs always execute for real.

## Test plan

- [ ] Verify the workflow appears under the scheduled triggers in the Actions tab after merge.
- [x] Trigger manually with `dry_run: true` to confirm the dry-run path still works.
- [x] Trigger manually with `dry_run: false` to confirm the real-run path works.