### PR TITLE
CHANGELOG_AMD: Mark features linked to ROCm-10.0

### DIFF
--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -5,6 +5,8 @@ Full documentation for ROCgdb is available at
 
 ## ROCgdb-X for ROCm-next
 
+## ROCgdb-16.3 for ROCm-10.0
+
 ### Added
 
 - The "catch hiperr" feature is now exposed to MI too, with a new


### PR DESCRIPTION
Update the CHANGELOG_AMD.md file to correctly describe what was part of the ROCm-10.0 release.