### PR TITLE
fix(gdb.rocm): skip watch-gpu-global-from-host where device memory is not host-accessible

### DIFF
--- a/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
+++ b/gdb/testsuite/gdb.rocm/watch-gpu-global-from-host.exp
@@ -20,6 +20,11 @@ load_lib rocm.exp
 
 require allow_hip_tests
 
+# This test writes to a __device__ global's storage from a CPU thread,
+# which only works where that memory is host-accessible (an APU, or
+# XNACK/HMM unified memory).  Skip it on GPUs that cannot do this.
+require hip_devices_support_host_access_to_global
+
 standard_testfile .cpp
 
 if {[build_executable "failed to prepare" $testfile $srcfile {debug hip}]} {

--- a/gdb/testsuite/lib/rocm.exp
+++ b/gdb/testsuite/lib/rocm.exp
@@ -501,6 +501,42 @@ proc hip_devices_support_debug_multi_process {} {
     return 1
 }
 
+# Return true if a CPU thread can write to a __device__ global's
+# storage (the address obtained via hipGetSymbolAddress).
+
+gdb_caching_proc hip_devices_support_host_access_to_global {} {
+    if {![gdb_simple_compile host_access_to_global {
+	    #include <hip/hip_runtime.h>
+
+	    __device__ int global = 0;
+
+	    __global__ void kern () {}
+
+	    int __attribute__ ((optnone))
+	    main ()
+	    {
+	      kern<<<1, 1>>> ();
+	      if (hipDeviceSynchronize () != hipSuccess)
+		return 1;
+
+	      int *dev_global;
+	      if (hipGetSymbolAddress (reinterpret_cast<void **> (&dev_global),
+				       global))
+		return 2;
+
+	      /* This store faults on GPUs whose device memory is not
+		 host-accessible.  */
+	      *static_cast<volatile int *> (dev_global) = 8;
+	      return 0;
+	    }
+	} executable hip]} {
+	return 0
+    }
+
+    set result [log_host_exec "$obj"]
+    return [expr {[lindex $result 0] == 0}]
+}
+
 # Helpers below gate cooperative-group debugging tests, i.e. tests that
 # debug kernels launched with hipLaunchCooperativeKernel and
 # synchronized via cooperative_groups::this_grid ().sync ().


### PR DESCRIPTION
## Motivation

`gdb.rocm/watch-gpu-global-from-host.exp` uses a hardware watchpoint on a
`__device__` global that is triggered by a **CPU** write to that global's
storage (the address obtained via `hipGetSymbolAddress`). This only works where
device memory is host-accessible. On GPUs without host-accessible device memory (e.g.
gfx1100 in its default config), the CPU store faults with SIGSEGV, so the
expected watchpoint hit never happens and the test reports a FAIL.

## Technical Details

- Add a `require hip_devices_support_host_access_to_global` gate to
  `gdb.rocm/watch-gpu-global-from-host.exp`. When the capability is absent the
  harness reports the test as UNSUPPORTED instead of FAIL.
- Implement `hip_devices_support_host_access_to_global` in
  `gdb/testsuite/lib/rocm.exp` as a **runtime capability probe**, in the same
  style as `find_amdgpu_devices`: it compiles and runs a small HIP program that
  performs the exact CPU store to a `__device__` global and checks that it exits
  cleanly. The result is cached via `gdb_caching_proc`.

## Test Plan

- Run the test on a GPU **without** host-accessible device memory (gfx1100,
  default config):
  `make check TESTS="gdb.rocm/watch-gpu-global-from-host.exp"` and confirm the
  result is UNSUPPORTED (skipped), not FAIL.
- Run the test on compatible system and confirm the
  probe passes and the test still executes and passes as before.

## Test Result

- gfx1100 (RHEL 10.x): `watch-gpu-global-from-host.exp` now reported as
  UNSUPPORTED instead of FAIL: `watch-gpu-global-from-host.exp` still PASS.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.