### PR TITLE
gdb.rocm: step-schedlock-spurious-waves.cpp: Use inlined asm for breakpoint

### DIFF
--- a/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
+++ b/gdb/testsuite/gdb.rocm/step-schedlock-spurious-waves.cpp
@@ -23,21 +23,25 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 
 /* Helper function where the debugger places a breakpoint to be sure no wave
-   can run to completion without the debugger noticing.  optnone implies
-   noinline and keeps the body opaque to the optimizer, so the breakpoint is
-   reliable and the call is not proven away under -O1/-O2/-O3.  */
-__device__ void __attribute__ ((optnone))
+   can run to completion without the debugger noticing.  __forceinline__ and
+   volatile asm guarantee the s_nop is emitted in-line in the kernel, giving
+   the debugger a reliable address to break on.  */
+__device__ __forceinline__ void
 end_of_kernel ()
 {
+  __asm__ volatile ("s_nop 0" ::: );  /* Debugger breaks on the inlined s_nop.  */
 }
 
-__global__ void
+__global__ void __attribute__ ((optnone))
 kern ()
 {
-  /* The test will need to step a few times, so provide an empty loop that
-     will make it possible.  */
-  for (int i = 0; i < 100; i++)
-    __builtin_amdgcn_s_sleep (1);
+  /* The test will need to step a few times.  */
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
+  __builtin_amdgcn_s_sleep (20);
 
   end_of_kernel ();
 }


### PR DESCRIPTION
On gfx1250 the original code did not achieve full wavefront occupancy; VGPR pressure was created by the unoptimized function call and for loop.

Instead of relying on optnone + an empty end_of_kernel function as a breakpoint site, use __forceinline__ with volatile inline assembly (s_nop 0).  This guarantees the instruction is emitted in-line in the kernel and cannot be optimized away, giving the debugger a reliable address to break on.

Move optnone to kern to keep the s_sleep calls from being optimized, and replace the counted loop with explicit s_sleep calls to make the stepping sequence clearer.

More details in Jira [AIROCGDB-552]