### PR TITLE
.github: automerge: unshallow repo before merge-base

### DIFF
--- a/.github/scripts/automerge.py
+++ b/.github/scripts/automerge.py
@@ -454,6 +454,21 @@ def main() -> None:
         print(f"Fetching origin/{TARGET_BRANCH}…")
         run_net(["git", "fetch", "origin", TARGET_BRANCH], cwd=repo)
 
+        # Unshallow if needed so that merge-base can find the common ancestor
+        # between origin/TARGET_BRANCH and sourceware/UPSTREAM_BRANCH.
+        is_shallow = (
+            run(
+                ["git", "rev-parse", "--is-shallow-repository"],
+                cwd=repo,
+            ).stdout.strip()
+            == "true"
+        )
+        if is_shallow:
+            print(f"Repo is shallow; unshallowing origin/{TARGET_BRANCH}…")
+            run_net(
+                ["git", "fetch", "--unshallow", "origin", TARGET_BRANCH], cwd=repo
+            )
+
         # ------------------------------------------------------------------ #
         # 5. Determine the commit range to merge.                             #
         # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem

The automerge workflow uses `actions/checkout` with the default
`fetch-depth: 1`, producing a shallow clone.  The script reuses that
repo (`--repo $WORKSPACE`), fetches full `sourceware/master` history,
then calls:

```
git merge-base origin/amd-staging sourceware/master
```

This fails with exit code 1 because the shallow clone does not contain
the common ancestor.  Example failure:
https://github.com/ROCm/ROCgdb/actions/runs/33000292878/job/98280035701

## Fix

After fetching `origin/TARGET_BRANCH`, check whether the repo is shallow
(`git rev-parse --is-shallow-repository`) and unshallow it if so.  When
the script manages its own clone the repo is never shallow, so this is a
no-op on that path.