### PR TITLE
ci: restructure TheRock CI and add multi-arch GPU testing

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Fetch sources
         run: |
+          # debug-tools only requires core build infrastructure; the excluded groups
+          # (rocm-libraries, ml-frameworks, media-libs, math-libraries) are not needed.
           ./build_tools/fetch_sources.py --jobs 12 --depth 1 \
             --no-include-rocm-libraries \
             --no-include-ml-frameworks \

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -12,38 +12,31 @@ on:
       build_runs_on:
         type: string
         default: aws-linux-scale-rocm-prod
+      therock_commit_ref:
+        type: string
+        required: true
+      build_image:
+        type: string
+        required: true
+    outputs:
+      therock_ref:
+        value: ${{ jobs.therock-build-linux.outputs.therock_ref }}
 
 permissions:
   contents: read
 
 jobs:
-  resolve:
-    name: Resolve TheRock references
-    runs-on: ubuntu-24.04
-    outputs:
-      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
-      build_image: ${{ steps.read.outputs.build_image }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Read TheRock dependency pins
-        id: read
-        run: python3 .github/scripts/config.py therock_commit_ref build_image
-
   therock-build-linux:
     name: Build Linux Packages
-    needs: resolve
     runs-on: ${{ inputs.build_runs_on }}
     permissions:
       contents: read
       id-token: write
     outputs:
-      therock_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      therock_ref: ${{ inputs.therock_commit_ref }}
     container:
-      image: ${{ needs.resolve.outputs.build_image }}
+      image: ${{ inputs.build_image }}
     env:
-      THEROCK_COMMIT_REF: ${{ needs.resolve.outputs.therock_commit_ref }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       CACHE_DIR: ${{ github.workspace }}/.container-cache
@@ -54,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+          ref: ${{ inputs.therock_commit_ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -91,7 +84,11 @@ jobs:
 
       - name: Fetch sources
         run: |
-          ./build_tools/fetch_sources.py --jobs 12
+          ./build_tools/fetch_sources.py --jobs 12 --depth 1 \
+            --no-include-rocm-libraries \
+            --no-include-ml-frameworks \
+            --no-include-media-libs \
+            --no-include-math-libraries
 
       - name: Configure Projects
         env:
@@ -141,17 +138,6 @@ jobs:
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
-            --artifact-group ${{ env.AMDGPU_FAMILIES }} \
+            --artifact-group ${{ inputs.artifact_group }} \
             --build-dir build \
             --upload
-
-  therock-test-linux:
-    name: "Run Tests"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
-    needs: [therock-build-linux]
-    uses: ./.github/workflows/therock-test-packages.yml
-    with:
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      artifact_group: ${{ inputs.artifact_group }}
-      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
-      artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -33,49 +33,106 @@ jobs:
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
-      - name: Checkout CI config
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: ROCm/therock-ci-config
-          ref: main
-          path: ci-config
-        continue-on-error: true
-
       - name: Select build runner
         id: runner
         run: python3 .github/scripts/select_runner.py build_runs_on
 
-  therock-ci-linux:
-    name: TheRock CI Linux
+  resolve:
+    name: Resolve TheRock references
     needs: setup
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      therock_commit_ref: ${{ steps.read.outputs.therock_commit_ref }}
+      build_image: ${{ steps.read.outputs.build_image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read TheRock dependency pins
+        id: read
+        run: python3 .github/scripts/config.py therock_commit_ref build_image
+
+  therock-build-linux:
+    name: Build Linux Packages
+    needs: [setup, resolve]
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        amdgpu_family: [gfx94X-dcgpu]
     uses: ./.github/workflows/therock-ci-linux.yml
     with:
-      amdgpu_families: ${{ matrix.amdgpu_family }}
-      artifact_group: ${{ matrix.amdgpu_family }}
+      amdgpu_families: dcgpu-all;dgpu-all;igpu-all
+      artifact_group: gfx94X
       build_runs_on: ${{ needs.setup.outputs.build_runs_on }}
+      therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
+      build_image: ${{ needs.resolve.outputs.build_image }}
       extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
+        -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
         -DTHEROCK_ENABLE_DEBUG_TOOLS=ON
         -DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3
         -DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python
         -DTHEROCK_USE_EXTERNAL_ROCGDB=ON
         -DTHEROCK_ROCGDB_SOURCE_DIR=./rocgdb_under_test
 
+  test-gpu:
+    name: Test GPU
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family:
+          - gfx94X
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-gpu
+
+  test-cpu:
+    name: Test CPU
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx94X
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-cpu
+
+  test-corefile:
+    name: Test corefile (gfx942)
+    needs: [setup, therock-build-linux]
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      amdgpu_families: gfx942
+      artifact_group: gfx94X
+      therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
+      artifact_run_id: ${{ github.run_id }}
+      projects_to_test: rocgdb-corefile
+
   therock_ci_summary:
     name: TheRock CI Summary
     if: always()
     needs:
       - setup
-      - therock-ci-linux
+      - therock-build-linux
+      - test-gpu
+      - test-cpu
+      - test-corefile
     runs-on: ubuntu-24.04
     steps:
       - name: Output failed jobs

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -2,6 +2,7 @@ name: TheRock CI for rocgdb
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - amd-staging
       - amd-staging-rocgdb-*
@@ -23,6 +24,8 @@ jobs:
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
       build_runs_on: ${{ steps.runner.outputs.build_runs_on }}
+      test_families: ${{ steps.families.outputs.test_families }}
+      artifact_group: ${{ steps.families.outputs.artifact_group }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,6 +39,16 @@ jobs:
       - name: Select build runner
         id: runner
         run: python3 .github/scripts/select_runner.py build_runs_on
+
+      - name: Select GPU test families
+        id: families
+        run: |
+          echo 'artifact_group=gfx94X' >> $GITHUB_OUTPUT
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:run-all-archs') }}" == "true" ]]; then
+            echo 'test_families=["gfx94X","gfx90a","gfx950","gfx110X","gfx1151","gfx120X"]' >> $GITHUB_OUTPUT
+          else
+            echo 'test_families=["gfx94X"]' >> $GITHUB_OUTPUT
+          fi
 
   resolve:
     name: Resolve TheRock references
@@ -63,10 +76,11 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     with:
       amdgpu_families: dcgpu-all;dgpu-all;igpu-all
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       build_runs_on: ${{ needs.setup.outputs.build_runs_on }}
       therock_commit_ref: ${{ needs.resolve.outputs.therock_commit_ref }}
       build_image: ${{ needs.resolve.outputs.build_image }}
+      # Multi-arch builds cannot use the default bundle name (derived from amdgpu_families).
       extra_cmake_options: >
         -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=multiarch
         -DTHEROCK_ENABLE_ALL=OFF
@@ -86,12 +100,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amdgpu_family:
-          - gfx94X
+        amdgpu_family: ${{ fromJSON(needs.setup.outputs.test_families) }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-gpu
@@ -105,7 +118,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       amdgpu_families: gfx94X
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-cpu
@@ -118,8 +131,9 @@ jobs:
       contents: read
     uses: ./.github/workflows/therock-test-packages.yml
     with:
+      # gfx942 is intentional: we only have a gfx942 corefile runner for rocgdb corefile testing.
       amdgpu_families: gfx942
-      artifact_group: gfx94X
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
       therock_ref: ${{ needs.therock-build-linux.outputs.therock_ref }}
       artifact_run_id: ${{ github.run_id }}
       projects_to_test: rocgdb-corefile

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -11,6 +11,9 @@ on:
         required: true
       amdgpu_families:
         type: string
+      artifact_group:
+        type: string
+        default: ""
       test_runs_on:
         type: string
       component:
@@ -39,7 +42,6 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: "./build"
       VENV_DIR: ${{ github.workspace }}/.venv
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-      ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
 
     steps:
       - name: Fetch 'build_tools' from TheRock
@@ -65,7 +67,7 @@ jobs:
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group != '' && inputs.artifact_group || inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -7,22 +7,30 @@ on:
         type: string
       artifact_group:
         type: string
+        default: ""
       therock_ref:
         type: string
         required: true
       artifact_run_id:
         type: string
+      projects_to_test:
+        type: string
+        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
   workflow_dispatch:
     inputs:
       amdgpu_families:
         type: string
       artifact_group:
         type: string
+        default: ""
       therock_ref:
         type: string
         required: true
       artifact_run_id:
         type: string
+      projects_to_test:
+        type: string
+        default: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
 
 permissions:
   contents: read
@@ -71,7 +79,7 @@ jobs:
 
       - name: Configure test matrix
         env:
-          PROJECTS_TO_TEST: "rocgdb-cpu,rocgdb-gpu,rocgdb-corefile"
+          PROJECTS_TO_TEST: ${{ inputs.projects_to_test }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           CI_CONFIG_PATH: ci-config
         id: configure
@@ -108,6 +116,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       therock_ref: ${{ inputs.therock_ref }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
       # Per-component runner selection:
       #   1. CPU-only components use the runner from therock-ci-config
       #   2. GPU components use the per-component runner from fetch_test_configurations.py


### PR DESCRIPTION
## Summary

- Restructures TheRock CI to reduce redundancy: a single multiarch build artifact is shared across all test jobs
- Adds `ci:run-all-archs` label support: when set, the GPU test matrix expands from `gfx94X` only to all supported GFX families (`gfx90a`, `gfx950`, `gfx110X`, `gfx1151`, `gfx120X`)
- Adding or removing the label now re-triggers CI immediately without requiring a new push
- Default behavior (no label): unchanged, GPU tests run on `gfx94X` only

## Test plan

- [x] Default (unlabeled) CI runs on gfx94X only
- [x] `ci:run-all-archs` label triggers multi-arch test matrix
- [x] Failing arch legs block the PR (intended)