### PR TITLE
gdb.rocm/step-schedlock-spurious-waves: fix failure at -O3

### DIFF
--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
@@ -31,7 +31,9 @@ end_of_kernel ()
 {
 }
 
-__global__ void
+/* optnone keeps the loop below intact under -O1/-O2/-O3, ensuring there are
+   enough source lines to step over.  */
+__global__ void __attribute__ ((optnone))
 kern ()
 {
   /* The test will need to step a few times, so provide an empty loop that


### PR DESCRIPTION
At -O3 the compiler collapses kern's loop body to fewer source line
mappings, causing the stepped wave to reach end_of_kernel in only 2
next commands instead of 5.  The test's next loop then fails to match
its expected pattern when the end_of_kernel breakpoint fires.

Apply __attribute__ ((optnone)) to kern, mirroring the same attribute
already used on end_of_kernel, to keep the loop intact under higher
optimization levels and ensure there are enough source lines to step
over.