### PR TITLE
[amd-staging-rocgdb-16] CHANGELOG_AMD: Add missing entries for previous releases

### DIFF
--- a/CHANGELOG_AMD.md
+++ b/CHANGELOG_AMD.md
@@ -16,9 +16,16 @@ Full documentation for ROCgdb is available at
   This allows evaluating expressions like 'private_lane#0x08' in Fortran
   applications that offload kernels to an AMD GPU.
 
+## ROCgdb-16-3 for ROCm-7.14
+
+### Added
+
 - Dumping core of AMD GPU programs with the "gcore" command is now
   significantly faster, particularly for kernels that use small
   amounts of VRAM.
+- New "catch hiperr" command that stops the inferior when a HIP API
+  call returns an error.  The convenience variable `$_hiperr` holds
+  the error code at the catchpoint.
 
 ## ROCgdb-16-3 for ROCm-7.13
 


### PR DESCRIPTION
It seems that the CHANGELOG_AMD.md file is missing a couple of entries for the amd-staging-rocgdb-16 branch.  This patch bridges the gaps.
