### PR TITLE
github: multi-arch CI for ROCgdb

### DIFF
--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -1,0 +1,13 @@
+{
+  "repositories": [
+    {
+      "name": "rocgdb",
+      "url": "ROCm/ROCgdb",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
+    }
+  ]
+}

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -1,0 +1,36 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+"""Maps ROCgdb source changes to TheRock build flags and tests.
+
+ROCgdb is the source of truth for a single component (rocgdb, built in TheRock's
+debug-tools stage). Unlike a monorepo, its files live at the repository root, so
+subtree mapping is trivial: any change maps to the single "rocgdb" project.
+
+TheRock's build_tools/github_actions/detect_external_repo_config.py imports this
+module for two things:
+  * _is_valid_repo_path(): requires this file (and therock_configure_ci.py) to
+    exist for ROCgdb to be treated as a valid external repo.
+  * get_test_list(): unions project_map[*]["project_to_test"] to know which tests
+    the external repo defines. It reads the "project_to_test" key (list or CSV)
+    and ignores cmake_options (multi-arch does full builds).
+"""
+
+# Root-level layout: the whole repository is the single rocgdb component.
+subtree_to_project_map = {
+    ".": "rocgdb",
+}
+
+project_map = {
+    "rocgdb": {
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_ALL=OFF",
+            "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON",
+        ],
+        "project_to_test": ["rocgdb-cpu", "rocgdb-gpu", "rocgdb-corefile"],
+    },
+}
+
+# ROCgdb multi-arch CI targets Linux only for now.
+windows_only_subtrees = set()
+
+trigger_windows_ci_for_subtrees_paths = []

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,10 +1,9 @@
 name: TheRock CI for rocgdb
 
+# Superseded by therock-multi-arch-ci.yml. The single-arch presubmit is disabled;
+# the pull_request trigger is removed so this chain (therock-ci-linux.yml,
+# therock-test-packages.yml, therock-test-component.yml) only runs on demand.
 on:
-  pull_request:
-    branches:
-      - amd-staging
-      - amd-staging-rocgdb-*
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -107,7 +107,7 @@ jobs:
       # main and rebuilds only the impacted stages.
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: main
+      ref: users/lumachad/main/stage-reuse-timing
       # Build ROCgdb from this PR's source instead of TheRock's pinned submodule.
       # detect_external_repo_config.py resolves the repo to rocgdb, checks it out
       # to external-rocgdb, and injects -DTHEROCK_ROCGDB_SOURCE_DIR automatically;
@@ -152,7 +152,7 @@ jobs:
       # Empty string when run_all_tests=true triggers a full test run downstream.
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: main
+      ref: users/lumachad/main/stage-reuse-timing
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -108,6 +108,9 @@ jobs:
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
       ref: users/lumachad/main/stage-reuse-timing
+      # Pass main's tip SHA explicitly so commit-ancestry checking uses a
+      # real main commit, not the tip of the instrumented branch.
+      stage_reuse_current_sha: 48d493e696d795a0aa49c8f39969345eef8f4257
       # Build ROCgdb from this PR's source instead of TheRock's pinned submodule.
       # detect_external_repo_config.py resolves the repo to rocgdb, checks it out
       # to external-rocgdb, and injects -DTHEROCK_ROCGDB_SOURCE_DIR automatically;

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -1,0 +1,178 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Multi-Arch CI for ROCgdb
+#
+# Builds and tests ROCgdb across multiple GPU architectures by calling TheRock's
+# reusable multi-arch workflows directly, passing ROCgdb as an external repo.
+# TheRock already registers rocgdb as an external repo (checkout path
+# external-rocgdb, THEROCK_ROCGDB_SOURCE_DIR) and defines its tests
+# (rocgdb-cpu, rocgdb-gpu, rocgdb-corefile), so this workflow is mostly wiring.
+#
+# Supersedes the single-arch therock-ci.yml chain.
+#
+# TheRock ref: tracks ROCm/TheRock@main with automatic stage-reuse. The `@<ref>`
+# on `uses:` is the workflow-definition ref (Actions forbids an expression there)
+# and is kept in sync with the `ref:` build-source inputs.
+
+name: TheRock Multi-Arch CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - amd-staging
+      - amd-staging-rocgdb-*
+  workflow_dispatch:
+    inputs:
+      linux_amdgpu_families:
+        type: string
+        description: "Comma-separated Linux GPU families to build and test. ex: gfx94X,gfx950 (empty = default set)"
+        default: ""
+      linux_test_labels:
+        type: string
+        description: "Reduce the Linux test set to labels prefixed with 'test:'. ex: test:rocgdb-cpu,test:rocgdb-gpu"
+        default: ""
+      prebuilt_stages:
+        type: string
+        default: ""
+        description: "Comma-separated build stages to skip (or 'all'); artifacts are copied from baseline_run_id instead"
+      baseline_run_id:
+        type: string
+        default: ""
+        description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. Cancels queued
+  # and in-progress runs for the same PR (presubmit) or commit (postsubmit).
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  configure:
+    name: Configure Changed Projects
+    runs-on: ubuntu-24.04
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
+    outputs:
+      changed_projects: ${{ steps.configure.outputs.changed_projects }}
+      run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
+      skip_tests: ${{ steps.configure.outputs.skip_tests }}
+    steps:
+      - name: Checkout repository config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/repos-config.json
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout TheRock for configure script
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROCm/TheRock
+          ref: main
+          path: _therock
+          sparse-checkout: build_tools/github_actions
+          sparse-checkout-cone-mode: true
+
+      - name: Configure CI
+        id: configure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 _therock/build_tools/github_actions/configure_external_repo_ci.py \
+            --event-name "${{ github.event_name }}" \
+            --github-repo "${{ github.repository }}" \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --config-path ".github/repos-config.json"
+
+  setup:
+    needs: configure
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    with:
+      build_variant: "release"
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
+      # Linux-only for the first cut.
+      windows_amdgpu_families: ""
+      linux_test_labels: ${{ inputs.linux_test_labels || '' }}
+      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
+      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      # Automatic stage reuse: TheRock finds a commit-compatible baseline run on
+      # main and rebuilds only the impacted stages.
+      stage_reuse_mode: reuse-stage
+      repository: ROCm/TheRock
+      ref: main
+      # Build ROCgdb from this PR's source instead of TheRock's pinned submodule.
+      # detect_external_repo_config.py resolves the repo to rocgdb, checks it out
+      # to external-rocgdb, and injects -DTHEROCK_ROCGDB_SOURCE_DIR automatically;
+      # extra_cmake_options is appended verbatim.
+      # The repository name must be lowercase "rocgdb": TheRock's stage-impact
+      # analysis matches the changed repo against BUILD_TOPOLOGY.toml submodules
+      # by exact string ("rocgdb"), so passing "ROCgdb" fails the match and forces
+      # a full rebuild with no stage reuse. actions/checkout is case-insensitive.
+      # TEMPORARY: gfx125X/MI455 is build-only (test-runs-on: "") until the runner
+      # is confirmed online. TODO: enable GPU tests once hardware is available.
+      external_repo: >-
+        {
+          "repository": "${{ github.repository_owner }}/rocgdb",
+          "ref": "${{ github.sha }}",
+          "extra_cmake_options": "-DTHEROCK_USE_EXTERNAL_ROCGDB=ON -DTHEROCK_BUILD_TESTING=ON -DTHEROCK_ENABLE_DEBUG_TOOLS=ON",
+          "family_overrides": {
+            "gfx125x": {
+              "linux": {
+                "test-runs-on": "",
+                "fetch-gfx-targets": ["gfx1250"]
+              }
+            }
+          }
+        }
+
+  linux_build_and_test:
+    name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
+    needs: [configure, setup]
+    if: >-
+      ${{
+        needs.setup.outputs.linux_build_config != '' &&
+        needs.setup.outputs.enable_build_jobs == 'true' &&
+        needs.configure.outputs.skip_tests != 'true'
+      }}
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    with:
+      build_config: ${{ needs.setup.outputs.linux_build_config }}
+      test_labels: ${{ needs.setup.outputs.linux_test_labels }}
+      rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      test_type: ${{ needs.setup.outputs.test_type }}
+      external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
+      # Empty string when run_all_tests=true triggers a full test run downstream.
+      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
+      repository: ROCm/TheRock
+      ref: main
+    permissions:
+      contents: read
+      id-token: write
+
+  multi_arch_ci_summary:
+    name: Multi-Arch CI Summary
+    if: always()
+    needs:
+      - setup
+      - linux_build_and_test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   setup:
     needs: configure
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@users/lumachad/main/stage-reuse-timing
     with:
       build_variant: "release"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
@@ -142,7 +142,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@users/lumachad/main/stage-reuse-timing
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}


### PR DESCRIPTION
## Summary

Replaces ROCgdb's single-arch presubmit with a multi-arch pipeline modeled on
rocm-systems, calling TheRock's reusable multi-arch workflows directly with
ROCgdb passed as an external repo.

- **Disable single-arch CI:** removes the pull_request trigger from
  `therock-ci.yml`; the reusable chain (`therock-ci-linux`,
  `therock-test-packages`, `therock-test-component`) stays on disk and runnable
  via `workflow_dispatch`.
- **Register rocgdb as a TheRock external repo:** adds
  `.github/scripts/therock_matrix.py` (single rocgdb project mapping to
  `rocgdb-cpu`, `rocgdb-gpu`, `rocgdb-corefile`) and `.github/repos-config.json`.
  TheRock already knows how to build (`external-rocgdb`,
  `THEROCK_ROCGDB_SOURCE_DIR`) and test rocgdb, so no upstream changes are needed.
- **Add `therock-multi-arch-ci.yml`:** `configure` -> `setup`
  (`setup_multi_arch.yml@main`) -> `linux_build_and_test`
  (`multi_arch_ci_linux.yml@main`) -> summary. Tracks TheRock `@main` with
  automatic stage reuse, targets Linux `gfx94X`, `gfx950`, `gfx125X`, and runs on
  PRs to `amd-staging` and `amd-staging-rocgdb-*`.

`configure_stage.py` in TheRock injects the embedded-Python cmake options
(`THEROCK_SHARED_PYTHON_EXECUTABLES` / `THEROCK_DIST_PYTHON_EXECUTABLES`)
automatically, so the workflow keeps `extra_cmake_options` minimal
(`-DTHEROCK_USE_EXTERNAL_ROCGDB=ON -DTHEROCK_BUILD_TESTING=ON
-DTHEROCK_ENABLE_DEBUG_TOOLS=ON`).

## Open items to validate

- **gfx125X / MI455** is build only (`test-runs-on: ""`) until its test runner
  is confirmed online.
- **rocgdb-corefile** is defined in TheRock's `fetch_test_configurations.py` but
  not in `test_policies.toml`; confirm it actually runs (may need a `test:` label
  or a small upstream addition).
- **changed_projects** resolves to empty for ROCgdb's root layout, so a normal PR
  runs the full rocgdb test set. Acceptable for now; can be scoped later.

## Test plan

- [ ] `workflow_dispatch` with `linux_amdgpu_families=gfx94X` to validate plumbing
  (external-rocgdb checkout, `THEROCK_ROCGDB_SOURCE_DIR` injection, rocgdb builds
  in the debug-tools stage, rocgdb test jobs appear and pass).
- [ ] Full run across `gfx94X,gfx950,gfx125X`; confirm stage reuse hits a recent
  TheRock main baseline and MI455 is build only.
- [ ] Confirm the disabled single-arch `therock-ci.yml` no longer triggers on PRs.